### PR TITLE
Add warning logs for plugin fallback and wizard catch-all

### DIFF
--- a/crates/skync/src/discover.rs
+++ b/crates/skync/src/discover.rs
@@ -82,6 +82,10 @@ fn discover_claude_plugins(source: &Source) -> Result<Vec<DiscoveredSkill>> {
         if let Some(ref path) = parent_json
             && path.exists()
         {
+            eprintln!(
+                "warning: installed_plugins.json not found at '{}', trying parent directory",
+                plugins_json_path.display()
+            );
             return discover_claude_plugins_from_json(path, &source.name);
         }
 

--- a/crates/skync/src/wizard.rs
+++ b/crates/skync/src/wizard.rs
@@ -192,7 +192,9 @@ fn configure_targets() -> Result<Targets> {
                     mcp_config: Some(expand_tilde(&PathBuf::from(path))),
                 });
             }
-            _ => {}
+            _ => {
+                eprintln!("warning: unexpected target index {idx}, skipping");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `eprintln!` warning when `installed_plugins.json` falls back to parent directory scan (fixes #14)
- Replace silent `_ => {}` catch-all in wizard target selection with a warning log (fixes #31)

## Test plan
- [x] All existing tests pass (25 unit + 11 integration)
- [x] Clippy clean with `-D warnings`
- [ ] Manual: run `skync sync` with a source path pointing to a subdirectory of the plugins cache to verify fallback warning appears