### PR TITLE
Fix 7 open bugs: panics, silent failures, path handling, dry_run

### DIFF
--- a/crates/skync/src/discover.rs
+++ b/crates/skync/src/discover.rs
@@ -171,7 +171,13 @@ fn scan_for_skills(dir: &Path, source_name: &str) -> Result<Vec<DiscoveredSkill>
         .min_depth(1)
         .max_depth(2)
         .into_iter()
-        .filter_map(|e| e.ok())
+        .filter_map(|e| match e {
+            Ok(entry) => Some(entry),
+            Err(err) => {
+                eprintln!("warning: skipping entry in {}: {}", dir.display(), err);
+                None
+            }
+        })
     {
         if entry.file_name() == "SKILL.md"
             && entry.file_type().is_file()

--- a/crates/skync/src/lib.rs
+++ b/crates/skync/src/lib.rs
@@ -6,6 +6,7 @@ pub mod distribute;
 pub mod doctor;
 pub mod library;
 pub mod mcp;
+pub mod paths;
 pub mod status;
 pub mod wizard;
 
@@ -169,7 +170,7 @@ fn list(config: &Config) -> Result<()> {
 /// Show or print config information.
 fn show_config(config: &Config, path_only: bool) -> Result<()> {
     if path_only {
-        println!("{}", config::default_config_path().display());
+        println!("{}", config::default_config_path()?.display());
     } else {
         let toml_str = toml::to_string_pretty(config)?;
         println!("{}", toml_str);

--- a/crates/skync/src/paths.rs
+++ b/crates/skync/src/paths.rs
@@ -1,0 +1,100 @@
+use std::path::{Path, PathBuf};
+
+/// Resolve a symlink's raw target to an absolute path.
+///
+/// `read_link()` returns the raw stored target, which may be relative.
+/// This function resolves relative targets against the symlink's parent directory.
+pub fn resolve_symlink_target(link_path: &Path, raw_target: &Path) -> PathBuf {
+    if raw_target.is_absolute() {
+        raw_target.to_path_buf()
+    } else {
+        link_path.parent().unwrap_or(link_path).join(raw_target)
+    }
+}
+
+/// Compare two paths for equivalence, using canonicalization when possible.
+///
+/// Falls back to `resolve_symlink_target` when the symlink target doesn't exist
+/// (e.g., the original was deleted).
+pub fn symlink_points_to(link_path: &Path, expected_target: &Path) -> bool {
+    let raw_target = match std::fs::read_link(link_path) {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+
+    let resolved = std::fs::canonicalize(link_path)
+        .unwrap_or_else(|_| resolve_symlink_target(link_path, &raw_target));
+    let expected =
+        std::fs::canonicalize(expected_target).unwrap_or_else(|_| expected_target.to_path_buf());
+
+    resolved == expected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs as unix_fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn resolve_absolute_target_unchanged() {
+        let result = resolve_symlink_target(Path::new("/some/link"), Path::new("/absolute/target"));
+        assert_eq!(result, PathBuf::from("/absolute/target"));
+    }
+
+    #[test]
+    fn resolve_relative_target_against_parent() {
+        let result = resolve_symlink_target(
+            Path::new("/lib/skills/my-skill"),
+            Path::new("../../sources/my-skill"),
+        );
+        assert_eq!(result, PathBuf::from("/lib/skills/../../sources/my-skill"));
+    }
+
+    #[test]
+    fn symlink_points_to_matches_absolute() {
+        let source = TempDir::new().unwrap();
+        let library = TempDir::new().unwrap();
+
+        let target_dir = source.path().join("skill");
+        std::fs::create_dir_all(&target_dir).unwrap();
+
+        let link = library.path().join("skill");
+        unix_fs::symlink(&target_dir, &link).unwrap();
+
+        assert!(symlink_points_to(&link, &target_dir));
+    }
+
+    #[test]
+    fn symlink_points_to_matches_relative() {
+        let tmp = TempDir::new().unwrap();
+
+        let target_dir = tmp.path().join("sources/skill");
+        std::fs::create_dir_all(&target_dir).unwrap();
+
+        let lib_dir = tmp.path().join("library");
+        std::fs::create_dir_all(&lib_dir).unwrap();
+
+        let link = lib_dir.join("skill");
+        // Create a relative symlink: ../sources/skill
+        unix_fs::symlink(Path::new("../sources/skill"), &link).unwrap();
+
+        // Should still match the absolute target
+        assert!(symlink_points_to(&link, &target_dir));
+    }
+
+    #[test]
+    fn symlink_points_to_detects_mismatch() {
+        let tmp = TempDir::new().unwrap();
+
+        let target_a = tmp.path().join("a");
+        let target_b = tmp.path().join("b");
+        std::fs::create_dir_all(&target_a).unwrap();
+        std::fs::create_dir_all(&target_b).unwrap();
+
+        let link = tmp.path().join("link");
+        unix_fs::symlink(&target_a, &link).unwrap();
+
+        assert!(!symlink_points_to(&link, &target_b));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes all remaining open bugs from the codebase review (#1, #3, #4, #5, #6, #7, #9). Also closes #8 (already fixed).

**Panics (#4, #5):**
- Replace `unwrap()` on `as_object_mut()` in `distribute_mcp` with `context()`
- Change `expand_tilde()` and `default_config_path()` to return `Result`, propagate through all callers

**Silent failures (#1, #3):**
- Log walkdir errors in discovery instead of silently dropping via `filter_map`
- `count_entries()`/`count_broken_symlinks()` return `Result`; status shows warnings and "?" instead of fake zeros

**Path handling (#6, #7):**
- New `paths.rs` module with `resolve_symlink_target()` and `symlink_points_to()` helpers
- Fix raw symlink comparison in library consolidation and target distribution
- Resolve relative symlink targets in cleanup and doctor

**Dry run (#9):**
- Guard `create_dir_all` behind `if !dry_run` in `library.rs` and `distribute.rs`

## Test plan

- [x] 12 new regression tests added covering all fixed behaviors
- [x] All 53 tests pass (42 unit + 11 integration)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `make ci` passes

Closes #1, closes #3, closes #4, closes #5, closes #6, closes #7, closes #8, closes #9