### PR TITLE
Add config validation, error context, and test coverage

### DIFF
--- a/crates/skync/src/cleanup.rs
+++ b/crates/skync/src/cleanup.rs
@@ -22,11 +22,13 @@ pub fn cleanup_library(library_dir: &Path, dry_run: bool) -> Result<CleanupResul
         .with_context(|| format!("failed to read library dir {}", library_dir.display()))?;
 
     for entry in entries {
-        let entry = entry?;
+        let entry =
+            entry.with_context(|| format!("failed to read entry in {}", library_dir.display()))?;
         let path = entry.path();
 
         if path.is_symlink() {
-            let raw_target = std::fs::read_link(&path)?;
+            let raw_target = std::fs::read_link(&path)
+                .with_context(|| format!("failed to read symlink {}", path.display()))?;
             let target = resolve_symlink_target(&path, &raw_target);
             // Check if the symlink target still exists
             if !target.exists() {
@@ -55,11 +57,13 @@ pub fn cleanup_target(target_dir: &Path, library_dir: &Path, dry_run: bool) -> R
         .with_context(|| format!("failed to read target dir {}", target_dir.display()))?;
 
     for entry in entries {
-        let entry = entry?;
+        let entry =
+            entry.with_context(|| format!("failed to read entry in {}", target_dir.display()))?;
         let path = entry.path();
 
         if path.is_symlink() {
-            let raw_target = std::fs::read_link(&path)?;
+            let raw_target = std::fs::read_link(&path)
+                .with_context(|| format!("failed to read symlink {}", path.display()))?;
             let target = resolve_symlink_target(&path, &raw_target);
 
             // Remove if it points into the library dir but the library entry is gone

--- a/crates/skync/src/doctor.rs
+++ b/crates/skync/src/doctor.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use console::style;
 use std::path::Path;
 
@@ -82,14 +82,17 @@ fn check_library(library_dir: &Path) -> Result<usize> {
     }
 
     let mut issues = 0;
-    let entries = std::fs::read_dir(library_dir)?;
+    let entries = std::fs::read_dir(library_dir)
+        .with_context(|| format!("failed to read library dir {}", library_dir.display()))?;
 
     for entry in entries {
-        let entry = entry?;
+        let entry =
+            entry.with_context(|| format!("failed to read entry in {}", library_dir.display()))?;
         let path = entry.path();
 
         if path.is_symlink() {
-            let raw_target = std::fs::read_link(&path)?;
+            let raw_target = std::fs::read_link(&path)
+                .with_context(|| format!("failed to read symlink {}", path.display()))?;
             let target = resolve_symlink_target(&path, &raw_target);
             if !target.exists() {
                 println!(
@@ -122,14 +125,17 @@ fn check_target_dir(name: &str, skills_dir: &Path, library_dir: &Path) -> Result
     }
 
     let mut issues = 0;
-    let entries = std::fs::read_dir(skills_dir)?;
+    let entries = std::fs::read_dir(skills_dir)
+        .with_context(|| format!("failed to read target dir {}", skills_dir.display()))?;
 
     for entry in entries {
-        let entry = entry?;
+        let entry =
+            entry.with_context(|| format!("failed to read entry in {}", skills_dir.display()))?;
         let path = entry.path();
 
         if path.is_symlink() {
-            let raw_target = std::fs::read_link(&path)?;
+            let raw_target = std::fs::read_link(&path)
+                .with_context(|| format!("failed to read symlink {}", path.display()))?;
             let target = resolve_symlink_target(&path, &raw_target);
             if target.starts_with(library_dir) && !target.exists() {
                 println!(

--- a/crates/skync/src/lib.rs
+++ b/crates/skync/src/lib.rs
@@ -33,6 +33,7 @@ pub fn run(cli: Cli) -> Result<()> {
     }
 
     let config = Config::load_or_default(cli.config.as_deref())?;
+    config.validate()?;
 
     match cli.command {
         Command::Init => unreachable!(),


### PR DESCRIPTION
## Summary

- **#54** — Closed as already implemented (v2 format parsing exists with passing test)
- **#30** — Added `with_context()` to all bare `?` operators in `distribute.rs`, `cleanup.rs`, and `doctor.rs` for actionable error messages
- **#33** — Added `Config::validate()` checking: library_dir type, empty/duplicate source names, target method/field consistency. Called after config load in `lib.rs`
- **#24** — Added 2 distribute error path tests (missing `skills_dir`, missing `mcp_config`)
- **#25** — Added 4 MCP server unit tests (`list_skills` empty/populated, `read_skill` success/not-found)
- **#26** — Added integration test verifying end-to-end sync with symlink targets

## Test plan

- [x] `make ci` passes (fmt-check + clippy + 66 tests: 54 unit + 12 integration)
- [ ] Verify CI passes on both ubuntu-latest and macos-latest

Closes #24, closes #25, closes #26, closes #30, closes #33