### PR TITLE
Remove unused deps, add module docs, tighten API surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Thin wrapper: loads config, calls `skync::mcp::serve()`. Exists so MCP-only cons
 - **Symlinks everywhere**: Library and target distribution both use Unix symlinks (`std::os::unix::fs::symlink`). Originals are never moved or copied. This means the project is Unix-only.
 - **Targets struct is hardcoded**: `config::Targets` has named fields (antigravity, codex, openclaw) — not a generic vec. The v0.2 roadmap plans to replace this with a connector trait and `Vec<Target>`.
 - **`dry_run` threading**: Most operations accept a `dry_run: bool` that skips filesystem writes but still counts what *would* change. Results report the same counts either way.
-- **Error handling**: `anyhow` for the application, `thiserror` is a dependency but not yet used for custom error types. Missing sources/paths produce warnings (stderr) rather than hard errors.
+- **Error handling**: `anyhow` for the application. Missing sources/paths produce warnings (stderr) rather than hard errors.
 
 ## Testing
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,8 @@ clap = { version = "4", features = ["derive"] }
 console = "0.15"
 dialoguer = "0.11"
 dirs = "6"
-indicatif = "0.17"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "2"
 toml = "0.8"
 walkdir = "2"
 

--- a/crates/skync/Cargo.toml
+++ b/crates/skync/Cargo.toml
@@ -17,10 +17,8 @@ clap.workspace = true
 console.workspace = true
 dialoguer.workspace = true
 dirs.workspace = true
-indicatif.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-thiserror.workspace = true
 toml.workspace = true
 walkdir.workspace = true
 

--- a/crates/skync/src/cleanup.rs
+++ b/crates/skync/src/cleanup.rs
@@ -1,3 +1,5 @@
+//! Remove broken and stale symlinks from the library and target directories.
+
 use anyhow::{Context, Result};
 use std::path::Path;
 
@@ -7,7 +9,6 @@ use crate::paths::resolve_symlink_target;
 #[derive(Debug, Default)]
 pub struct CleanupResult {
     pub removed_from_library: usize,
-    pub removed_from_targets: usize,
 }
 
 /// Remove stale symlinks from the library (broken or pointing to deleted sources).

--- a/crates/skync/src/cli.rs
+++ b/crates/skync/src/cli.rs
@@ -1,3 +1,5 @@
+//! CLI argument parsing with clap. Defines the `Cli` struct and `Command` enum.
+
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 

--- a/crates/skync/src/config.rs
+++ b/crates/skync/src/config.rs
@@ -1,3 +1,5 @@
+//! TOML configuration loading, saving, and validation. Handles tilde expansion and default paths.
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};

--- a/crates/skync/src/discover.rs
+++ b/crates/skync/src/discover.rs
@@ -1,3 +1,6 @@
+//! Skill discovery from configured sources. Supports `ClaudePlugins` and `Directory` source types,
+//! with deduplication (first source wins) and exclusion filtering.
+
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/crates/skync/src/distribute.rs
+++ b/crates/skync/src/distribute.rs
@@ -1,3 +1,5 @@
+//! Distribute library skills to target tools via symlinks or MCP config entries.
+
 use anyhow::{Context, Result};
 use std::os::unix::fs as unix_fs;
 use std::path::Path;

--- a/crates/skync/src/doctor.rs
+++ b/crates/skync/src/doctor.rs
@@ -1,3 +1,5 @@
+//! Diagnose and optionally repair issues such as broken symlinks and missing source paths.
+
 use anyhow::{Context, Result};
 use console::style;
 use std::path::Path;

--- a/crates/skync/src/lib.rs
+++ b/crates/skync/src/lib.rs
@@ -1,14 +1,17 @@
-pub mod cleanup;
+//! Skync — sync AI coding skills across tools.
+//! Re-exports all modules and contains the core `sync()` pipeline: discover, consolidate, distribute, cleanup.
+
+pub(crate) mod cleanup;
 pub mod cli;
 pub mod config;
-pub mod discover;
-pub mod distribute;
-pub mod doctor;
-pub mod library;
+pub(crate) mod discover;
+pub(crate) mod distribute;
+pub(crate) mod doctor;
+pub(crate) mod library;
 pub mod mcp;
-pub mod paths;
-pub mod status;
-pub mod wizard;
+pub(crate) mod paths;
+pub(crate) mod status;
+pub(crate) mod wizard;
 
 use anyhow::Result;
 use console::style;

--- a/crates/skync/src/library.rs
+++ b/crates/skync/src/library.rs
@@ -1,3 +1,6 @@
+//! Consolidate discovered skills into the library directory via symlinks.
+//! Idempotent — unchanged links are skipped, stale links are updated.
+
 use anyhow::{Context, Result};
 use std::os::unix::fs as unix_fs;
 use std::path::Path;

--- a/crates/skync/src/main.rs
+++ b/crates/skync/src/main.rs
@@ -1,3 +1,5 @@
+//! Thin binary entry point — parses CLI args and delegates to `skync::run()`.
+
 use std::process::ExitCode;
 
 use clap::Parser;

--- a/crates/skync/src/mcp.rs
+++ b/crates/skync/src/mcp.rs
@@ -1,3 +1,5 @@
+//! MCP server implementation using rmcp. Exposes `list_skills` and `read_skill` tools over stdio.
+
 use rmcp::{
     ErrorData as McpError, ServerHandler, ServiceExt, handler::server::tool::ToolRouter,
     handler::server::wrapper::Parameters, model::*, schemars, tool, tool_handler, tool_router,
@@ -8,7 +10,7 @@ use crate::config::Config;
 use crate::discover;
 
 #[derive(Debug, Clone)]
-pub struct SkyncServer {
+pub(crate) struct SkyncServer {
     config: Config,
     tool_router: ToolRouter<Self>,
 }
@@ -23,7 +25,7 @@ impl SkyncServer {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
-pub struct ReadSkillRequest {
+pub(crate) struct ReadSkillRequest {
     #[schemars(description = "The skill name (directory name) to read")]
     pub name: String,
 }

--- a/crates/skync/src/paths.rs
+++ b/crates/skync/src/paths.rs
@@ -1,3 +1,5 @@
+//! Symlink path utilities — resolving relative symlink targets and comparing symlink destinations.
+
 use std::path::{Path, PathBuf};
 
 /// Resolve a symlink's raw target to an absolute path.

--- a/crates/skync/src/status.rs
+++ b/crates/skync/src/status.rs
@@ -1,3 +1,5 @@
+//! Read-only summary of the library state, configured sources, targets, and overall health.
+
 use anyhow::Result;
 use console::style;
 use std::path::Path;

--- a/crates/skync/src/wizard.rs
+++ b/crates/skync/src/wizard.rs
@@ -1,3 +1,5 @@
+//! Interactive `skync init` setup wizard using dialoguer. Auto-discovers known source locations.
+
 use anyhow::{Context, Result};
 use console::style;
 use dialoguer::{Confirm, Input, MultiSelect, Select};


### PR DESCRIPTION
## Summary

- **#13** — Remove unused `indicatif` and `thiserror` dependencies from workspace and crate Cargo.toml
- **#29** — Add `//!` module-level doc comments to all 13 source files
- **#19** — Change 8 internal modules from `pub` to `pub(crate)`, restrict `SkyncServer` and `ReadSkillRequest` to `pub(crate)`
- Remove unused `CleanupResult.removed_from_targets` field (dead code exposed by visibility tightening)
- Update CLAUDE.md to reflect dependency removal

Also closed without code changes:
- **#28** — CLI descriptions are accurate (non-issue)
- **#16** — Tilde expansion already centralized (already solved)

## Test plan

- [x] `make ci` passes locally (66 tests, clippy clean)
- [ ] CI passes on ubuntu-latest and macos-latest

Closes #13, closes #19, closes #29