### PR TITLE
Cache MCP skills at startup, add doctor confirmation prompt

### DIFF
--- a/crates/skync/src/mcp.rs
+++ b/crates/skync/src/mcp.rs
@@ -11,16 +11,17 @@ use crate::discover;
 
 #[derive(Debug, Clone)]
 pub(crate) struct SkyncServer {
-    config: Config,
+    skills: Vec<discover::DiscoveredSkill>,
     tool_router: ToolRouter<Self>,
 }
 
 impl SkyncServer {
-    pub fn new(config: Config) -> Self {
-        Self {
-            config,
+    pub fn new(config: Config) -> anyhow::Result<Self> {
+        let skills = discover::discover_all(&config)?;
+        Ok(Self {
+            skills,
             tool_router: Self::tool_router(),
-        }
+        })
     }
 }
 
@@ -34,8 +35,7 @@ pub(crate) struct ReadSkillRequest {
 impl SkyncServer {
     #[tool(description = "List all skills available in the skync library")]
     fn list_skills(&self) -> Result<CallToolResult, McpError> {
-        let skills = discover::discover_all(&self.config)
-            .map_err(|e| McpError::internal_error(format!("discovery failed: {e}"), None))?;
+        let skills = &self.skills;
 
         if skills.is_empty() {
             return Ok(CallToolResult::success(vec![Content::text(
@@ -45,7 +45,7 @@ impl SkyncServer {
 
         let mut lines = Vec::with_capacity(skills.len() + 1);
         lines.push(format!("{} skill(s) found:\n", skills.len()));
-        for skill in &skills {
+        for skill in skills {
             lines.push(format!(
                 "- {} (source: {}, path: {})",
                 skill.name,
@@ -64,10 +64,7 @@ impl SkyncServer {
         &self,
         Parameters(ReadSkillRequest { name }): Parameters<ReadSkillRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let skills = discover::discover_all(&self.config)
-            .map_err(|e| McpError::internal_error(format!("discovery failed: {e}"), None))?;
-
-        let skill = skills.iter().find(|s| s.name.as_str() == name);
+        let skill = self.skills.iter().find(|s| s.name.as_str() == name);
 
         match skill {
             Some(skill) => {
@@ -108,7 +105,7 @@ impl ServerHandler for SkyncServer {
 
 /// Start the MCP server on stdio.
 pub async fn serve(config: Config) -> anyhow::Result<()> {
-    let server = SkyncServer::new(config);
+    let server = SkyncServer::new(config)?;
     let service = server.serve(stdio()).await?;
     service.waiting().await?;
     Ok(())
@@ -150,7 +147,7 @@ mod tests {
             sources: Vec::new(),
             targets: Targets::default(),
         };
-        let server = SkyncServer::new(config);
+        let server = SkyncServer::new(config).unwrap();
         let result = server.list_skills().unwrap();
         let text = extract_text(&result);
         assert!(text.contains("No skills found"), "unexpected: {text}");
@@ -163,7 +160,7 @@ mod tests {
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(skill_dir.join("SKILL.md"), "# My Skill").unwrap();
 
-        let server = SkyncServer::new(test_config(tmp.path().to_path_buf()));
+        let server = SkyncServer::new(test_config(tmp.path().to_path_buf())).unwrap();
         let result = server.list_skills().unwrap();
         let text = extract_text(&result);
         assert!(text.contains("my-skill"), "unexpected: {text}");
@@ -177,7 +174,7 @@ mod tests {
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(skill_dir.join("SKILL.md"), "# My Skill\nSome content.").unwrap();
 
-        let server = SkyncServer::new(test_config(tmp.path().to_path_buf()));
+        let server = SkyncServer::new(test_config(tmp.path().to_path_buf())).unwrap();
         let result = server
             .read_skill(Parameters(ReadSkillRequest {
                 name: "my-skill".into(),
@@ -190,7 +187,7 @@ mod tests {
     #[test]
     fn read_skill_not_found() {
         let tmp = TempDir::new().unwrap();
-        let server = SkyncServer::new(test_config(tmp.path().to_path_buf()));
+        let server = SkyncServer::new(test_config(tmp.path().to_path_buf())).unwrap();
         let result = server
             .read_skill(Parameters(ReadSkillRequest {
                 name: "nonexistent".into(),


### PR DESCRIPTION
## Summary

- **#12 — MCP caching**: `SkyncServer` now discovers skills once in `new()` and stores them. Both `list_skills()` and `read_skill()` use the cached `self.skills` instead of calling `discover_all()` on every invocation. The `config` field was removed from the struct since it became dead code after this change.
- **#11 — Doctor confirmation**: `skync doctor` now prompts with `dialoguer::Confirm` ("Repair these issues?") before performing any repairs. Diagnosis output still prints unconditionally so users see what would be fixed before deciding.

Closes #12, closes #11

## Test plan

- [x] `make ci` passes (69 tests, fmt, clippy)
- [ ] Manual: `skync serve` — verify skills are listed without per-call delay
- [ ] Manual: `skync doctor` with broken symlinks — verify confirmation prompt appears
- [ ] Manual: `skync doctor --dry-run` — verify no prompt, prints "(dry run)" message