### PR TITLE
Fix documentation accuracy (5 items)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ The main binary. All domain logic lives here as a library (`lib.rs` re-exports a
 4. **Cleanup** (`cleanup.rs`) — Remove broken symlinks from library and targets.
 
 **Other modules:**
-- `wizard.rs` — Interactive `skillet init` setup using `dialoguer` (MultiSelect, Input, Confirm). Auto-discovers known source locations (`~/.claude/plugins/cache`, `~/.claude/skills`, `~/.codex/skills`).
+- `wizard.rs` — Interactive `skillet init` setup using `dialoguer` (MultiSelect, Input, Confirm, Select). Auto-discovers known source locations (`~/.claude/plugins/cache`, `~/.claude/skills`, `~/.codex/skills`, `~/.gemini/antigravity/skills`).
 - `config.rs` — TOML config at `~/.config/skillet/config.toml`. `Config::load_or_default` handles missing files gracefully. All path fields support `~` expansion.
 - `doctor.rs` — Diagnoses broken symlinks and missing source paths; optionally repairs via cleanup.
 - `status.rs` — Read-only summary of library, sources, targets, and health.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@
 - ~~**Explain symlink model in wizard**: Clarify that the library uses symlinks (originals are never moved or copied), so users understand there's no data loss risk~~
 - **Optional git init for library**: Ask during `skillet init` whether to initialize a git repo in the library directory for change tracking across syncs
 - **Expand wizard auto-discovery**: ~~Added `~/.gemini/antigravity/skills`.~~ `~/.copilot/skills/` and `~/.cursor/` don't exist as official home-dir paths — Copilot uses per-project `.github/skills/` and Cursor uses per-project `.cursor/rules/`. Per-project sources deferred to v0.2 connector architecture.
-- **Fix `installed_plugins.json` v2 parsing**: Current parser expects a flat JSON array (v1); v2 wraps plugins in `{ "version": 2, "plugins": { "name@registry": [...] } }` — discovery silently finds nothing. Support both formats going forward.
+- ~~**Fix `installed_plugins.json` v2 parsing**: Current parser expects a flat JSON array (v1); v2 wraps plugins in `{ "version": 2, "plugins": { "name@registry": [...] } }` — discovery silently finds nothing. Support both formats going forward.~~
 - ~~**Finalize tool name**: Decided on **skillet** — *"Cook once, serve everywhere."*~~
 - **Improve doc comments for `cargo doc`**: Add module-level `//!` docs, expand struct/function docs, add `# Examples` to key public APIs.
 - **GitHub Pages deployment**: Add CI workflow to build and deploy mdBook + `cargo doc` to GitHub Pages.

--- a/crates/skillet/src/cli.rs
+++ b/crates/skillet/src/cli.rs
@@ -45,7 +45,7 @@ pub enum Command {
     /// Diagnose and repair broken symlinks or config issues
     Doctor,
 
-    /// Start the MCP filesystem server
+    /// Start the MCP server
     Serve,
 
     /// List all discovered skills with their sources

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -17,7 +17,7 @@ The core flow that `skillet sync` and `skillet init` both invoke (`lib.rs::sync`
 
 ### Other Modules
 
-- `wizard.rs` — Interactive `skillet init` setup using `dialoguer` (MultiSelect, Input, Confirm). Auto-discovers known source locations (`~/.claude/plugins/cache`, `~/.claude/skills`, `~/.codex/skills`).
+- `wizard.rs` — Interactive `skillet init` setup using `dialoguer` (MultiSelect, Input, Confirm, Select). Auto-discovers known source locations (`~/.claude/plugins/cache`, `~/.claude/skills`, `~/.codex/skills`, `~/.gemini/antigravity/skills`).
 - `config.rs` — TOML config at `~/.config/skillet/config.toml`. `Config::load_or_default` handles missing files gracefully. All path fields support `~` expansion.
 - `doctor.rs` — Diagnoses broken symlinks and missing source paths; optionally repairs via cleanup.
 - `status.rs` — Read-only summary of library, sources, targets, and health.
@@ -32,7 +32,7 @@ Thin wrapper: loads config, calls `skillet::mcp::serve()`. Exists so MCP-only co
 - **Symlinks everywhere**: Library and target distribution both use Unix symlinks (`std::os::unix::fs::symlink`). Originals are never moved or copied. This means the project is Unix-only.
 - **Targets struct is hardcoded**: `config::Targets` has named fields (antigravity, codex, openclaw) — not a generic vec. The v0.2 roadmap plans to replace this with a connector trait and `Vec<Target>`.
 - **`dry_run` threading**: Most operations accept a `dry_run: bool` that skips filesystem writes but still counts what *would* change. Results report the same counts either way.
-- **Error handling**: `anyhow` for the application, `thiserror` is a dependency but not yet used for custom error types. Missing sources/paths produce warnings (stderr) rather than hard errors.
+- **Error handling**: `anyhow` for the application. Missing sources/paths produce warnings (stderr) rather than hard errors.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Strike through completed v2 parsing roadmap item
- Add `~/.gemini/antigravity/skills` to auto-discovery path lists in CLAUDE.md and architecture.md
- Add `Select` to dialoguer widget list
- Remove incorrect `thiserror` dependency mention
- Fix MCP server doc comment (was "filesystem server")

Closes #67

## Test plan
- [x] `make ci` passes
- [x] No code logic changes — doc/comment only