### PR TITLE
Handle pre-init state gracefully in status and doctor

### DIFF
--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -11,6 +11,12 @@ use crate::paths::resolve_symlink_target;
 
 /// Diagnose and optionally repair issues.
 pub fn diagnose(config: &Config, dry_run: bool) -> Result<()> {
+    // Not yet initialised — no config file, no library directory
+    if !config.library_dir.is_dir() && config.sources.is_empty() {
+        println!("Not configured yet. Run `tome init` to get started.");
+        return Ok(());
+    }
+
     let mut total_issues = 0;
 
     // Check library
@@ -293,5 +299,19 @@ mod tests {
 
         let result = check_config(&config).unwrap();
         assert_eq!(result, 0);
+    }
+
+    // -- diagnose (pre-init guard) --
+
+    #[test]
+    fn diagnose_shows_init_prompt_when_unconfigured() {
+        let config = Config {
+            library_dir: PathBuf::from("/nonexistent/library"),
+            ..Config::default()
+        };
+
+        // Pre-init guard triggers: no library dir + no sources → friendly message, no error
+        let result = diagnose(&config, true);
+        assert!(result.is_ok());
     }
 }

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -291,3 +291,30 @@ fn doctor_detects_broken_symlinks() {
         .success()
         .stdout(predicate::str::contains("1 issue(s)"));
 }
+
+// -- Pre-init state (no config file) --
+
+#[test]
+fn status_without_config_shows_init_prompt() {
+    tome()
+        .args(["--config", "/nonexistent/config.toml", "status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Not configured yet"))
+        .stdout(predicate::str::contains("tome init"));
+}
+
+#[test]
+fn doctor_without_config_shows_init_prompt() {
+    tome()
+        .args([
+            "--config",
+            "/nonexistent/config.toml",
+            "--dry-run",
+            "doctor",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Not configured yet"))
+        .stdout(predicate::str::contains("tome init"));
+}


### PR DESCRIPTION
## Summary

- `tome status` and `tome doctor` now detect when the library directory doesn't exist and no sources are configured (fresh install / pre-init state)
- Instead of warnings or repair prompts, they show: `Not configured yet. Run 'tome init' to get started.`
- Guard condition: `!library_dir.is_dir() && sources.is_empty()` — if sources *are* configured but the library is missing, the existing warning behavior is preserved (that's a real problem worth surfacing)

Fixes #82, fixes #83.

## Test plan

- [x] Unit tests for both `status::show` and `doctor::diagnose` with unconfigured state
- [x] Unit test confirming warnings still appear when sources exist but library is missing
- [x] Integration tests via CLI with `--config /nonexistent/config.toml`
- [ ] CI passes