### PR TITLE
Bump to v0.1.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ make fmt            # cargo fmt
 make fmt-check      # cargo fmt -- --check
 make ci             # fmt-check + lint + test (matches CI pipeline)
 make install        # install both binaries via cargo install
-make release        # cargo build --release (LTO + strip)
+make build-release  # cargo build --release (LTO + strip)
+make release VERSION=0.1.4  # bump version, PR, merge, tag, push (triggers CI release)
 ```
 
 Run a single test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "tome"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "tome-mcp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 license = "MIT"
 authors = ["Martin Pfundmair <dev@martinp7r.com>"]
@@ -54,6 +54,8 @@ tap = "MartinP7r/homebrew-tap"
 formula = "tome"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
+# Allow CI file modifications (e.g. Dependabot bumps) without failing the release
+allow-dirty = ["ci"]
 
 [profile.dist]
 inherits = "release"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,35 @@
-.PHONY: build release check test lint fmt clean install docs docs-serve
+.PHONY: build build-release check test lint fmt clean install docs docs-serve release
 
 build:
 	cargo build
 
-release:
+build-release:
 	cargo build --release
+
+# Usage: make release VERSION=0.1.3  (or VERSION=v0.1.3)
+release:
+ifndef VERSION
+	$(error VERSION is required. Usage: make release VERSION=0.1.3)
+endif
+	@set -e; \
+	SEMVER=$$(echo "$(VERSION)" | sed 's/^v//'); \
+	TAG="v$$SEMVER"; \
+	echo "Releasing $$TAG..."; \
+	sed -i '' "s/^version = \".*\"/version = \"$$SEMVER\"/" Cargo.toml; \
+	cargo check --quiet; \
+	BRANCH="chore/release-$$TAG"; \
+	git checkout -b "$$BRANCH"; \
+	git commit --allow-empty -m "empty commit"; \
+	git add Cargo.toml Cargo.lock; \
+	git commit -m "Bump version to $$SEMVER"; \
+	git push -u origin "$$BRANCH"; \
+	gh pr create --title "Bump version to $$SEMVER" --body "Release $$TAG" --assignee MartinP7r; \
+	gh pr merge --squash --delete-branch; \
+	git checkout main; \
+	git pull origin main; \
+	git tag "$$TAG"; \
+	git push origin "$$TAG"; \
+	echo "Released $$TAG — release workflow triggered"
 
 check:
 	cargo check


### PR DESCRIPTION
## Summary
- Bump version 0.1.3 → 0.1.4
- Add `make release VERSION=x.y.z` target (normalizes `v` prefix, creates branch/PR/merge/tag)
- Rename `make release` (cargo build) → `make build-release`
- Add beta warning to README
- Fix cargo-dist CI drift: add `allow-dirty = ["ci"]` so Dependabot action bumps don't break releases
- Update CLAUDE.md with new make targets