### PR TITLE
Respect --quiet flag for SkillName naming warnings

### DIFF
--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -84,7 +84,7 @@ fn sync(config: &Config, dry_run: bool, verbose: bool, quiet: bool) -> Result<()
     if verbose {
         eprintln!("{}", style("Discovering skills...").dim());
     }
-    let skills = discover::discover_all(config)?;
+    let skills = discover::discover_all(config, quiet)?;
     if let Some(sp) = sp {
         sp.finish_and_clear();
     }
@@ -198,7 +198,7 @@ fn sync(config: &Config, dry_run: bool, verbose: bool, quiet: bool) -> Result<()
 
 /// List all discovered skills.
 fn list(config: &Config, quiet: bool) -> Result<()> {
-    let skills = discover::discover_all(config)?;
+    let skills = discover::discover_all(config, quiet)?;
 
     if quiet {
         return Ok(());

--- a/crates/tome/src/mcp.rs
+++ b/crates/tome/src/mcp.rs
@@ -17,7 +17,7 @@ pub(crate) struct TomeServer {
 
 impl TomeServer {
     pub fn new(config: Config) -> anyhow::Result<Self> {
-        let skills = discover::discover_all(&config)?;
+        let skills = discover::discover_all(&config, true)?;
         Ok(Self {
             skills,
             tool_router: Self::tool_router(),


### PR DESCRIPTION
## Summary
- Remove side-effect (`eprintln!`) from `SkillName::new()` — constructors should be pure
- Extract `SkillName::is_conventional()` method for checking `[a-z0-9-]+` pattern
- Thread `quiet: bool` through `discover_all()` to gate naming-convention and deduplication warnings
- MCP server always passes `quiet: true` (server context, no terminal)

## Test plan
- [x] `make ci` passes (all 97 unit + 14 integration tests)
- [x] New `skill_name_conventional_check` test validates `is_conventional()` behavior
- [x] `tome sync --quiet` no longer emits naming warnings
- [x] `tome sync` (without --quiet) still shows warnings for non-conventional names

Closes #89