### PR TITLE
Add sync --force option to recreate all symlinks

### DIFF
--- a/crates/tome/src/cli.rs
+++ b/crates/tome/src/cli.rs
@@ -37,7 +37,11 @@ pub enum Command {
     Init,
 
     /// Discover, consolidate, and distribute skills
-    Sync,
+    Sync {
+        /// Recreate all symlinks even if they appear up-to-date
+        #[arg(short, long)]
+        force: bool,
+    },
 
     /// Show current state of skills, symlinks, and targets
     Status,


### PR DESCRIPTION
## Summary
- Add `--force` / `-f` flag to `tome sync` subcommand
- When set, all library and target symlinks are recreated even if they already point to the correct destination
- Useful for recovery workflows: moved libraries, corrupted filesystem state, stale symlink metadata
- `consolidate()` and `distribute_to_target()` accept a `force: bool` parameter that bypasses the "unchanged" shortcut

## Test plan
- [x] `make ci` passes (84 unit + 14 integration tests)
- [x] `consolidate_force_recreates_links` — verifies force re-creates library links
- [x] `distribute_symlinks_force_recreates_links` — verifies force re-creates target links
- [x] Existing idempotency tests still pass with `force: false`
- [x] `tome sync --help` shows the `--force` flag

Closes #90