### PR TITLE
Wizard UX: keybinding hints and plugin cache clarification

### DIFF
--- a/crates/tome/src/wizard.rs
+++ b/crates/tome/src/wizard.rs
@@ -91,7 +91,14 @@ fn configure_sources() -> Result<Vec<Source>> {
     if !known_sources.is_empty() {
         let labels: Vec<String> = known_sources
             .iter()
-            .map(|s| format!("{} ({})", s.path.display(), s.source_type))
+            .map(|s| match s.source_type {
+                SourceType::ClaudePlugins => {
+                    format!("{} — installed marketplace plugins", s.path.display())
+                }
+                SourceType::Directory => {
+                    format!("{} ({})", s.path.display(), s.source_type)
+                }
+            })
             .collect();
 
         let selections = MultiSelect::new()


### PR DESCRIPTION
## Summary
- Show "(space to toggle, enter to confirm)" keybinding hints on both MultiSelect prompts
- Clarify plugin cache source label: show "installed marketplace plugins" instead of "ClaudePlugins" type name

## Test plan
- [x] `make ci` passes
- [x] Manual: `tome init` shows hints and descriptive labels

Closes #48
Closes #49