### PR TITLE
Add visual polish to wizard with dividers and summary

### DIFF
--- a/crates/tome/src/wizard.rs
+++ b/crates/tome/src/wizard.rs
@@ -56,9 +56,36 @@ pub fn run(dry_run: bool) -> Result<Config> {
         targets,
     };
 
-    // Step 5: Save config
-    let config_path = default_config_path()?;
+    // Summary
+    step_divider("Summary");
+    println!(
+        "  Sources:    {}",
+        if config.sources.is_empty() {
+            style("none".to_string()).yellow()
+        } else {
+            style(format!("{}", config.sources.len())).cyan()
+        }
+    );
+    println!(
+        "  Library:    {}",
+        style(config.library_dir.display()).cyan()
+    );
+    let target_count = config.targets.iter().count();
+    println!(
+        "  Targets:    {}",
+        if target_count == 0 {
+            style("none".to_string()).yellow()
+        } else {
+            style(format!("{target_count}")).cyan()
+        }
+    );
+    if !config.exclude.is_empty() {
+        println!("  Exclusions: {}", style(config.exclude.join(", ")).dim());
+    }
     println!();
+
+    // Save config
+    let config_path = default_config_path()?;
     println!(
         "Config will be saved to: {}",
         style(config_path.display()).cyan()
@@ -82,8 +109,15 @@ pub fn run(dry_run: bool) -> Result<Config> {
     Ok(config)
 }
 
+fn step_divider(label: &str) {
+    println!(
+        "{}",
+        style(format!("── {label} ──────────────────────────────")).dim()
+    );
+}
+
 fn configure_sources() -> Result<Vec<Source>> {
-    println!("{}", style("Step 1: Skill sources").bold());
+    step_divider("Step 1: Skill sources");
 
     let known_sources = find_known_sources()?;
     let mut sources = Vec::new();
@@ -140,7 +174,7 @@ fn configure_sources() -> Result<Vec<Source>> {
 }
 
 fn configure_library() -> Result<PathBuf> {
-    println!("{}", style("Step 2: Library location").bold());
+    step_divider("Step 2: Library location");
 
     let default = dirs::home_dir()
         .context("could not determine home directory")?
@@ -169,7 +203,7 @@ fn configure_library() -> Result<PathBuf> {
 }
 
 fn configure_targets() -> Result<Targets> {
-    println!("{}", style("Step 3: Distribution targets").bold());
+    step_divider("Step 3: Distribution targets");
 
     let home = dirs::home_dir().context("could not determine home directory")?;
 
@@ -234,7 +268,7 @@ fn configure_targets() -> Result<Targets> {
 }
 
 fn configure_exclusions() -> Result<Vec<String>> {
-    println!("{}", style("Step 4: Exclusions").bold());
+    step_divider("Step 4: Exclusions");
 
     let input: String = Input::new()
         .with_prompt("Exclude any skills? (comma-separated names, or Enter for none)")


### PR DESCRIPTION
## Summary
- Replace plain "Step N:" bold headers with dim `──` divider lines for cleaner visual separation
- Add a summary section before saving: shows source count, library path, target count, and exclusions
- Uses cyan for values, yellow for "none", dim for exclusion list

## Test plan
- [x] `make ci` passes
- [x] Manual: `tome init --dry-run` shows dividers and summary output

Closes #50