### PR TITLE
Offer optional git init for library directory during wizard

### DIFF
--- a/crates/tome/src/wizard.rs
+++ b/crates/tome/src/wizard.rs
@@ -77,6 +77,33 @@ pub fn run(dry_run: bool) -> Result<Config> {
     {
         config.save(&config_path)?;
         println!("{} Config saved!", style("done").green());
+
+        // Offer to git-init the library directory for change tracking
+        if !config.library_dir.join(".git").exists()
+            && Confirm::new()
+                .with_prompt("Initialize a git repo in the library directory for change tracking?")
+                .default(false)
+                .interact()?
+        {
+            std::fs::create_dir_all(&config.library_dir)?;
+            let status = std::process::Command::new("git")
+                .args(["init"])
+                .current_dir(&config.library_dir)
+                .status()
+                .context("failed to run git init")?;
+            if status.success() {
+                println!(
+                    "  {} Initialized git repo in {}",
+                    style("✓").green(),
+                    config.library_dir.display()
+                );
+            } else {
+                eprintln!(
+                    "warning: git init failed (exit code {})",
+                    status.code().unwrap_or(-1)
+                );
+            }
+        }
     }
 
     Ok(config)


### PR DESCRIPTION
## Summary
- After saving config during `tome init`, ask whether to initialize a git repo in the library directory
- Defaults to "no" — opt-in feature for users who want change tracking across syncs
- Skips the prompt if `.git` already exists in the library dir
- Creates the library directory if needed before running `git init`

## Test plan
- [x] `make ci` passes
- [x] Manual: `tome init` offers git init prompt after saving config

Closes #52