### PR TITLE
Fix claude-plugins source path

### DIFF
--- a/crates/tome/src/wizard.rs
+++ b/crates/tome/src/wizard.rs
@@ -359,7 +359,7 @@ fn configure_exclusions(skills: &[crate::discover::DiscoveredSkill]) -> Result<V
 const KNOWN_SOURCES: &[(&str, &str, SourceType)] = &[
     (
         "claude-plugins",
-        ".claude/plugins/cache",
+        ".claude/plugins",
         SourceType::ClaudePlugins,
     ),
     ("claude-skills", ".claude/skills", SourceType::Directory),


### PR DESCRIPTION
## Summary

- Fix known source path for `claude-plugins` from `~/.claude/plugins/cache` to `~/.claude/plugins`
- The `installed_plugins.json` file lives at `~/.claude/plugins/`, not in the `cache` subdirectory
- Eliminates the noisy fallback warning on every wizard/sync run

## Test plan

- [x] `cargo test -p tome --lib` — 93/93 pass
- [ ] `tome init --dry-run` — no more "trying parent directory" warning