### PR TITLE
Replace expect() with fallback in defaults::library_dir()

### DIFF
--- a/crates/tome/src/config.rs
+++ b/crates/tome/src/config.rs
@@ -205,7 +205,9 @@ impl Config {
             config.expand_tildes()?;
             Ok(config)
         } else {
-            Ok(Self::default())
+            let mut config = Self::default();
+            config.expand_tildes()?;
+            Ok(config)
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace `.expect()` panic in serde default with `.unwrap_or_else(|| "~")` fallback
- `expand_tildes()` and `validate()` will surface a proper error if `$HOME` is unavailable

Closes #119