### PR TITLE
Validate config in tome-mcp binary

### DIFF
--- a/crates/tome-mcp/src/main.rs
+++ b/crates/tome-mcp/src/main.rs
@@ -3,5 +3,6 @@ use tome::config::Config;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let config = Config::load_or_default(None)?;
+    config.validate()?;
     tome::mcp::serve(config).await
 }


### PR DESCRIPTION
## Summary
- Add `config.validate()?` call to `tome-mcp` binary, matching the main CLI's behavior
- Prevents confusing downstream errors from invalid configs

Closes #120