### PR TITLE
Check target.enabled in doctor repair phase

### DIFF
--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -77,7 +77,7 @@ pub fn diagnose(config: &Config, dry_run: bool) -> Result<()> {
                 }
 
                 for (name, t) in config.targets.iter() {
-                    if let Some(skills_dir) = t.skills_dir() {
+                    if t.enabled && let Some(skills_dir) = t.skills_dir() {
                         let removed =
                             cleanup::cleanup_target(skills_dir, &config.library_dir, false)?;
                         if removed > 0 {


### PR DESCRIPTION
## Summary
- Add `t.enabled` guard to the repair loop, matching the diagnosis phase
- Prevents `doctor --repair` from cleaning up disabled targets

Closes #121