### PR TITLE
Surface discovery errors in wizard

### DIFF
--- a/crates/tome/src/wizard.rs
+++ b/crates/tome/src/wizard.rs
@@ -32,7 +32,16 @@ pub fn run(dry_run: bool) -> Result<Config> {
             sources: sources.clone(),
             ..Config::default()
         };
-        crate::discover::discover_all(&tmp, true).unwrap_or_default()
+        match crate::discover::discover_all(&tmp, true) {
+            Ok(skills) => skills,
+            Err(e) => {
+                eprintln!(
+                    "warning: could not discover skills from selected sources: {e}"
+                );
+                eprintln!("  (exclusions can be added manually to config later)");
+                Vec::new()
+            }
+        }
     };
 
     // Step 2: Choose library location


### PR DESCRIPTION
## Summary
- Replace `unwrap_or_default()` with explicit match that prints the error
- Users now see why skill discovery failed instead of a silent empty list
- Falls back gracefully so wizard can still complete

Closes #122