### PR TITLE
Simplify repetitive patterns across modules

### DIFF
--- a/crates/tome/src/config.rs
+++ b/crates/tome/src/config.rs
@@ -82,6 +82,18 @@ impl Targets {
         .into_iter()
         .filter_map(|(name, config)| config.map(|c| (name, c)))
     }
+
+    /// Iterate mutably over all configured targets.
+    fn iter_mut(&mut self) -> impl Iterator<Item = &mut TargetConfig> {
+        [
+            self.antigravity.as_mut(),
+            self.claude.as_mut(),
+            self.codex.as_mut(),
+            self.openclaw.as_mut(),
+        ]
+        .into_iter()
+        .flatten()
+    }
 }
 
 /// How a target receives skills — each variant carries its required path.
@@ -282,16 +294,7 @@ impl Config {
         for source in &mut self.sources {
             source.path = expand_tilde(&source.path)?;
         }
-        if let Some(ref mut t) = self.targets.antigravity {
-            expand_target_tildes(t)?;
-        }
-        if let Some(ref mut t) = self.targets.claude {
-            expand_target_tildes(t)?;
-        }
-        if let Some(ref mut t) = self.targets.codex {
-            expand_target_tildes(t)?;
-        }
-        if let Some(ref mut t) = self.targets.openclaw {
+        for t in self.targets.iter_mut() {
             expand_target_tildes(t)?;
         }
         Ok(())

--- a/crates/tome/src/discover.rs
+++ b/crates/tome/src/discover.rs
@@ -2,7 +2,7 @@
 //! with deduplication (first source wins) and exclusion filtering.
 
 use anyhow::{Context, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
@@ -231,7 +231,7 @@ fn discover_claude_plugins_from_json(
 
     // Deduplicate within a single source — multiple install records can point to the
     // same installPath, which would otherwise surface as spurious same-source conflicts.
-    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut seen: HashSet<String> = HashSet::new();
     let skills = raw_skills
         .into_iter()
         .filter(|s| seen.insert(s.name.as_str().to_string()))
@@ -259,18 +259,18 @@ fn scan_install_records(
 
 /// Discover skills from a flat directory (scan for */SKILL.md).
 fn discover_directory(source: &Source) -> Result<Vec<DiscoveredSkill>> {
-    if source.path.exists() {
-        if !source.path.is_dir() {
-            eprintln!(
-                "warning: source '{}' path exists but is not a directory: {} — skipping",
-                source.name,
-                source.path.display()
-            );
-            return Ok(Vec::new());
-        }
-    } else {
+    if !source.path.exists() {
         eprintln!(
             "warning: source '{}' path does not exist: {}",
+            source.name,
+            source.path.display()
+        );
+        return Ok(Vec::new());
+    }
+
+    if !source.path.is_dir() {
+        eprintln!(
+            "warning: source '{}' path exists but is not a directory: {} — skipping",
             source.name,
             source.path.display()
         );

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -149,34 +149,21 @@ fn sync(config: &Config, dry_run: bool, force: bool, verbose: bool, quiet: bool)
 
     // Report
     println!("{}", style("Sync complete").green().bold());
-    let lib_skipped = if consolidate_result.skipped > 0 {
-        format!(
-            ", {} skipped (path conflict)",
-            style(consolidate_result.skipped).yellow()
-        )
-    } else {
-        String::new()
-    };
     println!(
         "  Library: {} created, {} unchanged, {} updated{}",
         style(consolidate_result.created).cyan(),
         consolidate_result.unchanged,
         consolidate_result.updated,
-        lib_skipped
+        skipped_note(consolidate_result.skipped)
     );
 
     for dr in &distribute_results {
-        let skipped_note = if dr.skipped > 0 {
-            format!(", {} skipped (path conflict)", style(dr.skipped).yellow())
-        } else {
-            String::new()
-        };
         println!(
             "  {}: {} linked, {} unchanged{}",
             style(&dr.target_name).bold(),
             style(dr.changed).cyan(),
             dr.unchanged,
-            skipped_note
+            skipped_note(dr.skipped)
         );
     }
 
@@ -240,6 +227,15 @@ fn list(config: &Config, quiet: bool) -> Result<()> {
     println!("{} skill(s) total", skills.len());
 
     Ok(())
+}
+
+/// Format a "skipped (path conflict)" suffix, or an empty string if count is zero.
+fn skipped_note(count: usize) -> String {
+    if count > 0 {
+        format!(", {} skipped (path conflict)", style(count).yellow())
+    } else {
+        String::new()
+    }
 }
 
 /// Show or print config information.


### PR DESCRIPTION
## Summary
- **config.rs**: Add `Targets::iter_mut()`, simplify `expand_tildes()` from 12 lines to 3
- **discover.rs**: Flatten nested if/else to guard clauses; import `HashSet` consistently
- **lib.rs**: Extract `skipped_note()` helper to deduplicate sync report formatting

No functional changes.