### PR TITLE
fix(cleanup): correct docstring to match actual behavior

### DIFF
--- a/crates/tome/src/cleanup.rs
+++ b/crates/tome/src/cleanup.rs
@@ -20,7 +20,7 @@ pub struct CleanupResult {
 /// Remove library entries whose skills are no longer present in any discovered source.
 ///
 /// When `interactive` is true and stdin is a TTY, prompts the user before removing each
-/// stale entry. When non-interactive, warns to stderr but preserves the entry.
+/// stale entry. When non-interactive, warns to stderr and removes automatically.
 pub fn cleanup_library(
     library_dir: &Path,
     discovered_names: &HashSet<String>,


### PR DESCRIPTION
## Summary
- Fixes misleading docstring on `cleanup_library` that claimed non-interactive mode preserves entries, when it actually removes them

Closes #144