### PR TITLE
refactor(manifest): use SkillName as manifest key

### DIFF
--- a/crates/tome/src/cleanup.rs
+++ b/crates/tome/src/cleanup.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 use std::io::IsTerminal;
 use std::path::Path;
 
+use crate::discover::SkillName;
 use crate::manifest::Manifest;
 use crate::paths::resolve_symlink_target;
 
@@ -36,15 +37,14 @@ pub fn cleanup_library(
     let interactive = std::io::stdin().is_terminal();
 
     // Find manifest entries not in discovered_names
-    let stale: Vec<String> = manifest
-        .skills
+    let stale: Vec<SkillName> = manifest
         .keys()
         .filter(|name| !discovered_names.contains(name.as_str()))
         .cloned()
         .collect();
 
     for name in stale {
-        let entry_path = library_dir.join(&name);
+        let entry_path = library_dir.join(name.as_str());
 
         if interactive {
             let prompt = format!(
@@ -72,7 +72,7 @@ pub fn cleanup_library(
                     format!("failed to remove stale skill dir {}", entry_path.display())
                 })?;
             }
-            manifest.skills.remove(&name);
+            manifest.remove(name.as_str());
         }
         result.removed_from_library += 1;
     }
@@ -167,8 +167,8 @@ mod tests {
         std::fs::write(skill_dir.join("SKILL.md"), "# old").unwrap();
 
         let mut manifest = Manifest::default();
-        manifest.skills.insert(
-            "old-skill".to_string(),
+        manifest.insert(
+            crate::discover::SkillName::new("old-skill").unwrap(),
             crate::manifest::SkillEntry {
                 source_path: std::path::PathBuf::from("/tmp/source/old-skill"),
                 source_name: "test".to_string(),
@@ -183,7 +183,7 @@ mod tests {
 
         assert_eq!(result.removed_from_library, 1);
         assert!(!library.path().join("old-skill").exists());
-        assert!(!manifest.skills.contains_key("old-skill"));
+        assert!(!manifest.contains_key("old-skill"));
     }
 
     #[test]
@@ -194,8 +194,8 @@ mod tests {
         std::fs::create_dir_all(&skill_dir).unwrap();
 
         let mut manifest = Manifest::default();
-        manifest.skills.insert(
-            "keep-me".to_string(),
+        manifest.insert(
+            crate::discover::SkillName::new("keep-me").unwrap(),
             crate::manifest::SkillEntry {
                 source_path: std::path::PathBuf::from("/tmp/source/keep-me"),
                 source_name: "test".to_string(),
@@ -219,8 +219,8 @@ mod tests {
         std::fs::create_dir_all(&skill_dir).unwrap();
 
         let mut manifest = Manifest::default();
-        manifest.skills.insert(
-            "stale".to_string(),
+        manifest.insert(
+            crate::discover::SkillName::new("stale").unwrap(),
             crate::manifest::SkillEntry {
                 source_path: std::path::PathBuf::from("/tmp/source/stale"),
                 source_name: "test".to_string(),
@@ -236,7 +236,7 @@ mod tests {
         // Should still exist in dry run
         assert!(library.path().join("stale").exists());
         // Manifest should still have the entry in dry run
-        assert!(manifest.skills.contains_key("stale"));
+        assert!(manifest.contains_key("stale"));
     }
 
     #[test]

--- a/crates/tome/src/discover.rs
+++ b/crates/tome/src/discover.rs
@@ -85,6 +85,12 @@ impl PartialEq<&str> for SkillName {
     }
 }
 
+impl std::borrow::Borrow<str> for SkillName {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
 impl TryFrom<String> for SkillName {
     type Error = anyhow::Error;
 

--- a/crates/tome/src/distribute.rs
+++ b/crates/tome/src/distribute.rs
@@ -94,7 +94,7 @@ fn distribute_symlinks(
         // Skip skills whose original source is already inside this target dir.
         // This prevents circular symlinks when a directory is both a source and target
         // (e.g. ~/.claude/skills used as both).
-        if let Some(manifest_entry) = manifest.skills.get(skill_name_str.as_ref())
+        if let Some(manifest_entry) = manifest.get(skill_name_str.as_ref())
             && let (Ok(source), Ok(target)) = (
                 manifest_entry.source_path.canonicalize(),
                 skills_dir.canonicalize(),
@@ -575,8 +575,8 @@ mod tests {
 
         // Manifest records the source origin
         let mut manifest = Manifest::default();
-        manifest.skills.insert(
-            "my-skill".to_string(),
+        manifest.insert(
+            crate::discover::SkillName::new("my-skill").unwrap(),
             SkillEntry {
                 source_path: skill_dir.clone(),
                 source_name: "test".to_string(),

--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -107,8 +107,8 @@ fn check_library(library_dir: &Path) -> Result<usize> {
     let mut issues = 0;
 
     // Check manifest entries exist on disk
-    for name in m.skills.keys() {
-        if !library_dir.join(name).is_dir() {
+    for name in m.keys() {
+        if !library_dir.join(name.as_str()).is_dir() {
             println!(
                 "  {} manifest entry '{}' has no directory on disk",
                 style("x").red(),
@@ -128,7 +128,7 @@ fn check_library(library_dir: &Path) -> Result<usize> {
         let path = entry.path();
         let name = entry.file_name().to_string_lossy().to_string();
 
-        if path.is_dir() && !name.starts_with('.') && !m.skills.contains_key(&name) {
+        if path.is_dir() && !name.starts_with('.') && !m.contains_key(&name) {
             println!(
                 "  {} orphan directory: {} (not in manifest)",
                 style("!").yellow(),
@@ -165,13 +165,12 @@ fn repair_library(library_dir: &Path) -> Result<()> {
 
     // Remove manifest entries missing from disk
     let missing: Vec<String> = m
-        .skills
         .keys()
         .filter(|name| !library_dir.join(name.as_str()).is_dir())
-        .cloned()
+        .map(|name| name.as_str().to_string())
         .collect();
     for name in missing {
-        m.skills.remove(&name);
+        m.remove(&name);
         println!(
             "  {} Removed manifest entry '{}' (directory missing)",
             style("fixed").green(),
@@ -306,8 +305,8 @@ mod tests {
         std::fs::create_dir_all(&skill_dir).unwrap();
 
         let mut m = manifest::Manifest::default();
-        m.skills.insert(
-            "my-skill".to_string(),
+        m.insert(
+            crate::discover::SkillName::new("my-skill").unwrap(),
             manifest::SkillEntry {
                 source_path: PathBuf::from("/tmp/source/my-skill"),
                 source_name: "test".to_string(),
@@ -327,8 +326,8 @@ mod tests {
 
         // Manifest entry with no directory
         let mut m = manifest::Manifest::default();
-        m.skills.insert(
-            "gone".to_string(),
+        m.insert(
+            crate::discover::SkillName::new("gone").unwrap(),
             manifest::SkillEntry {
                 source_path: PathBuf::from("/tmp/source/gone"),
                 source_name: "test".to_string(),

--- a/crates/tome/src/library.rs
+++ b/crates/tome/src/library.rs
@@ -66,14 +66,13 @@ pub fn consolidate(
                     // Symlink target is gone — copy from the discovered source instead
                     copy_dir_recursive(&skill.path, &dest)?;
                 }
-                manifest.skills.insert(
-                    skill.name.as_str().to_string(),
-                    SkillEntry {
-                        source_path: skill.path.clone(),
-                        source_name: skill.source_name.clone(),
-                        content_hash: content_hash.clone(),
-                        synced_at: manifest::now_iso8601(),
-                    },
+                manifest.insert(
+                    skill.name.clone(),
+                    SkillEntry::new(
+                        skill.path.clone(),
+                        skill.source_name.clone(),
+                        content_hash.clone(),
+                    ),
                 );
             }
             result.updated += 1;
@@ -81,7 +80,7 @@ pub fn consolidate(
         }
 
         // Check manifest for existing entry
-        if let Some(entry) = manifest.skills.get(skill.name.as_str()) {
+        if let Some(entry) = manifest.get(skill.name.as_str()) {
             if entry.content_hash == content_hash && !force {
                 result.unchanged += 1;
                 continue;
@@ -94,18 +93,17 @@ pub fn consolidate(
                     })?;
                 }
                 copy_dir_recursive(&skill.path, &dest)?;
-                manifest.skills.insert(
-                    skill.name.as_str().to_string(),
-                    SkillEntry {
-                        source_path: skill.path.clone(),
-                        source_name: skill.source_name.clone(),
-                        content_hash: content_hash.clone(),
-                        synced_at: manifest::now_iso8601(),
-                    },
+                manifest.insert(
+                    skill.name.clone(),
+                    SkillEntry::new(
+                        skill.path.clone(),
+                        skill.source_name.clone(),
+                        content_hash.clone(),
+                    ),
                 );
             }
             result.updated += 1;
-        } else if dest.exists() && !manifest.skills.contains_key(skill.name.as_str()) {
+        } else if dest.exists() && !manifest.contains_key(skill.name.as_str()) {
             // Something exists that's NOT in the manifest — skip with warning
             eprintln!(
                 "warning: {} exists but is not in the manifest, skipping",
@@ -116,14 +114,13 @@ pub fn consolidate(
             // New skill — copy
             if !dry_run {
                 copy_dir_recursive(&skill.path, &dest)?;
-                manifest.skills.insert(
-                    skill.name.as_str().to_string(),
-                    SkillEntry {
-                        source_path: skill.path.clone(),
-                        source_name: skill.source_name.clone(),
-                        content_hash: content_hash.clone(),
-                        synced_at: manifest::now_iso8601(),
-                    },
+                manifest.insert(
+                    skill.name.clone(),
+                    SkillEntry::new(
+                        skill.path.clone(),
+                        skill.source_name.clone(),
+                        content_hash.clone(),
+                    ),
                 );
             }
             result.created += 1;
@@ -323,7 +320,7 @@ mod tests {
 
         // Manifest should have the entry
         let manifest = manifest::load(library.path()).unwrap();
-        assert!(manifest.skills.contains_key("my-skill"));
+        assert!(manifest.contains_key("my-skill"));
     }
 
     #[test]
@@ -362,9 +359,9 @@ mod tests {
         consolidate(&[skill], library.path(), false, false).unwrap();
 
         let manifest = manifest::load(library.path()).unwrap();
-        assert_eq!(manifest.skills.len(), 1);
-        assert!(manifest.skills.contains_key("my-skill"));
-        let entry = &manifest.skills["my-skill"];
+        assert_eq!(manifest.len(), 1);
+        assert!(manifest.contains_key("my-skill"));
+        let entry = manifest.get("my-skill").unwrap();
         assert!(!entry.content_hash.is_empty());
         assert!(!entry.synced_at.is_empty());
     }

--- a/crates/tome/src/manifest.rs
+++ b/crates/tome/src/manifest.rs
@@ -12,12 +12,53 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use walkdir::WalkDir;
 
+use crate::discover::SkillName;
+
 const MANIFEST_FILENAME: &str = ".tome-manifest.json";
 
 /// The library manifest, tracking all skills and their provenance.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Manifest {
-    pub skills: BTreeMap<String, SkillEntry>,
+    skills: BTreeMap<SkillName, SkillEntry>,
+}
+
+impl Manifest {
+    /// Returns the entry for the given skill name, if present.
+    pub fn get(&self, name: &str) -> Option<&SkillEntry> {
+        self.skills.get(name)
+    }
+
+    /// Returns true if the manifest contains an entry for the given skill name.
+    pub fn contains_key(&self, name: &str) -> bool {
+        self.skills.contains_key(name)
+    }
+
+    /// Inserts a skill entry into the manifest, keyed by the given `SkillName`.
+    pub fn insert(&mut self, name: SkillName, entry: SkillEntry) {
+        self.skills.insert(name, entry);
+    }
+
+    /// Removes the entry for the given skill name.
+    pub fn remove(&mut self, name: &str) {
+        self.skills.remove(name);
+    }
+
+    /// Returns an iterator over the skill names in the manifest.
+    pub fn keys(&self) -> impl Iterator<Item = &SkillName> {
+        self.skills.keys()
+    }
+
+    /// Returns true if the manifest has no entries.
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.skills.is_empty()
+    }
+
+    /// Returns the number of entries in the manifest.
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.skills.len()
+    }
 }
 
 /// A single skill entry in the manifest.
@@ -31,6 +72,18 @@ pub struct SkillEntry {
     pub content_hash: String,
     /// ISO 8601 timestamp of when this skill was last synced.
     pub synced_at: String,
+}
+
+impl SkillEntry {
+    /// Create a new `SkillEntry`, recording the current timestamp automatically.
+    pub fn new(source_path: PathBuf, source_name: String, content_hash: String) -> Self {
+        Self {
+            source_path,
+            source_name,
+            content_hash,
+            synced_at: now_iso8601(),
+        }
+    }
 }
 
 /// Load the manifest from the library directory, or return an empty one if missing.
@@ -182,8 +235,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
 
         let mut manifest = Manifest::default();
-        manifest.skills.insert(
-            "my-skill".to_string(),
+        manifest.insert(
+            crate::discover::SkillName::new("my-skill").unwrap(),
             SkillEntry {
                 source_path: PathBuf::from("/tmp/source/my-skill"),
                 source_name: "test".to_string(),
@@ -194,15 +247,15 @@ mod tests {
 
         save(&manifest, tmp.path()).unwrap();
         let loaded = load(tmp.path()).unwrap();
-        assert_eq!(loaded.skills.len(), 1);
-        assert_eq!(loaded.skills["my-skill"].content_hash, "abc123");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded.get("my-skill").unwrap().content_hash, "abc123");
     }
 
     #[test]
     fn load_missing_manifest_returns_empty() {
         let tmp = TempDir::new().unwrap();
         let manifest = load(tmp.path()).unwrap();
-        assert!(manifest.skills.is_empty());
+        assert!(manifest.is_empty());
     }
 
     #[test]

--- a/crates/tome/src/status.rs
+++ b/crates/tome/src/status.rs
@@ -146,8 +146,8 @@ fn count_health_issues(dir: &Path) -> Result<usize> {
     let mut issues = 0;
 
     // Check manifest entries exist on disk
-    for name in m.skills.keys() {
-        if !dir.join(name).is_dir() {
+    for name in m.keys() {
+        if !dir.join(name.as_str()).is_dir() {
             issues += 1;
         }
     }
@@ -158,7 +158,7 @@ fn count_health_issues(dir: &Path) -> Result<usize> {
     {
         let entry = entry.with_context(|| format!("failed to read entry in {}", dir.display()))?;
         let name = entry.file_name().to_string_lossy().to_string();
-        if entry.path().is_dir() && !name.starts_with('.') && !m.skills.contains_key(&name) {
+        if entry.path().is_dir() && !name.starts_with('.') && !m.contains_key(&name) {
             issues += 1;
         }
     }
@@ -297,8 +297,8 @@ mod tests {
 
         // Create a manifest entry with no corresponding directory
         let mut m = manifest::Manifest::default();
-        m.skills.insert(
-            "missing".to_string(),
+        m.insert(
+            crate::discover::SkillName::new("missing").unwrap(),
             manifest::SkillEntry {
                 source_path: PathBuf::from("/tmp/source"),
                 source_name: "test".to_string(),


### PR DESCRIPTION
## Summary
- Changes Manifest map key from `String` to `SkillName` for type-safe keys
- Makes `skills` field private with accessor methods
- Adds `SkillEntry::new()` constructor to centralize timestamp creation
- Updates all callers across library, cleanup, distribute, doctor, and status modules

Closes #149