### PR TITLE
feat(warnings): add warnings for silent fallback paths

### DIFF
--- a/crates/tome/src/cleanup.rs
+++ b/crates/tome/src/cleanup.rs
@@ -115,8 +115,14 @@ pub fn cleanup_target(target_dir: &Path, library_dir: &Path, dry_run: bool) -> R
     // Canonicalize library_dir so that starts_with works when library_dir itself
     // contains a symlink component (e.g., /var -> /private/var on macOS).
     // We keep both forms so we can match symlinks created with either path variant.
-    let canonical_library =
-        std::fs::canonicalize(library_dir).unwrap_or_else(|_| library_dir.to_path_buf());
+    let canonical_library = std::fs::canonicalize(library_dir).unwrap_or_else(|e| {
+        eprintln!(
+            "warning: could not canonicalize library path {}: {}",
+            library_dir.display(),
+            e
+        );
+        library_dir.to_path_buf()
+    });
 
     let entries = std::fs::read_dir(target_dir)
         .with_context(|| format!("failed to read target dir {}", target_dir.display()))?;

--- a/crates/tome/src/distribute.rs
+++ b/crates/tome/src/distribute.rs
@@ -94,15 +94,23 @@ fn distribute_symlinks(
         // Skip skills whose original source is already inside this target dir.
         // This prevents circular symlinks when a directory is both a source and target
         // (e.g. ~/.claude/skills used as both).
-        if let Some(manifest_entry) = manifest.get(skill_name_str.as_ref())
-            && let (Ok(source), Ok(target)) = (
+        if let Some(manifest_entry) = manifest.get(skill_name_str.as_ref()) {
+            match (
                 manifest_entry.source_path.canonicalize(),
                 skills_dir.canonicalize(),
-            )
-            && source.starts_with(&target)
-        {
-            result.unchanged += 1;
-            continue;
+            ) {
+                (Ok(source), Ok(target)) if source.starts_with(&target) => {
+                    result.unchanged += 1;
+                    continue;
+                }
+                (Err(_), _) | (_, Err(_)) => {
+                    eprintln!(
+                        "warning: could not resolve paths for circular symlink check on '{}', proceeding",
+                        skill_name_str
+                    );
+                }
+                _ => {}
+            }
         }
 
         if target_link.is_symlink() {

--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -234,8 +234,14 @@ fn check_target_dir(name: &str, skills_dir: &Path, library_dir: &Path) -> Result
 
     // Canonicalize library_dir so starts_with works when library_dir contains
     // a symlink component (e.g., /var -> /private/var on macOS).
-    let canonical_library =
-        std::fs::canonicalize(library_dir).unwrap_or_else(|_| library_dir.to_path_buf());
+    let canonical_library = std::fs::canonicalize(library_dir).unwrap_or_else(|e| {
+        eprintln!(
+            "warning: could not canonicalize library path {}: {}",
+            library_dir.display(),
+            e
+        );
+        library_dir.to_path_buf()
+    });
 
     let entries = std::fs::read_dir(skills_dir)
         .with_context(|| format!("failed to read target dir {}", skills_dir.display()))?;

--- a/crates/tome/src/library.rs
+++ b/crates/tome/src/library.rs
@@ -69,6 +69,10 @@ pub fn consolidate(
                     copy_dir_recursive(&abs_resolved, &dest)?;
                 } else {
                     // Symlink target is gone — copy from the discovered source instead
+                    eprintln!(
+                        "warning: v0.1 symlink target for '{}' is gone, copying from current source",
+                        skill.name
+                    );
                     copy_dir_recursive(&skill.path, &dest)?;
                 }
                 manifest.insert(
@@ -163,8 +167,13 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
                     target.display()
                 )
             })?;
+        } else if entry.file_type().is_symlink() {
+            // Skip symlinks inside skill dirs — we don't follow them
+            eprintln!(
+                "warning: skipping symlink inside skill dir: {}",
+                entry.path().display()
+            );
         }
-        // Skip symlinks inside skill dirs — we don't follow them
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Adds `eprintln!("warning: ...")` to silent fallback paths across distribute, library, cleanup, and doctor modules
- Covers: canonicalize failures, v0.1 migration fallbacks, symlink skipping in copy_dir_recursive

Closes #151