### PR TITLE
test: add missing coverage for v0.2 edge cases

### DIFF
--- a/crates/tome/src/distribute.rs
+++ b/crates/tome/src/distribute.rs
@@ -565,6 +565,35 @@ mod tests {
     }
 
     #[test]
+    fn distribute_symlinks_skips_manifest_file() {
+        let library = TempDir::new().unwrap();
+        let target_dir = TempDir::new().unwrap();
+
+        // Create a skill dir AND a manifest file in library
+        setup_library(library.path(), &["skill-a"]);
+        std::fs::write(library.path().join(".tome-manifest.json"), "{}").unwrap();
+
+        let target = TargetConfig {
+            enabled: true,
+            method: TargetMethod::Symlink {
+                skills_dir: target_dir.path().to_path_buf(),
+            },
+        };
+        let manifest = Manifest::default();
+        let result =
+            distribute_to_target(library.path(), "test", &target, &manifest, false, false).unwrap();
+
+        assert_eq!(
+            result.changed, 1,
+            "only the skill dir should be distributed"
+        );
+        assert!(
+            !target_dir.path().join(".tome-manifest.json").exists(),
+            "manifest file should not be symlinked to target"
+        );
+    }
+
+    #[test]
     fn distribute_skips_skills_originating_from_target_dir() {
         // Simulate: ~/.claude/skills is both a source and a target.
         // The library has a real copy (v0.2), and the manifest records the source.

--- a/crates/tome/src/library.rs
+++ b/crates/tome/src/library.rs
@@ -373,4 +373,92 @@ mod tests {
         assert!(!entry.content_hash.is_empty());
         assert!(!entry.synced_at.is_empty());
     }
+
+    #[test]
+    fn consolidate_migrates_v01_symlink_with_broken_target() {
+        use std::os::unix::fs as unix_fs;
+        let source = TempDir::new().unwrap();
+        let library = TempDir::new().unwrap();
+        let skill = make_skill(source.path(), "my-skill");
+
+        // Create a symlink pointing to a nonexistent target (simulating gone original)
+        unix_fs::symlink(
+            "/nonexistent/original/path",
+            library.path().join("my-skill"),
+        )
+        .unwrap();
+
+        let (result, _manifest) = consolidate(&[skill], library.path(), false, false).unwrap();
+        assert_eq!(result.updated, 1);
+
+        let dest = library.path().join("my-skill");
+        assert!(dest.is_dir());
+        assert!(!dest.is_symlink());
+        assert!(dest.join("SKILL.md").is_file());
+    }
+
+    #[test]
+    fn consolidate_copies_nested_subdirectories() {
+        let source = TempDir::new().unwrap();
+        let library = TempDir::new().unwrap();
+
+        let skill_dir = source.path().join("deep-skill");
+        std::fs::create_dir_all(skill_dir.join("sub/nested")).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "# test").unwrap();
+        std::fs::write(skill_dir.join("sub/file.txt"), "content").unwrap();
+        std::fs::write(skill_dir.join("sub/nested/deep.txt"), "deep").unwrap();
+
+        let skill = DiscoveredSkill {
+            name: crate::discover::SkillName::new("deep-skill").unwrap(),
+            path: skill_dir,
+            source_name: "test".into(),
+        };
+
+        let (result, _) = consolidate(&[skill], library.path(), false, false).unwrap();
+        assert_eq!(result.created, 1);
+        assert!(
+            library
+                .path()
+                .join("deep-skill/sub/nested/deep.txt")
+                .is_file()
+        );
+        let content =
+            std::fs::read_to_string(library.path().join("deep-skill/sub/nested/deep.txt")).unwrap();
+        assert_eq!(content, "deep");
+    }
+
+    #[test]
+    fn consolidate_dry_run_no_manifest_written() {
+        let source = TempDir::new().unwrap();
+        let library = TempDir::new().unwrap();
+        // Create the library dir so it exists
+        std::fs::create_dir_all(library.path()).unwrap();
+        let skill = make_skill(source.path(), "my-skill");
+
+        let (result, _) = consolidate(&[skill], library.path(), true, false).unwrap();
+        assert_eq!(result.created, 1);
+        assert!(
+            !library.path().join(".tome-manifest.json").exists(),
+            "dry-run should not write manifest"
+        );
+    }
+
+    #[test]
+    fn consolidate_migrates_v01_symlink_records_discovered_source() {
+        use std::os::unix::fs as unix_fs;
+        let source = TempDir::new().unwrap();
+        let library = TempDir::new().unwrap();
+        let skill = make_skill(source.path(), "my-skill");
+
+        unix_fs::symlink(&skill.path, library.path().join("my-skill")).unwrap();
+
+        let (_, manifest) = consolidate(&[skill.clone()], library.path(), false, false).unwrap();
+        let entry = manifest
+            .get("my-skill")
+            .expect("manifest should have entry");
+        assert_eq!(
+            entry.source_path, skill.path,
+            "manifest source_path should point to discovered source"
+        );
+    }
 }

--- a/crates/tome/src/manifest.rs
+++ b/crates/tome/src/manifest.rs
@@ -259,6 +259,28 @@ mod tests {
     }
 
     #[test]
+    fn hash_directory_different_filenames_different_hashes() {
+        let tmp1 = TempDir::new().unwrap();
+        let tmp2 = TempDir::new().unwrap();
+        // Same content, different filenames
+        std::fs::write(tmp1.path().join("file_a.txt"), "hello").unwrap();
+        std::fs::write(tmp2.path().join("file_b.txt"), "hello").unwrap();
+        let h1 = hash_directory(tmp1.path()).unwrap();
+        let h2 = hash_directory(tmp2.path()).unwrap();
+        assert_ne!(
+            h1, h2,
+            "different filenames should produce different hashes"
+        );
+    }
+
+    #[test]
+    fn load_corrupt_json_returns_error() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".tome-manifest.json"), "not valid json{{{").unwrap();
+        assert!(load(tmp.path()).is_err());
+    }
+
+    #[test]
     fn now_iso8601_format() {
         let ts = now_iso8601();
         // Should match YYYY-MM-DDTHH:MM:SSZ


### PR DESCRIPTION
## Summary
- hash_directory filename sensitivity test
- Corrupt manifest JSON handling test
- v0.1.x migration with broken symlink target test
- Nested subdirectory copy test
- Dry-run manifest not written test
- Manifest file not distributed test
- Migration records correct source_path test

Closes #150