### PR TITLE
feat: generate .gitignore in library for git-friendly tracking

### DIFF
--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -135,11 +135,6 @@ fn sync(config: &Config, dry_run: bool, force: bool, verbose: bool, quiet: bool)
         sp.finish_and_clear();
     }
 
-    // Generate .gitignore in the library (managed skills are ignored, local skills tracked)
-    if !dry_run && config.library_dir.is_dir() {
-        library::generate_gitignore(&config.library_dir, &manifest)?;
-    }
-
     let discovered_names: HashSet<String> =
         skills.iter().map(|s| s.name.as_str().to_string()).collect();
 
@@ -186,6 +181,11 @@ fn sync(config: &Config, dry_run: bool, force: bool, verbose: bool, quiet: bool)
     // Save manifest after cleanup (may have removed entries)
     if !dry_run && config.library_dir.is_dir() {
         manifest::save(&manifest, &config.library_dir)?;
+    }
+
+    // Generate .gitignore after cleanup so stale entries are excluded
+    if !dry_run && config.library_dir.is_dir() {
+        library::generate_gitignore(&config.library_dir, &manifest)?;
     }
 
     if let Some(sp) = sp {

--- a/crates/tome/src/library.rs
+++ b/crates/tome/src/library.rs
@@ -381,7 +381,7 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
 /// Only writes the file if the content would change, to avoid unnecessary git noise.
 pub fn generate_gitignore(library_dir: &Path, manifest: &Manifest) -> Result<()> {
     let mut managed: Vec<&str> = manifest
-        .entries()
+        .iter()
         .filter(|(_, entry)| entry.managed)
         .map(|(name, _)| name.as_str())
         .collect();

--- a/crates/tome/src/manifest.rs
+++ b/crates/tome/src/manifest.rs
@@ -49,7 +49,7 @@ impl Manifest {
     }
 
     /// Returns an iterator over (name, entry) pairs in the manifest.
-    pub fn entries(&self) -> impl Iterator<Item = (&SkillName, &SkillEntry)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&SkillName, &SkillEntry)> {
         self.skills.iter()
     }
 


### PR DESCRIPTION
## Summary

- Generate `.gitignore` in the library directory during `tome sync`
- Managed (symlinked) skills are gitignored — they are recreated by `tome sync`
- Local (copied) skills and `.tome-manifest.json` are git-tracked
- `.gitignore` is only written when content changes (avoids git noise)
- Generation runs after cleanup so stale entries are excluded

Closes #42

## Test plan

- [x] `gitignore_lists_managed_skills` — managed entries appear in `.gitignore`
- [x] `gitignore_does_not_list_local_skills` — local entries absent
- [x] `gitignore_idempotent` — running twice produces same file
- [x] `gitignore_always_ignores_manifest_tmp` — internal file always ignored
- [x] 154 tests pass (133 unit + 21 integration)
- [x] `cargo clippy -- -D warnings` clean