### PR TITLE
docs: npx skills research — tool-landscape and roadmap updates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,13 +46,14 @@ The current model hardcodes targets as struct fields and keeps source/target log
 
 - **Generic `[[targets]]` array**: Replace the hardcoded `Targets` struct with a `Vec<Target>` — same shape as sources. Each target has a `name`, `path`, `type`, and connector-specific options
 - **Connector trait**: Unified interface for both source and target behavior — discovery format, distribution method (symlink, MCP config, copy), and format translation needs
-- **Built-in connectors**: Claude (plugins + standalone), Codex, Antigravity, Cursor, Windsurf, OpenCode, Nanobot, PicoClaw, OpenClaw, VS Code Copilot, Amp, Goose
+- **Built-in connectors**: Claude (plugins + standalone), Codex, Antigravity, Cursor, Windsurf, OpenCode, Nanobot, PicoClaw, OpenClaw, VS Code Copilot, Amp, Goose, Cline, Augment, CodeBuddy, Command Code, Continue, Cortex, Kimi Code CLI, Kiro CLI, Roo, Replit, Qwen Code, Windsurf — see `npx skills` for the full 41-agent landscape
 - **Gemini CLI connector**: Investigate sandbox mode — Gemini CLI may use a different skills/context folder depending on whether it runs in sandbox or not; connector may need to detect or allow configuring which path to target
 - **Bidirectional by design**: Any connector can act as both source and target — discover skills *from* Cursor rules and distribute *to* Cursor rules
 - **Format awareness per connector**: Each connector declares its native format — the pipeline handles translation between them (e.g., SKILL.md ↔ Cursor rules ↔ Windsurf conventions)
 - Support syncing `.claude/rules/` and agent definitions alongside skills
 - **Instruction file syncing**: Bidirectional sync of tool instruction files (CLAUDE.md ↔ AGENTS.md ↔ GEMINI.md ↔ copilot-instructions.md) — extract shared sections and distribute to each tool's native format
-- **npm-based skill sources** ([#97](https://github.com/MartinP7r/tome/issues/97)): Discover skills installed via `npx skills` (Vercel) and `npx openskills` — investigate install paths, manifest formats, and whether existing `Directory` source type suffices or a dedicated connector is needed
+- **`.agents/skills/` as emerging universal path**: 9 agents (Amp, Cline, Codex, Cursor, Gemini CLI, GitHub Copilot, Kimi Code CLI, OpenCode, Replit) converge on `.agents/skills/` as the project-scoped canonical skills directory. Tome connectors should support this path natively
+- **npm-based skill sources** ([#97](https://github.com/MartinP7r/tome/issues/97)): Discover skills installed via `npx skills` (Vercel Labs). Confirmed: canonical copies in `.agents/skills/<name>/`, lockfile at `.agents/.skill-lock.json` (v3) with content hashes and provenance. A `Directory` source pointed at `~/.agents/skills/` works for basic discovery; a dedicated source type would preserve provenance metadata from the lockfile
 
 ## v0.4 — Format Transforms
 

--- a/docs/src/tool-landscape.md
+++ b/docs/src/tool-landscape.md
@@ -2,7 +2,7 @@
 
 Research into agent file formats (skills, rules, memory, hooks, agents, plugins), invocation methods, context loading strategies, and format differences across AI coding tools — informing tome's connector architecture.
 
-*Last updated: February 2026*
+*Last updated: March 2026*
 
 ---
 
@@ -1417,6 +1417,129 @@ Everything else (hooks, agents, plugins, memory) remains fragmented with no sign
 
 ---
 
+## 20. Skill Installers: `npx skills` (Vercel Labs)
+
+[`npx skills`](https://github.com/vercel-labs/skills) is a JavaScript-based skill installer with a polished interactive CLI. It supports **41 agent targets** and uses a two-tier architecture remarkably similar to tome's library model.
+
+**Registry:** [skills.sh](https://skills.sh) — browsable skill registry with per-skill detail pages.
+
+### Architecture
+
+Canonical copies are stored in `.agents/skills/<name>/` (the emerging universal path) or tool-specific directories. Distribution to individual tools uses symlinks from their native skill dirs back to the canonical location.
+
+**Install flow:** clone repo → select skills → select targets → choose scope (project/global) → choose method (symlink/copy) → security assessment → install.
+
+### `.skill-lock.json` (v3)
+
+Lockfile at `.agents/.skill-lock.json` tracks installed skills with provenance and content hashes:
+
+```json
+{
+  "version": 3,
+  "skills": {
+    "skill-name": {
+      "source": "owner/repo",
+      "sourceType": "github",
+      "sourceUrl": "https://github.com/owner/repo.git",
+      "skillPath": "skills/skill-name/SKILL.md",
+      "skillFolderHash": "c2f31172b6f256272305a5e6e7228b258446899f",
+      "installedAt": "2026-03-06T12:49:32.629Z",
+      "updatedAt": "2026-03-06T12:49:32.629Z"
+    }
+  },
+  "dismissed": { ... },
+  "lastSelectedAgents": ["amp", "cline", "codex", "cursor", "..."]
+}
+```
+
+Key fields: `sourceType` + `sourceUrl` for provenance, `skillFolderHash` for content-based idempotency (similar to tome's SHA-256 manifest hashes), `installedAt`/`updatedAt` timestamps.
+
+### Agent Targets (41 total)
+
+**Universal agents** (share `.agents/skills/` as project-scoped path):
+
+| Agent | Global Path |
+|-------|------------|
+| Amp | `$XDG_CONFIG_HOME/agents/skills` |
+| Cline | `~/.agents/skills` |
+| Codex | `$CODEX_HOME/skills` |
+| Cursor | `~/.cursor/skills` |
+| Gemini CLI | `~/.gemini/skills` |
+| GitHub Copilot | `~/.copilot/skills` |
+| Kimi Code CLI | `$XDG_CONFIG_HOME/agents/skills` |
+| OpenCode | `$XDG_CONFIG_HOME/opencode/skills` |
+| Replit | `$XDG_CONFIG_HOME/agents/skills` |
+
+**Additional agents** (tool-specific paths):
+
+| Agent | Project Path | Global Path |
+|-------|-------------|------------|
+| Adal | `.adal/skills` | `~/.adal/skills` |
+| Antigravity | `.agent/skills` | `~/.gemini/antigravity/skills` |
+| Augment | `.augment/skills` | `~/.augment/skills` |
+| Claude Code | `.claude/skills` | `$CLAUDE_HOME/skills` |
+| CodeBuddy | `.codebuddy/skills` | `~/.codebuddy/skills` |
+| Command Code | `.commandcode/skills` | `~/.commandcode/skills` |
+| Continue | `.continue/skills` | `~/.continue/skills` |
+| Cortex | `.cortex/skills` | `~/.snowflake/cortex/skills` |
+| Crush | `.crush/skills` | `$XDG_CONFIG_HOME/crush/skills` |
+| Droid | `.factory/skills` | `~/.factory/skills` |
+| Goose | `.goose/skills` | `$XDG_CONFIG_HOME/goose/skills` |
+| iFlow CLI | `.iflow/skills` | `~/.iflow/skills` |
+| Junie | `.junie/skills` | `~/.junie/skills` |
+| Kilo | `.kilocode/skills` | `~/.kilocode/skills` |
+| Kiro CLI | `.kiro/skills` | `~/.kiro/skills` |
+| Kode | `.kode/skills` | `~/.kode/skills` |
+| MCPJam | `.mcpjam/skills` | `~/.mcpjam/skills` |
+| Mistral Vibe | `.vibe/skills` | `~/.vibe/skills` |
+| Mux | `.mux/skills` | `~/.mux/skills` |
+| Neovate | `.neovate/skills` | `~/.neovate/skills` |
+| OpenClaw | `skills` | (custom) |
+| OpenHands | `.openhands/skills` | `~/.openhands/skills` |
+| Pi | `.pi/skills` | `~/.pi/agent/skills` |
+| Pochi | `.pochi/skills` | `~/.pochi/skills` |
+| Qoder | `.qoder/skills` | `~/.qoder/skills` |
+| Qwen Code | `.qwen/skills` | `~/.qwen/skills` |
+| Roo | `.roo/skills` | `~/.roo/skills` |
+| Trae | `.trae/skills` | `~/.trae/skills` |
+| Trae CN | `.trae/skills` | `~/.trae-cn/skills` |
+| Windsurf | `.windsurf/skills` | `~/.codeium/windsurf/skills` |
+| Zencoder | `.zencoder/skills` | `~/.zencoder/skills` |
+
+### CLI Commands
+
+| Command | Purpose |
+|---------|---------|
+| `npx skills add <url>` | Install skills from a git repo |
+| `npx skills find <query>` | Search the skills.sh registry |
+| `npx skills list` | List installed skills |
+| `npx skills check` | Verify skill integrity |
+| `npx skills update` | Update installed skills |
+| `npx skills remove` | Remove installed skills |
+| `npx skills init` | Initialize skills in a project |
+
+### Security Assessment
+
+The installer integrates security risk assessment with three providers:
+
+| Provider | Assessment |
+|----------|-----------|
+| Gen | Safe / Unsafe |
+| Socket | Alert count |
+| Snyk | Risk level |
+
+Each skill gets a security rating before installation, with a link to details on skills.sh.
+
+### Implications for tome
+
+1. **`.agents/skills/` is the emerging universal path** — 9 agents converge on it. Tome's `Directory` source type can discover skills there today.
+2. **Lockfile as prior art for `tome.lock`** — `.skill-lock.json` v3 tracks the same concepts tome needs: content hashes for idempotency, source provenance, install timestamps.
+3. **Symlink vs copy choice** — `npx skills` offers both, recommending symlink. Tome already uses this model (library copies + symlink distribution).
+4. **Security assessment** — interesting prior art for a future `tome audit` command.
+5. **41-agent coverage** — significantly expands the known agent landscape beyond tome's current connector list.
+
+---
+
 ## Sources
 
 ### Standards & Specifications
@@ -1467,6 +1590,10 @@ Everything else (hooks, agents, plugins, memory) remains fragmented with no sign
 - [Aider Configuration](https://aider.chat/docs/config/aider_conf.html) — YAML config
 - [Nanobot (HKUDS)](https://github.com/HKUDS/nanobot) — OpenClaw-compatible agent
 - [PicoClaw](https://picoclaw.ai/docs) — ultra-lightweight agent
+
+### Skill Installers
+- [npx skills (Vercel Labs)](https://github.com/vercel-labs/skills) — 41-agent skill installer with lockfile and security assessment
+- [skills.sh](https://skills.sh) — skill registry with per-skill detail pages and security ratings
 
 ### Analysis & Security
 - [Skills Are More Context-Efficient Than MCP](https://www.mlad.ai/articles/skills-are-more-context-efficient-than-mcp) — token comparison


### PR DESCRIPTION
## Summary

- Add section 20 to `docs/src/tool-landscape.md` documenting `npx skills` (Vercel Labs): architecture, `.skill-lock.json` v3 lockfile format, all 41 agent targets with install paths, CLI commands, security assessment features, and implications for tome
- Update `ROADMAP.md` v0.3 section with `.agents/skills/` as the emerging universal path convention and expanded connector list
- Updated issue #97 body with full research findings and architecture comparison
- Added comment on issue #38 noting `.skill-lock.json` as prior art for `tome.lock`

## Key Findings

- **41 agents** supported by `npx skills`, 9 of which share `.agents/skills/` as a universal project-scoped path
- **`.skill-lock.json` v3** tracks source provenance + content hashes — direct prior art for `tome.lock` (#38)
- **Two-tier model** (canonical copies + symlink distribution) mirrors tome's library → target architecture
- **Security risk assessment** (Gen, Socket, Snyk) — prior art for future `tome audit`

## Test plan

- [ ] Verify `docs/src/tool-landscape.md` renders correctly in mdBook
- [ ] Verify `ROADMAP.md` reads coherently with new v0.3 bullets
- [ ] Confirm issue #97 body updated correctly
- [ ] Confirm issue #38 comment added

Closes #97