### PR TITLE
docs: update commands.md — add missing flags and aliases

### DIFF
--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -5,9 +5,36 @@
 | `tome init` | Interactive wizard to configure sources and targets |
 | `tome sync` | Discover, consolidate, and distribute skills |
 | `tome status` | Show library, sources, targets, and health |
-| `tome list` | List all discovered skills with sources |
-| `tome doctor` | Diagnose and repair broken symlinks |
+| `tome list` (alias: `ls`) | List all discovered skills with sources |
+| `tome doctor` | Diagnose and repair library issues |
 | `tome serve` | Start the MCP server (stdio) |
 | `tome config` | Show current configuration |
 
-All commands support `--dry-run`, `--verbose`, and `--config <path>`.
+## Global Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--config <path>` | | Path to config file (default: `~/.config/tome/config.toml`) |
+| `--dry-run` | | Preview changes without modifying filesystem |
+| `--verbose` | `-v` | Detailed output |
+| `--quiet` | `-q` | Suppress non-error output (conflicts with `--verbose`) |
+
+## Command-Specific Flags
+
+### `tome sync`
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--force` | `-f` | Recreate all symlinks even if they appear up-to-date |
+
+### `tome list`
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output as JSON |
+
+### `tome config`
+
+| Flag | Description |
+|------|-------------|
+| `--path` | Print config file path only |


### PR DESCRIPTION
## Summary
- Add `--json` flag for `tome list`
- Add `tome ls` alias
- Add `--force` for `tome sync`
- Add `--quiet` to global flags
- Add `--path` for `tome config`
- Expand into structured sections with tables

Closes #201

## Test plan
- [x] All flags match `cli.rs` definitions