### PR TITLE
fix: add `--all-targets` to `make lint` to match CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test:
 	cargo test
 
 lint:
-	cargo clippy -- -D warnings
+	cargo clippy --all-targets -- -D warnings
 
 fmt:
 	cargo fmt


### PR DESCRIPTION
## Summary
- Aligns `make lint` with CI by adding `--all-targets` flag to clippy

Closes #196

## Test plan
- [x] `make ci` passes locally