### PR TITLE
chore: add MSRV `rust-version = 1.85.0` for edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = ["crates/*"]
 [workspace.package]
 version = "0.2.0"
 edition = "2024"
+rust-version = "1.85.0"
 license = "MIT"
 authors = ["Martin Pfundmair <dev@martinp7r.com>"]
 repository = "https://github.com/martinP7r/tome"


### PR DESCRIPTION
## Summary
- Adds `rust-version = "1.85.0"` to `[workspace.package]` to declare the minimum supported Rust version for edition 2024

Closes #197

## Test plan
- [x] `cargo check` works
- [x] `make ci` passes