### PR TITLE
docs: update architecture.md — fix stale claims

### DIFF
--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -25,7 +25,7 @@ The core flow that `tome sync` and `tome init` both invoke (`lib.rs::sync`):
 - `status.rs` — Read-only summary of library, sources, targets, and health.
 - `mcp.rs` — MCP server implementation using `rmcp`. Exposes `list_skills` and `read_skill` tools over stdio.
 - `manifest.rs` — Library manifest (`.tome-manifest.json`): tracks provenance, content hashes, and sync timestamps for each skill. Provides `hash_directory()` for deterministic SHA-256 of directory contents.
-- `paths.rs` — Filesystem utility functions including `expand_tilde()` for path expansion and `symlink_points_to()` for symlink target validation.
+- `paths.rs` — Symlink path utilities: resolves relative symlink targets to absolute paths and checks whether a symlink points to a given destination.
 
 ## `crates/tome-mcp` — Standalone MCP binary (`tome-mcp`)
 


### PR DESCRIPTION
## Summary
- Fix consolidation step: describe managed (symlink) vs local (copy) model with manifest hashing
- Fix key patterns: remove "Symlinks everywhere", update to two-tier model
- Fix key patterns: update targets from hardcoded struct to data-driven BTreeMap
- Add `manifest.rs` and `paths.rs` to module list
- Fix `doctor.rs` description to include orphan dirs and missing manifest entries

Closes #199

## Test plan
- [x] `make ci` passes (fmt, clippy, tests)
- [x] Docs-only change — no code affected