### PR TITLE
chore: add `cargo-deny` for dependency license and advisory checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,10 @@ jobs:
         run: cargo test --all
       - name: Build
         run: cargo build --release
+
+  deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-release check test lint fmt clean install docs docs-rust docs-serve release
+.PHONY: build build-release check test lint fmt clean install docs docs-rust docs-serve release deny
 
 build:
 	cargo build
@@ -55,6 +55,9 @@ install:
 
 ci: fmt-check lint test
 	@echo "All checks passed"
+
+deny:
+	cargo deny check
 
 docs: docs-rust
 	mdbook build

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,48 @@
+[graph]
+all-features = false
+no-default-features = false
+
+[output]
+feature-depth = 1
+
+# Deny known vulnerabilities in dependencies
+[advisories]
+ignore = []
+
+# Allowed dependency licenses
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Unlicense",
+]
+confidence-threshold = 0.8
+exceptions = []
+
+[licenses.private]
+ignore = false
+registries = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+allow = []
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary
- Adds `deny.toml` configuration for cargo-deny
- Adds `cargo-deny` CI job using `EmbarkStudios/cargo-deny-action@v2` (ubuntu-only)
- Adds `make deny` target for local checking

Closes #198

## Test plan
- [x] `cargo deny check` passes locally
- [x] `make ci` passes