### PR TITLE
docs: pre-release audit for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,41 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- Atomic lockfile and machine prefs saves (temp+rename) to prevent corruption on crash
-- `sync` now cleans up disabled skill symlinks from targets (previously only `update` did this)
-- MCP server now filters out disabled skills from machine preferences
-- `offer_git_commit` stages specific file paths instead of `git add .`
-- `cleanup_disabled_from_target` now verifies symlinks point into the library before removing
-- `count_health_issues` merged triple directory read into a single pass
-- Managed skill consolidation repairs stale directory state instead of silently skipping
-
-### Added
-- `--machine` global CLI flag to override machine preferences path
-
-## [0.2.0] - 2026-03-13
+## [0.3.0] - 2026-03-13
 
 ### Added
 - **Per-machine preferences**: `~/.config/tome/machine.toml` with `disabled` list — skills stay in library but are skipped during distribution
 - **`tome update` command**: loads lockfile, diffs against current state, presents added/changed/removed skills interactively, offers to disable unwanted new skills
 - **`tome.lock` lockfile**: reproducible library snapshots with provenance metadata
-- **Connector architecture**: `BTreeMap<String, TargetConfig>` replaces hardcoded Targets struct — any tool can be a target without code changes
+- **Connector architecture**: `BTreeMap<String, TargetConfig>` replaces hardcoded Targets struct — any tool can be added as a target without code changes
 - **KnownTarget registry**: wizard auto-discovers common tool locations for target configuration
 - `--json` flag for `tome list`, structured warning collection, data struct extraction
-- **Library copies**: two-tier consolidation model — managed skills (ClaudePlugins) are symlinked, local skills (Directory) are copied into the library
+- **Two-tier consolidation**: managed skills (ClaudePlugins) are symlinked, local skills (Directory) are copied into the library
 - **Content hashing**: SHA-256 manifest (`.tome-manifest.json`) for idempotent sync — unchanged skills are skipped
 - **`.gitignore` generation** for library directory to support git-friendly skill tracking
-- **Git init** offered during wizard for library directory
-- Tool-landscape and frontmatter compatibility research docs
+- `--machine` global CLI flag to override machine preferences path
 
 ### Changed
 - `Config::exclude` changed from `Vec<String>` to `BTreeSet<SkillName>` for type safety
-- Consolidation strategies: managed skills symlinked (package manager owns files), local skills copied (library is canonical home)
 - `count_entries` now skips hidden directories
 
 ### Fixed
+- Atomic lockfile and machine prefs saves (temp+rename) to prevent corruption on crash
+- `sync` now cleans up disabled skill symlinks from targets (previously only `update` did this)
+- MCP server now filters out disabled skills from machine preferences
+- `offer_git_commit` scopes `git add` to tome-managed paths instead of `git add .`
+- `cleanup_disabled_from_target` verifies symlinks point into the library before removing
+- `count_health_issues` no longer double-counts broken managed symlinks
+- Managed skill consolidation repairs stale directory state instead of silently skipping
 - Various security and correctness fixes (MCP path validation, doctor repair, config validation)
 - Sync lifecycle and `--force` integration test coverage
+
+## [0.2.0] - 2026-02-25
+
+### Added
+- **Library copies**: library is the source of truth for local skills — `tome sync` copies from sources into the library instead of symlinking
+- **Git init** offered during wizard for library directory
+- **Git commit** offered after sync when library is a git repo with changes
+
+### Changed
+- Consolidation model: sources → (copy) → library → (symlink) → targets (previously sources → (symlink) → library → (symlink) → targets)
+
+### Fixed
+- Skip distribution to targets where skills already originate (prevents circular symlinks)
+- MCP `read_skill` path validation (symlink escape vulnerability)
+- Doctor repair checks `target.enabled` before operating
+- Config validation errors on nonexistent parent directory
+- Wizard surfaces discovery errors instead of silently swallowing
+- Various hardening (canonicalization, error propagation, `expect()` removal)
 
 ## [0.1.4] - 2026-02-25
 
@@ -99,7 +110,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI on Ubuntu and macOS (fmt, clippy, test, release build)
 - cargo-dist release workflow for cross-platform binaries
 
-[Unreleased]: https://github.com/MartinP7r/tome/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/MartinP7r/tome/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/MartinP7r/tome/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/MartinP7r/tome/compare/v0.1.4...v0.2.0
 [0.1.4]: https://github.com/MartinP7r/tome/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/MartinP7r/tome/compare/v0.1.2...v0.1.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Current State
 
-**v0.3.x MVP complete** — Portable Library milestone shipped: `tome.lock` lockfile (PR #220), per-machine preferences via `machine.toml` (#39), `tome update` command with lockfile diffing and interactive triage (#40). Next up: **v0.4 Format Transforms** (pluggable transform pipeline, Copilot/Cursor/Windsurf format support).
+**v0.3.0 released** — Portable Library milestone shipped: `tome.lock` lockfile, per-machine preferences via `machine.toml`, `tome update` command with lockfile diffing and interactive triage, connector architecture with data-driven targets. Next up: **v0.4 Format Transforms** (pluggable transform pipeline, Copilot/Cursor/Windsurf format support).
 
 ## Quick Reference
 
@@ -64,24 +64,28 @@ The main binary. All domain logic lives here as a library (`lib.rs` re-exports a
 **Sync pipeline** (`lib.rs::sync`) — the core flow that `tome sync` and `tome init` both invoke:
 1. **Discover** (`discover.rs`) — Scan configured sources for `*/SKILL.md` dirs. Two source types: `ClaudePlugins` (reads `installed_plugins.json`) and `Directory` (flat walkdir scan). First source wins on name conflicts; exclusion list applied.
 2. **Consolidate** (`library.rs`) — Two strategies based on source type: managed skills (ClaudePlugins) are symlinked from library → source dir (package manager owns the files); local skills (Directory) are copied into the library (library is the canonical home). A manifest (`.tome-manifest.json`) tracks SHA-256 content hashes for idempotent updates: unchanged skills are skipped, changed skills are re-copied or re-linked.
-3. **Distribute** (`distribute.rs`) — Push library skills to target tools. Two methods: `Symlink` (creates links in target's skills dir pointing to library copies) and `Mcp` (writes a `tome` entry into the target's `.mcp.json`).
-4. **Cleanup** (`cleanup.rs`) — Remove stale entries from library (skills no longer in any source) and broken symlinks from targets. Interactive in TTY mode; auto-removes with warning otherwise.
+3. **Distribute** (`distribute.rs`) — Push library skills to target tools. Two methods: `Symlink` (creates links in target's skills dir pointing to library copies) and `Mcp` (writes a `tome` entry into the target's `.mcp.json`). Skills disabled in machine preferences are skipped.
+4. **Cleanup** (`cleanup.rs`) — Remove stale entries from library (skills no longer in any source), broken symlinks from targets, and disabled skill symlinks from target directories. Interactive in TTY mode; auto-removes with warning otherwise.
 
 **Other modules:**
 - `wizard.rs` — Interactive `tome init` setup using `dialoguer` (MultiSelect, Input, Confirm, Select). Auto-discovers known source locations (`~/.claude/plugins/cache`, `~/.claude/skills`, `~/.codex/skills`, `~/.gemini/antigravity/skills`).
 - `config.rs` — TOML config at `~/.config/tome/config.toml`. `Config::load_or_default` handles missing files gracefully. All path fields support `~` expansion.
 - `manifest.rs` — Library manifest (`.tome-manifest.json`): tracks provenance, content hashes, and sync timestamps for each skill. Provides `hash_directory()` for deterministic SHA-256 of directory contents.
 - `doctor.rs` — Diagnoses library issues (orphan directories, missing manifest entries, broken legacy symlinks) and missing source paths; optionally repairs.
-- `status.rs` — Read-only summary of library, sources, targets, and health.
-- `mcp.rs` — MCP server implementation using `rmcp`. Exposes `list_skills` and `read_skill` tools over stdio.
+- `status.rs` — Read-only summary of library, sources, targets, and health. Single-pass directory scan for efficiency.
+- `mcp.rs` — MCP server implementation using `rmcp`. Exposes `list_skills` and `read_skill` tools over stdio. Filters out disabled skills based on machine preferences.
+- `lockfile.rs` — Generates and loads `tome.lock` files. Each entry records skill name, content hash, source, and provenance metadata. Uses atomic temp+rename writes.
+- `machine.rs` — Per-machine preferences (`~/.config/tome/machine.toml`). Tracks a `disabled` set of skill names. Uses atomic temp+rename writes.
+- `update.rs` — Implements `tome update`: loads the previous lockfile, diffs against current state, presents changes interactively, and offers to disable unwanted new skills.
+- `paths.rs` — Symlink path utilities: resolves relative symlink targets to absolute paths and checks whether a symlink points to a given destination.
 
 ### `crates/tome-mcp` — Standalone MCP binary (`tome-mcp`)
 Thin wrapper: loads config, calls `tome::mcp::serve()`. Exists so MCP-only consumers don't need the full CLI. The same server is also reachable via `tome serve`.
 
 ## Key Patterns
 
-- **Two-tier model**: Sources →(copy)→ Library →(symlink)→ Targets. The library is the source of truth, containing real copies of each skill directory. Distribution to targets uses Unix symlinks (`std::os::unix::fs::symlink`) pointing into the library. This means the project is Unix-only.
-- **Targets are data-driven**: `config::targets` is a `BTreeMap<String, TargetConfig>` — any tool can be added as a target without code changes. The wizard uses a `KnownTarget` registry for auto-discovery of common tools. Future: connector trait (#192) for unified source/target abstraction.
+- **Two-tier model**: Sources →(consolidate)→ Library →(distribute)→ Targets. The library is the source of truth. Managed skills (from package managers) are symlinked from library → source dir; local skills are copied into the library. Distribution to targets uses Unix symlinks (`std::os::unix::fs::symlink`) pointing into the library. This means the project is Unix-only.
+- **Targets are data-driven**: `config::targets` is a `BTreeMap<String, TargetConfig>` — any tool can be added as a target without code changes. The wizard uses a `KnownTarget` registry for auto-discovery of common tools.
 - **`dry_run` threading**: Most operations accept a `dry_run: bool` that skips filesystem writes but still counts what *would* change. Results report the same counts either way.
 - **Error handling**: `anyhow` for the application. Missing sources/paths produce warnings (stderr) rather than hard errors.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ graph LR
 ```
 
 1. **Discover** — Scan configured sources for `*/SKILL.md` directories
-2. **Consolidate** — Copy or symlink skills into a central library (local skills are copied, managed skills are symlinked; deduplicates, first source wins)
+2. **Consolidate** — Gather skills into a central library: local skills are copied, managed (plugin) skills are symlinked; deduplicates with first source winning
 3. **Distribute** — Create symlinks or MCP config entries in each target tool's directory (respects per-machine disabled list)
 4. **Cleanup** — Remove stale entries and broken symlinks from library and targets
 
@@ -148,8 +148,8 @@ tome serve
 ```
 
 The server exposes two tools:
-- `list_skills` — List all discovered skills (respects machine preferences)
-- `read_skill` — Read a skill's SKILL.md content by name
+- `list_skills` — List all discovered skills (excludes disabled skills per machine preferences)
+- `read_skill` — Read a skill's SKILL.md content by name (returns "not found" for disabled skills)
 
 ## License
 

--- a/crates/tome/src/cli.rs
+++ b/crates/tome/src/cli.rs
@@ -50,7 +50,7 @@ pub enum Command {
     /// Review library changes and sync with interactive triage
     Update,
 
-    /// Show current state of skills, symlinks, and targets
+    /// Show library, sources, targets, and health summary
     Status,
 
     /// Diagnose and repair broken symlinks or config issues

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> **[v0.2 System Diagram (Excalidraw)](https://excalidraw.com/#json=5-pjpDsna4Way3lfGW5km,p0bQwpcJEl6do68RrnKAgw)** — interactive diagram showing the two-tier source → library → target flow.
+> **[System Diagram (Excalidraw)](https://excalidraw.com/#json=5-pjpDsna4Way3lfGW5km,p0bQwpcJEl6do68RrnKAgw)** — interactive diagram showing the two-tier source → library → target flow.
 
 Rust workspace (edition 2024) with two crates producing two binaries.
 
@@ -37,7 +37,7 @@ Thin wrapper: loads config, calls `tome::mcp::serve()`. Exists so MCP-only consu
 
 ## Key Patterns
 
-- **Two-tier model**: Sources →(consolidate)→ Library →(distribute)→ Targets. The library is the source of truth. Managed skills (from package managers like Claude plugins) are symlinked into the library; local skills (from directory sources) are copied. Distribution to targets always uses symlinks pointing into the library. This means the project is Unix-only (`std::os::unix::fs::symlink`).
+- **Two-tier model**: Sources →(consolidate)→ Library →(distribute)→ Targets. The library is the source of truth. Managed skills (from package managers like Claude plugins) are symlinked from library → source dir (the package manager owns the files); local skills (from directory sources) are copied into the library (the library is canonical home). Distribution to targets always uses symlinks pointing into the library. This means the project is Unix-only (`std::os::unix::fs::symlink`).
 - **Targets are data-driven**: `config::targets` is a `BTreeMap<String, TargetConfig>` — any tool can be added as a target without code changes. The wizard uses a `KnownTarget` registry for auto-discovery of common tools.
 - **`dry_run` threading**: Most operations accept a `dry_run: bool` that skips filesystem writes but still counts what *would* change. Results report the same counts either way.
 - **Error handling**: `anyhow` for the application. Missing sources/paths produce warnings (stderr) rather than hard errors.

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -5,11 +5,11 @@
 | `tome init` | Interactive wizard to configure sources and targets |
 | `tome sync` | Discover, consolidate, and distribute skills |
 | `tome update` | Review library changes and sync with interactive triage |
-| `tome status` | Show current state of skills, symlinks, and targets |
-| `tome list` (alias: `ls`) | List all discovered skills with sources |
+| `tome status` | Show library, sources, targets, and health summary |
+| `tome list` (alias: `ls`) | List all discovered skills with sources (supports `--json`) |
 | `tome doctor` | Diagnose and repair broken symlinks or config issues |
 | `tome serve` | Start the MCP server (stdio) |
-| `tome config` | Show or edit configuration |
+| `tome config` | Show current configuration |
 
 ## Global Flags
 
@@ -33,7 +33,7 @@ Runs the full pipeline: discover skills from sources, consolidate into the libra
 
 ### `tome update`
 
-Loads the existing `tome.lock` lockfile, diffs against the current state, and presents added/changed/removed skills interactively. Offers to disable unwanted new skills via machine preferences.
+Loads the existing `tome.lock` lockfile, diffs against the current state, and presents added/changed/removed skills interactively. Offers to disable unwanted new skills via machine preferences. If no lockfile exists yet, performs an initial sync.
 
 ### `tome list`
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -73,3 +73,13 @@ Use `tome update` to interactively review new or changed skills and disable unwa
 `tome sync` generates a `tome.lock` file in the library directory. This lockfile captures a reproducible snapshot of all skills — their names, content hashes, sources, and provenance metadata. It is used by `tome update` to diff against the current state and surface changes.
 
 The lockfile is designed to be committed to version control alongside the library, enabling multi-machine workflows where `tome update` on a new machine can detect what changed since the last sync.
+
+## Library `.gitignore`
+
+`tome sync` automatically generates a `.gitignore` in the library directory:
+
+- **Managed skills** (symlinked from package managers) are gitignored — they are recreated by `tome sync`
+- **Local skills** (copied into the library) are tracked in version control
+- **Temporary files** (`.tome-manifest.tmp`, `tome.lock.tmp`) are always ignored
+
+This allows the library directory to serve as a git repository for portable skill management while keeping transient entries out of version control.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -64,7 +64,7 @@ graph LR
 ```
 
 1. **Discover** — Scan configured sources for `*/SKILL.md` directories
-2. **Consolidate** — Copy or symlink skills into a central library (local skills are copied, managed skills are symlinked; deduplicates, first source wins)
+2. **Consolidate** — Gather skills into a central library: local skills are copied, managed (plugin) skills are symlinked; deduplicates with first source winning
 3. **Distribute** — Create symlinks or MCP config entries in each target tool's directory (respects per-machine disabled list)
 4. **Cleanup** — Remove stale entries and broken symlinks from library and targets
 

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -11,8 +11,8 @@ tome serve
 ```
 
 The server exposes two tools:
-- `list_skills` — List all discovered skills with name and description
-- `read_skill` — Read a skill's SKILL.md content by name
+- `list_skills` — List all discovered skills with name and description (excludes disabled skills per machine preferences)
+- `read_skill` — Read a skill's SKILL.md content by name (returns "not found" for disabled skills)
 
 ## Machine Preferences
 


### PR DESCRIPTION
## Summary

- Restructure CHANGELOG.md — `[0.2.0]` section incorrectly included features that shipped after the v0.2.0 tag. All post-tag features moved to `[0.3.0]`, `[0.2.0]` fixed to reflect what actually shipped (Scoped SOT)
- Fix doc consistency across README, introduction, architecture, commands, configuration, MCP server, and CLAUDE.md
- Add missing `.gitignore` generation section to configuration docs
- Add missing modules (lockfile, machine, update, paths) to CLAUDE.md

## Test plan

- [x] `make ci` passes (228 tests, fmt, clippy)
- [ ] Review rendered docs (mdBook) for formatting