### PR TITLE
feat: audit known targets/sources against current platform docs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,6 +84,7 @@ Complete the multi-machine skill management story. The lockfile (#38, shipped ea
 - Preserve original format — transforms are output-only
 - Connectors declare input/output formats; the pipeline resolves the translation chain
 - **Copilot `.instructions.md` format**: Support Copilot's `.instructions.md` as a transform target alongside Cursor `.mdc` and Windsurf rules
+- **Deprecate `DistributionMethod::Mcp`**: No known targets use MCP distribution as of March 2026 — all major AI coding tools now support SKILL.md directory scanning natively. Emit a deprecation warning when MCP targets are configured; remove the variant in a future major version.
 
 ## v0.4.x — Browse + Skill Validation
 

--- a/crates/tome/src/wizard.rs
+++ b/crates/tome/src/wizard.rs
@@ -288,10 +288,10 @@ const KNOWN_TARGETS: &[KnownTarget] = &[
     },
     KnownTarget {
         name: "codex",
-        display: "Codex (MCP)",
-        method: DistributionMethod::Mcp,
-        default_path: ".codex/.mcp.json",
-        path_prompt: "Codex MCP config path",
+        display: "Codex",
+        method: DistributionMethod::Symlink,
+        default_path: ".agents/skills",
+        path_prompt: "Codex skills directory",
     },
     KnownTarget {
         name: "openclaw",
@@ -300,6 +300,41 @@ const KNOWN_TARGETS: &[KnownTarget] = &[
         default_path: ".openclaw/skills",
         path_prompt: "OpenClaw skills directory",
     },
+    KnownTarget {
+        name: "goose",
+        display: "Goose",
+        method: DistributionMethod::Symlink,
+        default_path: ".config/goose/skills",
+        path_prompt: "Goose skills directory",
+    },
+    KnownTarget {
+        name: "gemini-cli",
+        display: "Gemini CLI",
+        method: DistributionMethod::Symlink,
+        default_path: ".gemini/skills",
+        path_prompt: "Gemini CLI skills directory",
+    },
+    KnownTarget {
+        name: "amp",
+        display: "Amp",
+        method: DistributionMethod::Symlink,
+        default_path: ".config/amp/skills",
+        path_prompt: "Amp skills directory",
+    },
+    KnownTarget {
+        name: "opencode",
+        display: "OpenCode",
+        method: DistributionMethod::Symlink,
+        default_path: ".config/opencode/skills",
+        path_prompt: "OpenCode skills directory",
+    },
+    KnownTarget {
+        name: "copilot",
+        display: "VS Code Copilot",
+        method: DistributionMethod::Symlink,
+        default_path: ".copilot/skills",
+        path_prompt: "Copilot skills directory",
+    },
 ];
 
 fn configure_targets() -> Result<BTreeMap<String, TargetConfig>> {
@@ -307,7 +342,10 @@ fn configure_targets() -> Result<BTreeMap<String, TargetConfig>> {
 
     let home = dirs::home_dir().context("could not determine home directory")?;
 
-    let labels: Vec<&str> = KNOWN_TARGETS.iter().map(|t| t.display).collect();
+    let labels: Vec<String> = KNOWN_TARGETS
+        .iter()
+        .map(|t| format!("{} (~/{}/)", t.display, t.default_path))
+        .collect();
     let selections = MultiSelect::new()
         .with_prompt("Which tools should receive skills?\n  (space to toggle, enter to confirm)")
         .items(&labels)
@@ -428,12 +466,26 @@ const KNOWN_SOURCES: &[(&str, &str, SourceType)] = &[
         SourceType::ClaudePlugins,
     ),
     ("claude-skills", ".claude/skills", SourceType::Directory),
-    ("codex-skills", ".codex/skills", SourceType::Directory),
+    ("codex-skills", ".agents/skills", SourceType::Directory),
     (
         "antigravity-skills",
         ".gemini/antigravity/skills",
         SourceType::Directory,
     ),
+    (
+        "goose-skills",
+        ".config/goose/skills",
+        SourceType::Directory,
+    ),
+    ("gemini-cli-skills", ".gemini/skills", SourceType::Directory),
+    ("amp-skills", ".config/amp/skills", SourceType::Directory),
+    (
+        "opencode-skills",
+        ".config/opencode/skills",
+        SourceType::Directory,
+    ),
+    ("copilot-skills", ".copilot/skills", SourceType::Directory),
+    ("agents-skills", ".agents/skills", SourceType::Directory),
 ];
 
 /// Check if any source path matches a symlink target path.
@@ -441,6 +493,10 @@ const KNOWN_SOURCES: &[(&str, &str, SourceType)] = &[
 /// Returns `(source_name, overlapping_path)` pairs for each conflict.
 /// Only compares against `Symlink` targets (not `Mcp`), since MCP config
 /// files are JSON configs, not skills directories.
+///
+/// NOTE: No known targets use MCP distribution as of March 2026.
+/// All major AI coding tools now support SKILL.md directory scanning natively.
+/// MCP distribution is retained for custom user targets but may be removed in a future version.
 fn find_source_target_overlaps(
     sources: &[Source],
     targets: &BTreeMap<String, TargetConfig>,
@@ -618,18 +674,20 @@ mod tests {
 
     #[test]
     fn no_overlap_with_mcp_targets() {
+        // Synthetic MCP target — no known targets use MCP as of March 2026,
+        // but custom user targets may still use it.
         let sources = vec![Source {
-            name: "codex-skills".into(),
-            path: PathBuf::from("/home/user/.codex/.mcp.json"),
+            name: "custom-skills".into(),
+            path: PathBuf::from("/home/user/.custom/.mcp.json"),
             source_type: SourceType::Directory,
         }];
 
         let targets = BTreeMap::from([(
-            "codex".to_string(),
+            "custom-mcp".to_string(),
             TargetConfig {
                 enabled: true,
                 method: TargetMethod::Mcp {
-                    mcp_config: PathBuf::from("/home/user/.codex/.mcp.json"),
+                    mcp_config: PathBuf::from("/home/user/.custom/.mcp.json"),
                 },
             },
         )]);

--- a/docs/src/tool-landscape.md
+++ b/docs/src/tool-landscape.md
@@ -12,7 +12,7 @@ AI coding tools have up to **seven layers** of configuration. Most discussions f
 
 | Layer | Purpose | Portable? | Who Has It |
 |-------|---------|-----------|-----------|
-| **Skills** | Reusable instructions activated on demand | Yes (SKILL.md standard, 20+ tools) | Claude, Codex, Copilot, Antigravity, Cursor, OpenCode, Amp, Goose |
+| **Skills** | Reusable instructions activated on demand | Yes (SKILL.md standard, 30+ tools) | Claude, Codex, Copilot, Antigravity, Gemini CLI, Cursor, OpenCode, Amp, Goose |
 | **Rules** | Always-on project/global conventions | Partially (markdown, but different filenames/formats) | All tools |
 | **Memory** | Learned context persisted across sessions | No (completely tool-specific) | Claude, Codex, Cursor, Windsurf, Copilot, OpenClaw |
 | **Hooks** | Lifecycle event handlers | No (tool-specific JSON/config) | Claude (12 events), Codex, Windsurf, Amp |
@@ -237,7 +237,7 @@ PicoClaw prioritizes extreme minimalism. For tome, it would likely be an MCP tar
 
 ### Gemini CLI
 
-**Vendor:** Google | **Type:** CLI agent | **SKILL.md:** Not documented
+**Vendor:** Google | **Type:** CLI agent | **SKILL.md:** Standard
 
 | Aspect | Details |
 |--------|---------|
@@ -253,6 +253,8 @@ PicoClaw prioritizes extreme minimalism. For tome, it would likely be an MCP tar
 **Shell execution:** `!{command}` syntax for shell injection with auto-escaping of `{{args}}`. Argument substitution via `{{args}}` (not `$ARGUMENTS`).
 
 Gemini CLI is the simplest format for instructions — plain markdown files concatenated into context. No frontmatter, no structured fields. The `@file.md` import syntax and `!{command}` execution are unique.
+
+**Skills (2026):** Gemini CLI now supports SKILL.md directory scanning. Personal skills at `~/.gemini/skills/` and the portable `~/.agents/skills/` path. For tome, Gemini CLI is a Symlink target via `~/.gemini/skills/`.
 
 ---
 
@@ -294,15 +296,16 @@ Amp is a useful case study — their migration from custom commands to Agent Ski
 
 ### Goose
 
-**Vendor:** Block (Square) | **Type:** Autonomous agent | **SKILL.md:** Not documented
+**Vendor:** Block (Square) | **Type:** Autonomous agent | **SKILL.md:** Standard
 
 | Aspect | Details |
 |--------|---------|
+| **Skills** | SKILL.md standard. Scans 6 directories: `~/.config/goose/skills/`, `~/.config/agents/skills/`, `~/.claude/skills/`, and project-level equivalents. |
 | **Extensions** | Six types: Stdio (MCP via pipes), HTTP (MCP via SSE), Builtin (Rust). |
 | **MCP** | Core mechanism — 100+ servers in toolkit catalog. Auto-OAuth on HTTP 401. |
 | **Config** | TOML at `~/.config/goose/` |
 
-Goose is built entirely around MCP — extensions are MCP servers, not skill directories. For tome, Goose is exclusively an MCP target.
+Goose now supports SKILL.md directory scanning alongside its MCP-centric extension model. For tome, Goose is a Symlink target via `~/.config/goose/skills/`.
 
 ---
 
@@ -347,6 +350,10 @@ A "rule" that should apply everywhere needs to exist as up to 5 different files:
 
 Symlinks can unify the markdown-based ones, but Cursor/Windsurf require format transforms.
 
+### AGENTS.md as open standard
+
+**AGENTS.md** has emerged as an open instruction-file standard under the Linux Foundation / Agentic AI Foundation. It is adopted by Codex, OpenCode, OpenClaw, and configurable in Gemini CLI — the instruction-file equivalent of the SKILL.md skills standard. The portable path `~/.agents/` (and its `skills/` subdirectory) is scanned by Codex, Goose, Gemini CLI, OpenCode, Amp, and Cursor.
+
 ---
 
 ## 4. SKILL.md Standard (agentskills.io)
@@ -364,7 +371,9 @@ The [Agent Skills](https://agentskills.io) format originated at Anthropic in lat
 | Cursor | Adopted (2026) | — |
 | OpenCode | Standard | — |
 | OpenClaw | Compatible | — |
-| Gemini CLI | Not documented | Uses `@file` imports instead |
+| Gemini CLI | Standard | Scans `~/.gemini/skills/` and `~/.agents/skills/` |
+| Goose | Standard | Scans 6 dirs including `~/.config/goose/skills/`, `~/.config/agents/skills/`, `~/.claude/skills/` |
+| Amp | Standard (migrating to) | Scans `~/.config/amp/skills/`, `~/.config/agents/skills/`, `.claude/skills/` |
 | Windsurf | Not documented | Uses native rules format |
 
 ### Invocation methods
@@ -417,8 +426,11 @@ skill-name/
 | Claude Code | `~/.claude/skills/` | `.claude/skills/` + nested subdirs |
 | Codex CLI | `$HOME/.agents/skills/` | `.agents/skills/` → parent → repo root |
 | VS Code Copilot | `~/.copilot/skills/` | `.github/skills/` + `.claude/skills/` |
-| Antigravity | — | Skills directory (semantic matching) |
-| OpenCode | — | Via `opencode.json` `instructions` array |
+| Antigravity | `~/.gemini/antigravity/skills/` | `.gemini/skills/`, `.agents/skills/` |
+| Gemini CLI | `~/.gemini/skills/` | `~/.agents/skills/` |
+| Goose | `~/.config/goose/skills/` | `~/.config/agents/skills/`, `~/.claude/skills/` |
+| Amp | `~/.config/amp/skills/` | `~/.config/agents/skills/`, `.claude/skills/` |
+| OpenCode | `~/.config/opencode/skills/` | `~/.claude/skills/`, `~/.agents/skills/` |
 
 ---
 


### PR DESCRIPTION
## Summary

- **Codex target**: Switch from MCP distribution (`.codex/.mcp.json`) to Symlink (`~/.agents/skills/`) — Codex fully supports SKILL.md directory scanning
- **5 new targets**: Goose, Gemini CLI, Amp, OpenCode, VS Code Copilot
- **7 new sources**: goose-skills, gemini-cli-skills, amp-skills, opencode-skills, copilot-skills, agents-skills (portable `~/.agents/skills/` cross-tool path)
- **Wizard UX**: Target labels now show paths (e.g. `Claude Code (~/.claude/skills/)`)
- **MCP deprecation**: Added deprecation note and roadmap item — no known targets use MCP as of March 2026
- **Docs**: Updated tool-landscape.md with current Goose, Gemini CLI, Amp SKILL.md support; added AGENTS.md open standard note

## Test plan

- [x] `make ci` passes (228 tests)
- [ ] `tome init` visually shows new targets with path labels
- [ ] Verify new target paths match official platform documentation