### PR TITLE
fix: pass --head to gh pr create in release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 	git add Cargo.toml Cargo.lock; \
 	git commit -m "Bump version to $$SEMVER"; \
 	git push -u origin "$$BRANCH"; \
-	gh pr create --title "Bump version to $$SEMVER" --body "Release $$TAG" --assignee MartinP7r; \
+	gh pr create --head "$$BRANCH" --title "Bump version to $$SEMVER" --body "Release $$TAG" --assignee MartinP7r; \
 	gh pr merge --squash --delete-branch; \
 	git checkout main; \
 	git pull origin main; \


### PR DESCRIPTION
## Summary

- Adds explicit `--head "$BRANCH"` to `gh pr create` in the `make release` target
- Without it, gh could default to `main` for both base and head, causing "head branch is the same as base branch" errors (hit during v0.3.2 release)

## Test plan

- [ ] `make release VERSION=0.3.3` succeeds end-to-end