### PR TITLE
fix: suppress noisy canonicalize warnings in dry-run mode

### DIFF
--- a/crates/tome/src/distribute.rs
+++ b/crates/tome/src/distribute.rs
@@ -114,12 +114,10 @@ fn distribute_symlinks(
                     result.unchanged += 1;
                     continue;
                 }
-                (Err(_), _) | (_, Err(_)) => {
-                    eprintln!(
-                        "warning: could not resolve paths for circular symlink check on '{}', proceeding",
-                        skill_name_str
-                    );
-                }
+                // If either path can't be canonicalized (e.g. target dir doesn't
+                // exist yet in dry-run mode), they can't be the same physical
+                // directory — no circular symlink risk.
+                (Err(_), _) | (_, Err(_)) => {}
                 _ => {}
             }
         }


### PR DESCRIPTION
## Summary

- Remove spurious `warning: could not resolve paths for circular symlink check` messages that flood `tome sync --dry-run` output
- When `canonicalize()` fails (target dir doesn't exist yet because `create_dir_all` is skipped in dry-run), silently proceed — non-existent paths can't form circular symlinks

## Test plan

- [ ] `tome sync --dry-run` produces no warnings for new targets
- [ ] Existing `distribute::tests` all pass (12/12)
- [ ] Circular symlink prevention still works for real source-is-target scenarios (`distribute_skips_skills_originating_from_target_dir`)