### PR TITLE
Restructure tome home directory to ~/.tome/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,12 +69,12 @@ The main binary. All domain logic lives here as a library (`lib.rs` re-exports a
 
 **Other modules:**
 - `wizard.rs` — Interactive `tome init` setup using `dialoguer` (MultiSelect, Input, Confirm, Select). Auto-discovers known source locations (`~/.claude/plugins/cache`, `~/.claude/skills`, `~/.codex/skills`, `~/.gemini/antigravity/skills`).
-- `config.rs` — TOML config at `~/.config/tome/config.toml`. `Config::load_or_default` handles missing files gracefully. All path fields support `~` expansion.
+- `config.rs` — TOML config at `~/.tome/tome.toml`. `Config::load_or_default` handles missing files gracefully. All path fields support `~` expansion.
 - `manifest.rs` — Library manifest (`.tome-manifest.json`): tracks provenance, content hashes, and sync timestamps for each skill. Provides `hash_directory()` for deterministic SHA-256 of directory contents.
 - `doctor.rs` — Diagnoses library issues (orphan directories, missing manifest entries, broken legacy symlinks) and missing source paths; optionally repairs.
 - `status.rs` — Read-only summary of library, sources, targets, and health. Single-pass directory scan for efficiency.
 - `lockfile.rs` — Generates and loads `tome.lock` files. Each entry records skill name, content hash, source, and provenance metadata. Uses atomic temp+rename writes.
-- `machine.rs` — Per-machine preferences (`~/.config/tome/machine.toml`). Tracks a `disabled` set of skill names. Uses atomic temp+rename writes.
+- `machine.rs` — Per-machine preferences (`~/.config/tome/machine.toml`). Tracks a `disabled` set of skill names and a `disabled_targets` set of target names. Uses atomic temp+rename writes.
 - `update.rs` — Implements `tome update`: loads the previous lockfile, diffs against current state, presents changes interactively, and offers to disable unwanted new skills.
 - `paths.rs` — Symlink path utilities: resolves relative symlink targets to absolute paths and checks whether a symlink points to a given destination.
 

--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ graph LR
 
 ## Configuration
 
-TOML at `~/.config/tome/config.toml`:
+TOML at `~/.tome/tome.toml`:
 
 ```toml
-library_dir = "~/.local/share/tome/skills"
+library_dir = "~/.tome/skills"
 exclude = ["deprecated-skill"]
 
 [[sources]]
@@ -125,6 +125,7 @@ Control which skills are active on each machine via `~/.config/tome/machine.toml
 
 ```toml
 disabled = ["noisy-skill", "work-only-skill"]
+disabled_targets = ["openclaw"]
 ```
 
 Disabled skills stay in the library but are skipped during distribution. Use `tome update` to interactively review new or changed skills and disable unwanted ones.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@
 | **v0.3**   | Connector Architecture | `BTreeMap` targets, `KnownTarget` registry, npm skill source research  | ✓ |
 | **v0.3.x** | Portable Library (MVP) | Per-machine preferences, `tome update`, lockfile                        | ✓ |
 | **v0.4.1** | Browse + Validation    | `tome browse` (ratatui+nucleo), `tome lint`, frontmatter parsing        |        |
-| **v0.4.2** | Format Transforms      | Pluggable transform pipeline, Copilot/Cursor/Windsurf format support    |        |
+| **v0.4.2** | Format Transforms      | `~/.tome/` unified home, rules/instructions syncing, transform pipeline |        |
 | **v0.5**   | Managed Sources        | Claude marketplace auto-install, git-backed backup                      |        |
 | **v0.6**   | Git Sources            | Remote skill repos, branch/tag/SHA pinning, private repo support        |        |
 | **v0.7**   | Watch Mode             | Auto-sync on filesystem changes, desktop notifications                  |        |
@@ -69,8 +69,8 @@ Replaced the hardcoded `Targets` struct with a flexible, data-driven target conf
 - **Connector trait** → [#192](https://github.com/MartinP7r/tome/issues/192). Unified source/target interface. The BTreeMap solved config flexibility; the trait solves architectural abstraction.
 - **Built-in connectors** → Part of [#192](https://github.com/MartinP7r/tome/issues/192). Claude, Codex, Antigravity, Cursor, Windsurf, Amp, Goose, etc.
 - **Format awareness per connector** → Captured in [#57](https://github.com/MartinP7r/tome/issues/57) (v0.4.2 Format Transforms).
-- **`.claude/rules/` syncing** → [#193](https://github.com/MartinP7r/tome/issues/193). Separate concern from skills.
-- **Instruction file syncing** → [#194](https://github.com/MartinP7r/tome/issues/194). High complexity, needs design.
+- **`.claude/rules/` syncing** → [#193](https://github.com/MartinP7r/tome/issues/193). Managed from `~/.tome/rules/`, distributed to each target's rules dir. See v0.4.2.
+- **Instruction file syncing** → [#194](https://github.com/MartinP7r/tome/issues/194). Managed from `~/.tome/instructions/`, mapped to tool-specific filenames. See v0.4.2.
 
 ## v0.3.x — Portable Library (MVP) ✓
 
@@ -138,7 +138,30 @@ Requires the v0.3 connector architecture. When distributing to specific targets,
 - Description length exceeding target's limit
 - Body syntax incompatible with target (e.g., XML tags, `!command`, `$ARGUMENTS`)
 
-## v0.4.2 — Format Transforms
+## v0.4.2 — Format Transforms & Unified Home Directory
+
+### `~/.tome/` — Unified Home Directory
+
+All tome state moves under a single `~/.tome/` directory, replacing the previous split across `~/.config/tome/` and `~/.local/share/tome/`. The new layout:
+
+```
+~/.tome/
+├── tome.toml          # main config (was ~/.config/tome/config.toml)
+├── tome.lock          # lockfile
+├── skills/            # skill library (was ~/.local/share/tome/skills/)
+├── rules/             # shared rules → .claude/rules/, .cursor/rules/, etc.
+└── instructions/      # instruction files → CLAUDE.md, AGENTS.md, GEMINI.md, etc.
+```
+
+### Rules Syncing ([#193](https://github.com/MartinP7r/tome/issues/193))
+
+Manage tool-specific rule files from a single canonical location. `~/.tome/rules/` contains shared rules that get distributed to each target's rules directory (e.g., `.claude/rules/`, `.cursor/rules/`). Same two-tier model as skills: `~/.tome/rules/` is the source of truth, targets get symlinks.
+
+### Instruction File Syncing ([#194](https://github.com/MartinP7r/tome/issues/194))
+
+Manage root-level instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, .cursorrules, etc.) from `~/.tome/instructions/`. High complexity — each tool expects a different filename and format at the project root. Needs a mapping layer (instruction → tool-specific filename) and careful conflict handling for user-managed instruction files.
+
+### Format Transforms
 
 - Pluggable transform pipeline driven by connector format declarations
 - Preserve original format — transforms are output-only
@@ -188,7 +211,7 @@ Native macOS skill manager app (inspired by [CodexSkillManager](https://github.c
 - **Browse & manage library**: View all skills in the tome library with rendered Markdown previews using [swift-markdown-ui](https://github.com/gonzalezreal/swift-markdown-ui)
 - **Visual skill editing**: Edit skill frontmatter and body with live preview
 - **Sync trigger**: Run `tome sync` from the GUI with status feedback
-- **Source & target management**: Configure sources and targets visually instead of editing `config.toml`
+- **Source & target management**: Configure sources and targets visually instead of editing `tome.toml`
 - **Health dashboard**: Surface `tome doctor` and `tome status` diagnostics in a native UI
 - **Import/export**: Import skills from folders or zip files; export skills for sharing
 - **Tech stack**: SwiftUI (macOS 15+), swift-markdown-ui for rendering, invokes `tome` CLI under the hood

--- a/crates/tome/src/cli.rs
+++ b/crates/tome/src/cli.rs
@@ -14,7 +14,7 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Command,
 
-    /// Path to config file (default: ~/.config/tome/config.toml)
+    /// Path to config file (default: ~/.tome/tome.toml)
     #[arg(long, global = true)]
     pub config: Option<PathBuf>,
 

--- a/crates/tome/src/config.rs
+++ b/crates/tome/src/config.rs
@@ -166,7 +166,7 @@ impl Config {
     /// # Examples
     ///
     /// ```text
-    /// // Load from default ~/.config/tome/config.toml
+    /// // Load from default ~/.tome/tome.toml
     /// let config = Config::load_or_default(None)?;
     ///
     /// // Load from explicit path (parent dir must exist)
@@ -274,13 +274,16 @@ pub fn expand_tilde(path: &Path) -> Result<PathBuf> {
     }
 }
 
-/// Default config file path: ~/.config/tome/config.toml
-pub fn default_config_path() -> Result<PathBuf> {
+/// Default tome home directory: ~/.tome/
+pub fn default_tome_home() -> Result<PathBuf> {
     Ok(dirs::home_dir()
         .context("could not determine home directory")?
-        .join(".config")
-        .join("tome")
-        .join("config.toml"))
+        .join(".tome"))
+}
+
+/// Default config file path: ~/.tome/tome.toml
+pub fn default_config_path() -> Result<PathBuf> {
+    Ok(default_tome_home()?.join("tome.toml"))
 }
 
 mod defaults {
@@ -291,9 +294,7 @@ mod defaults {
         // surface a proper error if home is unavailable.
         dirs::home_dir()
             .unwrap_or_else(|| PathBuf::from("~"))
-            .join(".local")
-            .join("share")
-            .join("tome")
+            .join(".tome")
             .join("skills")
     }
 }
@@ -505,7 +506,7 @@ mod tests {
     #[test]
     fn config_parses_full_toml() {
         let toml_str = r#"
-library_dir = "~/.local/share/tome/skills"
+library_dir = "~/.tome/skills"
 exclude = ["deprecated-skill"]
 
 [[sources]]

--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -53,7 +53,7 @@ impl DoctorReport {
 // -- Data gathering (pure computation, no I/O) --
 
 /// Run all diagnostic checks and return a structured report.
-pub fn check(config: &Config) -> Result<DoctorReport> {
+pub fn check(config: &Config, tome_home: &Path) -> Result<DoctorReport> {
     let configured = config.library_dir.is_dir() || !config.sources.is_empty();
 
     if !configured {
@@ -65,7 +65,7 @@ pub fn check(config: &Config) -> Result<DoctorReport> {
         });
     }
 
-    let library_issues = check_library(&config.library_dir)?;
+    let library_issues = check_library(&config.library_dir, tome_home)?;
 
     let mut target_issues = Vec::new();
     for (name, t) in config.targets.iter() {
@@ -88,8 +88,8 @@ pub fn check(config: &Config) -> Result<DoctorReport> {
 // -- Rendering + control flow --
 
 /// Diagnose and optionally repair issues.
-pub fn diagnose(config: &Config, dry_run: bool) -> Result<()> {
-    let report = check(config)?;
+pub fn diagnose(config: &Config, tome_home: &Path, dry_run: bool) -> Result<()> {
+    let report = check(config, tome_home)?;
 
     if !report.configured {
         println!("Not configured yet. Run `tome init` to get started.");
@@ -135,7 +135,7 @@ pub fn diagnose(config: &Config, dry_run: bool) -> Result<()> {
             if confirmed {
                 println!();
                 println!("{}", style("Repairing...").bold());
-                repair_library(&config.library_dir)?;
+                repair_library(&config.library_dir, tome_home)?;
 
                 for (name, t) in config.targets.iter() {
                     if t.enabled {
@@ -190,7 +190,7 @@ fn render_issues_for_target(name: &str, issues: &[DiagnosticIssue]) {
 
 // -- Check functions (return structured data) --
 
-fn check_library(library_dir: &Path) -> Result<Vec<DiagnosticIssue>> {
+fn check_library(library_dir: &Path, tome_home: &Path) -> Result<Vec<DiagnosticIssue>> {
     let mut issues = Vec::new();
 
     if !library_dir.is_dir() {
@@ -201,7 +201,7 @@ fn check_library(library_dir: &Path) -> Result<Vec<DiagnosticIssue>> {
         return Ok(issues);
     }
 
-    let m = match manifest::load(library_dir) {
+    let m = match manifest::load(tome_home) {
         Ok(m) => m,
         Err(e) => {
             issues.push(DiagnosticIssue {
@@ -345,8 +345,8 @@ fn check_config(config: &Config) -> Result<Vec<DiagnosticIssue>> {
 }
 
 /// Repair library issues: remove orphan manifest entries and broken symlinks.
-fn repair_library(library_dir: &Path) -> Result<()> {
-    let mut m = manifest::load(library_dir).with_context(|| {
+fn repair_library(library_dir: &Path, tome_home: &Path) -> Result<()> {
+    let mut m = manifest::load(tome_home).with_context(|| {
         "cannot repair: manifest is unreadable. Back up .tome-manifest.json and run sync --force"
     })?;
     let mut fixed = 0;
@@ -396,7 +396,7 @@ fn repair_library(library_dir: &Path) -> Result<()> {
     }
 
     if fixed > 0 {
-        manifest::save(&m, library_dir)?;
+        manifest::save(&m, tome_home)?;
     }
 
     Ok(())
@@ -419,7 +419,8 @@ mod tests {
             ..Config::default()
         };
 
-        let report = check(&config).unwrap();
+        let tmp = TempDir::new().unwrap();
+        let report = check(&config, tmp.path()).unwrap();
         assert!(!report.configured);
         assert_eq!(report.total_issues(), 0);
     }
@@ -448,7 +449,7 @@ mod tests {
             ..Config::default()
         };
 
-        let report = check(&config).unwrap();
+        let report = check(&config, lib.path()).unwrap();
         assert!(report.configured);
         assert_eq!(report.total_issues(), 0);
     }
@@ -463,7 +464,7 @@ mod tests {
             ..Config::default()
         };
 
-        let report = check(&config).unwrap();
+        let report = check(&config, lib.path()).unwrap();
         assert_eq!(report.library_issues.len(), 1);
         assert_eq!(report.library_issues[0].severity, IssueSeverity::Warning);
         assert!(report.library_issues[0].message.contains("orphan"));
@@ -483,7 +484,7 @@ mod tests {
             ..Config::default()
         };
 
-        let report = check(&config).unwrap();
+        let report = check(&config, lib.path()).unwrap();
         assert_eq!(report.config_issues.len(), 1);
         assert!(report.config_issues[0].message.contains("gone"));
     }
@@ -492,7 +493,8 @@ mod tests {
 
     #[test]
     fn check_library_missing_dir() {
-        let result = check_library(Path::new("/nonexistent/library")).unwrap();
+        let tmp = TempDir::new().unwrap();
+        let result = check_library(Path::new("/nonexistent/library"), tmp.path()).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].severity, IssueSeverity::Warning);
     }
@@ -516,7 +518,7 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        let result = check_library(lib.path()).unwrap();
+        let result = check_library(lib.path(), lib.path()).unwrap();
         assert!(result.is_empty());
     }
 
@@ -537,7 +539,7 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        let result = check_library(lib.path()).unwrap();
+        let result = check_library(lib.path(), lib.path()).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].severity, IssueSeverity::Error);
     }
@@ -547,7 +549,7 @@ mod tests {
         let lib = TempDir::new().unwrap();
         std::fs::create_dir_all(lib.path().join("orphan")).unwrap();
 
-        let result = check_library(lib.path()).unwrap();
+        let result = check_library(lib.path(), lib.path()).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].severity, IssueSeverity::Warning);
     }
@@ -557,7 +559,7 @@ mod tests {
         let lib = TempDir::new().unwrap();
         unix_fs::symlink("/nonexistent/target", lib.path().join("broken")).unwrap();
 
-        let result = check_library(lib.path()).unwrap();
+        let result = check_library(lib.path(), lib.path()).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].severity, IssueSeverity::Error);
     }
@@ -637,7 +639,8 @@ mod tests {
             ..Config::default()
         };
 
-        let result = diagnose(&config, true);
+        let tmp = TempDir::new().unwrap();
+        let result = diagnose(&config, tmp.path(), true);
         assert!(result.is_ok());
     }
 
@@ -661,7 +664,7 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        repair_library(lib.path()).unwrap();
+        repair_library(lib.path(), lib.path()).unwrap();
 
         let after = manifest::load(lib.path()).unwrap();
         assert!(
@@ -689,7 +692,7 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        repair_library(lib.path()).unwrap();
+        repair_library(lib.path(), lib.path()).unwrap();
 
         assert!(
             !lib.path().join("broken-plugin").exists(),
@@ -706,7 +709,7 @@ mod tests {
         // Broken legacy symlink (not in manifest)
         unix_fs::symlink("/nonexistent/v01/skill", lib.path().join("legacy")).unwrap();
 
-        repair_library(lib.path()).unwrap();
+        repair_library(lib.path(), lib.path()).unwrap();
 
         assert!(
             !lib.path().join("legacy").exists(),
@@ -733,7 +736,7 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        repair_library(lib.path()).unwrap();
+        repair_library(lib.path(), lib.path()).unwrap();
 
         let after = manifest::load(lib.path()).unwrap();
         assert!(after.contains_key("healthy-skill"));

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -80,6 +80,20 @@ fn resolve_machine_path(machine_override: Option<&Path>) -> Result<std::path::Pa
     }
 }
 
+/// Derive the tome home directory from the config file path.
+///
+/// If an explicit `--config` path is given, tome home is its parent directory.
+/// Otherwise, use the default `~/.tome/`.
+fn resolve_tome_home(cli_config: Option<&Path>) -> Result<std::path::PathBuf> {
+    match cli_config {
+        Some(p) => Ok(p
+            .parent()
+            .context("config path has no parent directory")?
+            .to_path_buf()),
+        None => config::default_tome_home(),
+    }
+}
+
 /// Run the CLI with parsed arguments.
 pub fn run(cli: Cli) -> Result<()> {
     if matches!(cli.command, Command::Init) {
@@ -89,11 +103,13 @@ pub fn run(cli: Cli) -> Result<()> {
                 e
             );
         }
+        let tome_home = resolve_tome_home(cli.config.as_deref())?;
         let config = wizard::run(cli.dry_run)?;
         config.validate()?;
         if !cli.dry_run {
             sync(
                 &config,
+                &tome_home,
                 cli.dry_run,
                 false,
                 cli.verbose,
@@ -106,11 +122,13 @@ pub fn run(cli: Cli) -> Result<()> {
 
     let config = Config::load_or_default(cli.config.as_deref())?;
     config.validate()?;
+    let tome_home = resolve_tome_home(cli.config.as_deref())?;
 
     match cli.command {
         Command::Init => unreachable!(),
         Command::Sync { force } => sync(
             &config,
+            &tome_home,
             cli.dry_run,
             force,
             cli.verbose,
@@ -119,13 +137,14 @@ pub fn run(cli: Cli) -> Result<()> {
         )?,
         Command::Update => update_cmd(
             &config,
+            &tome_home,
             cli.dry_run,
             cli.verbose,
             cli.quiet,
             cli.machine.as_deref(),
         )?,
-        Command::Status => status::show(&config)?,
-        Command::Doctor => doctor::diagnose(&config, cli.dry_run)?,
+        Command::Status => status::show(&config, &tome_home)?,
+        Command::Doctor => doctor::diagnose(&config, &tome_home, cli.dry_run)?,
         Command::Browse => {
             let mut warnings = Vec::new();
             let skills = discover::discover_all(&config, &mut warnings)?;
@@ -150,6 +169,7 @@ pub fn run(cli: Cli) -> Result<()> {
 /// The core sync pipeline: discover → consolidate → distribute → cleanup.
 fn sync(
     config: &Config,
+    tome_home: &Path,
     dry_run: bool,
     force: bool,
     verbose: bool,
@@ -199,7 +219,7 @@ fn sync(
         eprintln!("{}", style("Consolidating to library...").dim());
     }
     let (consolidate_result, mut manifest) =
-        library::consolidate(&skills, &config.library_dir, dry_run, force)?;
+        library::consolidate(&skills, &config.library_dir, tome_home, dry_run, force)?;
     if let Some(sp) = sp {
         sp.finish_and_clear();
     }
@@ -207,13 +227,16 @@ fn sync(
     let discovered_names: HashSet<String> =
         skills.iter().map(|s| s.name.as_str().to_string()).collect();
 
-    // Load per-machine preferences (disabled skills)
+    // Load per-machine preferences (disabled skills and targets)
     let machine_path = resolve_machine_path(machine_override)?;
     let machine_prefs = machine::load(&machine_path)?;
 
     // 3. Distribute to targets
     let mut distribute_results = Vec::new();
     for (name, target) in config.targets.iter() {
+        if machine_prefs.is_target_disabled(name) {
+            continue;
+        }
         let sp = show_progress.then(|| spinner(&format!("Distributing to {}...", name)));
         if verbose {
             eprintln!("{}", style(format!("Distributing to {}...", name)).dim());
@@ -255,8 +278,8 @@ fn sync(
             cleanup_disabled_from_target(skills_dir, &config.library_dir, &machine_prefs, dry_run)?;
     }
     // Save manifest after cleanup (may have removed entries)
-    if !dry_run && config.library_dir.is_dir() {
-        manifest::save(&manifest, &config.library_dir)?;
+    if !dry_run && tome_home.is_dir() {
+        manifest::save(&manifest, tome_home)?;
     }
 
     // Generate .gitignore after cleanup so stale entries are excluded
@@ -265,9 +288,9 @@ fn sync(
     }
 
     // Generate lockfile for reproducibility
-    if !dry_run && config.library_dir.is_dir() {
+    if !dry_run && tome_home.is_dir() {
         let lf = lockfile::generate(&manifest, &skills);
-        lockfile::save(&lf, &config.library_dir)?;
+        lockfile::save(&lf, tome_home)?;
     }
 
     if let Some(sp) = sp {
@@ -301,8 +324,10 @@ fn sync(
 }
 
 /// The update command: diff-then-distribute with interactive triage.
+#[allow(clippy::too_many_arguments)]
 fn update_cmd(
     config: &Config,
+    tome_home: &Path,
     dry_run: bool,
     verbose: bool,
     quiet: bool,
@@ -322,7 +347,7 @@ fn update_cmd(
     let mut machine_prefs = machine::load(&machine_path)?;
 
     // 1. Load existing lockfile (may be committed by another machine)
-    let old_lockfile = lockfile::load(&config.library_dir)?;
+    let old_lockfile = lockfile::load(tome_home)?;
 
     // 2. Discover
     let sp = show_progress.then(|| spinner("Discovering skills..."));
@@ -353,7 +378,7 @@ fn update_cmd(
         eprintln!("{}", style("Consolidating to library...").dim());
     }
     let (consolidate_result, mut manifest) =
-        library::consolidate(&skills, &config.library_dir, dry_run, false)?;
+        library::consolidate(&skills, &config.library_dir, tome_home, dry_run, false)?;
     if let Some(sp) = sp {
         sp.finish_and_clear();
     }
@@ -393,6 +418,9 @@ fn update_cmd(
     // 5. Distribute (respects machine_prefs including just-disabled skills)
     let mut distribute_results = Vec::new();
     for (name, target) in config.targets.iter() {
+        if machine_prefs.is_target_disabled(name) {
+            continue;
+        }
         let sp = show_progress.then(|| spinner(&format!("Distributing to {}...", name)));
         if verbose {
             eprintln!("{}", style(format!("Distributing to {}...", name)).dim());
@@ -439,10 +467,12 @@ fn update_cmd(
     }
 
     // 7. Save lockfile + manifest
-    if !dry_run && config.library_dir.is_dir() {
-        manifest::save(&manifest, &config.library_dir)?;
-        library::generate_gitignore(&config.library_dir, &manifest)?;
-        lockfile::save(&new_lockfile, &config.library_dir)?;
+    if !dry_run && tome_home.is_dir() {
+        manifest::save(&manifest, tome_home)?;
+        if config.library_dir.is_dir() {
+            library::generate_gitignore(&config.library_dir, &manifest)?;
+        }
+        lockfile::save(&new_lockfile, tome_home)?;
     }
 
     let report = SyncReport {
@@ -696,12 +726,9 @@ fn offer_git_commit(
     }
 
     // Stage specific paths instead of `git add .` to avoid accidentally
-    // committing unrelated files.
-    let mut paths: Vec<String> = vec![
-        ".gitignore".into(),
-        ".tome-manifest.json".into(),
-        "tome.lock".into(),
-    ];
+    // committing unrelated files. Manifest and lockfile live at tome home
+    // (outside the library), so only stage .gitignore and skill dirs.
+    let mut paths: Vec<String> = vec![".gitignore".into()];
     for (name, entry) in manifest.iter() {
         if !entry.managed {
             paths.push(name.as_str().to_string());

--- a/crates/tome/src/library.rs
+++ b/crates/tome/src/library.rs
@@ -77,6 +77,7 @@ fn record_in_manifest(manifest: &mut Manifest, skill: &DiscoveredSkill, content_
 pub fn consolidate(
     skills: &[DiscoveredSkill],
     library_dir: &Path,
+    tome_home: &Path,
     dry_run: bool,
     force: bool,
 ) -> Result<(ConsolidateResult, Manifest)> {
@@ -85,8 +86,8 @@ pub fn consolidate(
             .with_context(|| format!("failed to create library dir {}", library_dir.display()))?;
     }
 
-    let mut manifest = if library_dir.is_dir() {
-        manifest::load(library_dir)?
+    let mut manifest = if tome_home.is_dir() {
+        manifest::load(tome_home)?
     } else {
         Manifest::default()
     };
@@ -111,8 +112,8 @@ pub fn consolidate(
         }
     }
 
-    if !dry_run && library_dir.is_dir() {
-        manifest::save(&manifest, library_dir)?;
+    if !dry_run && tome_home.is_dir() {
+        manifest::save(&manifest, tome_home)?;
     }
 
     Ok((result, manifest))
@@ -344,9 +345,7 @@ pub fn generate_gitignore(library_dir: &Path, manifest: &Manifest) -> Result<()>
         }
     }
 
-    content.push_str("# Internal\n");
-    content.push_str(".tome-manifest.tmp\n");
-    content.push_str("tome.lock.tmp\n");
+    // No internal entries — manifest and lockfile now live at tome home, not in library
 
     let gitignore_path = library_dir.join(".gitignore");
 
@@ -397,7 +396,8 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        let (result, _manifest) = consolidate(&[skill], library.path(), false, false).unwrap();
+        let (result, _manifest) =
+            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
         assert_eq!(result.created, 1);
         assert_eq!(result.unchanged, 0);
 
@@ -413,9 +413,22 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        consolidate(std::slice::from_ref(&skill), library.path(), false, false).unwrap();
-        let (result, _manifest) =
-            consolidate(std::slice::from_ref(&skill), library.path(), false, false).unwrap();
+        consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
+        let (result, _manifest) = consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.created, 0);
         assert_eq!(result.unchanged, 1);
     }
@@ -426,9 +439,22 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        consolidate(std::slice::from_ref(&skill), library.path(), false, false).unwrap();
-        let (result, _manifest) =
-            consolidate(std::slice::from_ref(&skill), library.path(), false, true).unwrap();
+        consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
+        let (result, _manifest) = consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.updated, 1, "force should recopy unchanged skill");
         assert_eq!(result.unchanged, 0);
     }
@@ -439,13 +465,26 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        consolidate(std::slice::from_ref(&skill), library.path(), false, false).unwrap();
+        consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
 
         // Modify source content
         std::fs::write(source.path().join("my-skill/SKILL.md"), "# updated").unwrap();
 
-        let (result, _manifest) =
-            consolidate(std::slice::from_ref(&skill), library.path(), false, false).unwrap();
+        let (result, _manifest) = consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.updated, 1);
 
         // Library copy should have the new content
@@ -459,7 +498,8 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        let (result, _manifest) = consolidate(&[skill], library.path(), true, false).unwrap();
+        let (result, _manifest) =
+            consolidate(&[skill], library.path(), library.path(), true, false).unwrap();
         assert_eq!(result.created, 1);
 
         // Directory should NOT exist
@@ -473,7 +513,8 @@ mod tests {
         let source = TempDir::new().unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        let (result, _manifest) = consolidate(&[skill], &nonexistent_lib, true, false).unwrap();
+        let (result, _manifest) =
+            consolidate(&[skill], &nonexistent_lib, &nonexistent_lib, true, false).unwrap();
         assert_eq!(result.created, 1);
         assert!(!nonexistent_lib.exists());
     }
@@ -490,7 +531,8 @@ mod tests {
         std::fs::create_dir_all(&collision).unwrap();
         std::fs::write(collision.join("README.md"), "user-created").unwrap();
 
-        let (result, _manifest) = consolidate(&[skill], library.path(), false, false).unwrap();
+        let (result, _manifest) =
+            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
         assert_eq!(result.created, 0);
         assert_eq!(result.unchanged, 0);
         assert_eq!(result.skipped, 1);
@@ -514,7 +556,8 @@ mod tests {
         unix_fs::symlink(&skill.path, library.path().join("my-skill")).unwrap();
         assert!(library.path().join("my-skill").is_symlink());
 
-        let (result, _manifest) = consolidate(&[skill], library.path(), false, false).unwrap();
+        let (result, _manifest) =
+            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
         assert_eq!(result.updated, 1, "symlink should be migrated");
 
         // Should now be a real directory, not a symlink
@@ -535,7 +578,7 @@ mod tests {
         let library = TempDir::new().unwrap();
 
         let skill1 = make_skill(source1.path(), "my-skill");
-        consolidate(&[skill1], library.path(), false, false).unwrap();
+        consolidate(&[skill1], library.path(), library.path(), false, false).unwrap();
 
         // New skill from a different source with different content
         let skill2_dir = source2.path().join("my-skill");
@@ -549,8 +592,14 @@ mod tests {
             provenance: None,
         };
 
-        let (result, _manifest) =
-            consolidate(std::slice::from_ref(&skill2), library.path(), false, false).unwrap();
+        let (result, _manifest) = consolidate(
+            std::slice::from_ref(&skill2),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.updated, 1);
 
         let content = std::fs::read_to_string(library.path().join("my-skill/SKILL.md")).unwrap();
@@ -563,7 +612,8 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        let (_, manifest) = consolidate(&[skill], library.path(), false, false).unwrap();
+        let (_, manifest) =
+            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
 
         assert_eq!(manifest.len(), 1);
         assert!(manifest.contains_key("my-skill"));
@@ -586,7 +636,8 @@ mod tests {
         )
         .unwrap();
 
-        let (result, _manifest) = consolidate(&[skill], library.path(), false, false).unwrap();
+        let (result, _manifest) =
+            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
         assert_eq!(result.updated, 1);
 
         let dest = library.path().join("my-skill");
@@ -614,7 +665,8 @@ mod tests {
             provenance: None,
         };
 
-        let (result, _) = consolidate(&[skill], library.path(), false, false).unwrap();
+        let (result, _) =
+            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
         assert_eq!(result.created, 1);
         assert!(
             library
@@ -635,7 +687,8 @@ mod tests {
         std::fs::create_dir_all(library.path()).unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        let (result, _) = consolidate(&[skill], library.path(), true, false).unwrap();
+        let (result, _) =
+            consolidate(&[skill], library.path(), library.path(), true, false).unwrap();
         assert_eq!(result.created, 1);
         assert!(
             !library.path().join(".tome-manifest.json").exists(),
@@ -651,12 +704,18 @@ mod tests {
 
         // First: consolidate as local (creates real copy + manifest entry)
         let local_skill = make_skill(source.path(), "my-skill");
-        consolidate(&[local_skill], library.path(), false, false).unwrap();
+        consolidate(&[local_skill], library.path(), library.path(), false, false).unwrap();
 
         // Now: dry-run consolidate the same skill as managed
         let managed_skill = make_managed_skill(source.path(), "my-skill");
-        let (result, manifest) =
-            consolidate(&[managed_skill], library.path(), true, false).unwrap();
+        let (result, manifest) = consolidate(
+            &[managed_skill],
+            library.path(),
+            library.path(),
+            true,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.updated, 1);
 
         // In-memory manifest should reflect managed=true even though no disk changes
@@ -681,8 +740,14 @@ mod tests {
 
         unix_fs::symlink(&skill.path, library.path().join("my-skill")).unwrap();
 
-        let (_, manifest) =
-            consolidate(std::slice::from_ref(&skill), library.path(), false, false).unwrap();
+        let (_, manifest) = consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
         let entry = manifest
             .get("my-skill")
             .expect("manifest should have entry");
@@ -700,7 +765,8 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_managed_skill(source.path(), "plugin-skill");
 
-        let (result, manifest) = consolidate(&[skill], library.path(), false, false).unwrap();
+        let (result, manifest) =
+            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
         assert_eq!(result.created, 1);
 
         let dest = library.path().join("plugin-skill");
@@ -717,9 +783,22 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_managed_skill(source.path(), "plugin-skill");
 
-        consolidate(std::slice::from_ref(&skill), library.path(), false, false).unwrap();
-        let (result, _) =
-            consolidate(std::slice::from_ref(&skill), library.path(), false, false).unwrap();
+        consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
+        let (result, _) = consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.unchanged, 1);
         assert_eq!(result.created, 0);
         assert_eq!(result.updated, 0);
@@ -732,12 +811,18 @@ mod tests {
         let library = TempDir::new().unwrap();
 
         let skill1 = make_managed_skill(source1.path(), "plugin-skill");
-        consolidate(&[skill1], library.path(), false, false).unwrap();
+        consolidate(&[skill1], library.path(), library.path(), false, false).unwrap();
 
         // Same skill name from different path
         let skill2 = make_managed_skill(source2.path(), "plugin-skill");
-        let (result, _) =
-            consolidate(std::slice::from_ref(&skill2), library.path(), false, false).unwrap();
+        let (result, _) = consolidate(
+            std::slice::from_ref(&skill2),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.updated, 1);
 
         // Should point to the new path
@@ -754,15 +839,21 @@ mod tests {
 
         // First: consolidate as local (copy)
         let local_skill = make_skill(source.path(), "my-skill");
-        consolidate(&[local_skill], library.path(), false, false).unwrap();
+        consolidate(&[local_skill], library.path(), library.path(), false, false).unwrap();
         let dest = library.path().join("my-skill");
         assert!(dest.is_dir());
         assert!(!dest.is_symlink(), "should be a real dir initially");
 
         // Now: same skill but managed
         let managed_skill = make_managed_skill(source.path(), "my-skill");
-        let (result, manifest) =
-            consolidate(&[managed_skill], library.path(), false, false).unwrap();
+        let (result, manifest) = consolidate(
+            &[managed_skill],
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.updated, 1);
         assert!(dest.is_symlink(), "should now be a symlink");
         assert!(manifest.get("my-skill").unwrap().managed);
@@ -775,13 +866,21 @@ mod tests {
 
         // First: consolidate as managed (symlink)
         let managed_skill = make_managed_skill(source.path(), "my-skill");
-        consolidate(&[managed_skill], library.path(), false, false).unwrap();
+        consolidate(
+            &[managed_skill],
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
         let dest = library.path().join("my-skill");
         assert!(dest.is_symlink(), "should be a symlink initially");
 
         // Now: same skill but local
         let local_skill = make_skill(source.path(), "my-skill");
-        let (result, manifest) = consolidate(&[local_skill], library.path(), false, false).unwrap();
+        let (result, manifest) =
+            consolidate(&[local_skill], library.path(), library.path(), false, false).unwrap();
         assert_eq!(result.updated, 1);
         assert!(dest.is_dir());
         assert!(!dest.is_symlink(), "should now be a real directory");
@@ -794,7 +893,8 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_managed_skill(source.path(), "plugin-skill");
 
-        let (_, manifest) = consolidate(&[skill], library.path(), false, false).unwrap();
+        let (_, manifest) =
+            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
         let entry = manifest.get("plugin-skill").unwrap();
         assert!(entry.managed);
         assert!(!entry.content_hash.is_empty());
@@ -810,7 +910,14 @@ mod tests {
         let managed = make_managed_skill(source.path(), "plugin-a");
         let local = make_skill(source.path(), "user-skill");
 
-        let (_, manifest) = consolidate(&[managed, local], library.path(), false, false).unwrap();
+        let (_, manifest) = consolidate(
+            &[managed, local],
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
         generate_gitignore(library.path(), &manifest).unwrap();
 
         let content = std::fs::read_to_string(library.path().join(".gitignore")).unwrap();
@@ -828,7 +935,14 @@ mod tests {
         let managed = make_managed_skill(source.path(), "plugin-a");
         let local = make_skill(source.path(), "user-skill");
 
-        let (_, manifest) = consolidate(&[managed, local], library.path(), false, false).unwrap();
+        let (_, manifest) = consolidate(
+            &[managed, local],
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
         generate_gitignore(library.path(), &manifest).unwrap();
 
         let content = std::fs::read_to_string(library.path().join(".gitignore")).unwrap();
@@ -844,7 +958,8 @@ mod tests {
         let source = TempDir::new().unwrap();
 
         let managed = make_managed_skill(source.path(), "plugin-a");
-        let (_, manifest) = consolidate(&[managed], library.path(), false, false).unwrap();
+        let (_, manifest) =
+            consolidate(&[managed], library.path(), library.path(), false, false).unwrap();
 
         generate_gitignore(library.path(), &manifest).unwrap();
         let first = std::fs::read_to_string(library.path().join(".gitignore")).unwrap();
@@ -864,7 +979,8 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_managed_skill(source.path(), "plugin-skill");
 
-        let (result, manifest) = consolidate(&[skill], library.path(), true, false).unwrap();
+        let (result, manifest) =
+            consolidate(&[skill], library.path(), library.path(), true, false).unwrap();
         assert_eq!(result.created, 1);
 
         // Symlink should NOT exist on disk
@@ -883,9 +999,22 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_managed_skill(source.path(), "plugin-skill");
 
-        consolidate(std::slice::from_ref(&skill), library.path(), false, false).unwrap();
-        let (result, _) =
-            consolidate(std::slice::from_ref(&skill), library.path(), false, true).unwrap();
+        consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
+        let (result, _) = consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.updated, 1, "force should recreate managed symlink");
         assert_eq!(result.unchanged, 0);
 
@@ -900,7 +1029,14 @@ mod tests {
         let skill = make_managed_skill(source.path(), "plugin-skill");
 
         // First: consolidate normally (creates symlink)
-        consolidate(std::slice::from_ref(&skill), library.path(), false, false).unwrap();
+        consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
         let dest = library.path().join("plugin-skill");
         assert!(dest.is_symlink(), "should be a symlink initially");
 
@@ -914,8 +1050,14 @@ mod tests {
         );
 
         // Re-consolidate — should repair by replacing dir with symlink
-        let (result, _) =
-            consolidate(std::slice::from_ref(&skill), library.path(), false, false).unwrap();
+        let (result, _) = consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.updated, 1, "should repair stale directory");
         assert_eq!(result.unchanged, 0);
         assert!(dest.is_symlink(), "should be a symlink again after repair");
@@ -933,7 +1075,8 @@ mod tests {
         std::fs::create_dir_all(&collision).unwrap();
         std::fs::write(collision.join("README.md"), "user-created").unwrap();
 
-        let (result, _) = consolidate(&[skill], library.path(), false, false).unwrap();
+        let (result, _) =
+            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
         assert_eq!(result.skipped, 1);
         assert_eq!(result.created, 0);
 
@@ -949,15 +1092,27 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        let (_, manifest1) =
-            consolidate(std::slice::from_ref(&skill), library.path(), false, false).unwrap();
+        let (_, manifest1) = consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
         let hash1 = manifest1.get("my-skill").unwrap().content_hash.clone();
 
         // Modify source content
         std::fs::write(source.path().join("my-skill/SKILL.md"), "# updated").unwrap();
 
-        let (result, manifest2) =
-            consolidate(std::slice::from_ref(&skill), library.path(), false, false).unwrap();
+        let (result, manifest2) = consolidate(
+            std::slice::from_ref(&skill),
+            library.path(),
+            library.path(),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.updated, 1);
 
         let entry = manifest2.get("my-skill").expect("should have entry");
@@ -970,7 +1125,7 @@ mod tests {
     }
 
     #[test]
-    fn gitignore_always_ignores_tmp_files() {
+    fn gitignore_empty_manifest_no_tmp_entries() {
         let library = TempDir::new().unwrap();
         std::fs::create_dir_all(library.path()).unwrap();
 
@@ -979,10 +1134,13 @@ mod tests {
         generate_gitignore(library.path(), &manifest).unwrap();
 
         let content = std::fs::read_to_string(library.path().join(".gitignore")).unwrap();
-        assert!(content.contains(".tome-manifest.tmp"));
         assert!(
-            content.contains("tome.lock.tmp"),
-            "gitignore should include lockfile tmp"
+            !content.contains(".tome-manifest.tmp"),
+            "manifest tmp files now live at tome home, not in library"
+        );
+        assert!(
+            !content.contains("tome.lock.tmp"),
+            "lockfile tmp files now live at tome home, not in library"
         );
     }
 }

--- a/crates/tome/src/lockfile.rs
+++ b/crates/tome/src/lockfile.rs
@@ -80,11 +80,11 @@ pub fn generate(manifest: &Manifest, skills: &[DiscoveredSkill]) -> Lockfile {
     }
 }
 
-/// Load an existing lockfile from the library directory.
+/// Load an existing lockfile from the tome home directory.
 ///
 /// Returns `None` if the file doesn't exist (first run). Errors on corrupt JSON.
-pub fn load(library_dir: &Path) -> Result<Option<Lockfile>> {
-    let path = library_dir.join(LOCKFILE_NAME);
+pub fn load(tome_home: &Path) -> Result<Option<Lockfile>> {
+    let path = tome_home.join(LOCKFILE_NAME);
     if !path.exists() {
         return Ok(None);
     }
@@ -95,10 +95,10 @@ pub fn load(library_dir: &Path) -> Result<Option<Lockfile>> {
     Ok(Some(lockfile))
 }
 
-/// Write the lockfile to the library directory using atomic temp+rename.
-pub fn save(lockfile: &Lockfile, library_dir: &Path) -> Result<()> {
-    let path = library_dir.join(LOCKFILE_NAME);
-    let tmp_path = library_dir.join("tome.lock.tmp");
+/// Write the lockfile to the tome home directory using atomic temp+rename.
+pub fn save(lockfile: &Lockfile, tome_home: &Path) -> Result<()> {
+    let path = tome_home.join(LOCKFILE_NAME);
+    let tmp_path = tome_home.join("tome.lock.tmp");
     let content = serde_json::to_string_pretty(lockfile).context("failed to serialize lockfile")?;
     // Add trailing newline for POSIX compliance
     let content = format!("{content}\n");

--- a/crates/tome/src/machine.rs
+++ b/crates/tome/src/machine.rs
@@ -12,12 +12,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::discover::SkillName;
 
-/// Per-machine preferences — currently just a set of disabled skill names.
+/// Per-machine preferences — disabled skills and targets for this machine.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MachinePrefs {
     /// Skills that should not be distributed to targets on this machine.
     #[serde(default)]
     pub disabled: BTreeSet<SkillName>,
+
+    /// Targets to skip on this machine (e.g. machine A doesn't have a certain tool installed).
+    #[serde(default)]
+    pub disabled_targets: BTreeSet<String>,
 }
 
 impl MachinePrefs {
@@ -29,6 +33,11 @@ impl MachinePrefs {
     /// Mark a skill as disabled on this machine.
     pub fn disable(&mut self, name: SkillName) {
         self.disabled.insert(name);
+    }
+
+    /// Returns true if the given target is disabled on this machine.
+    pub fn is_target_disabled(&self, name: &str) -> bool {
+        self.disabled_targets.contains(name)
     }
 }
 
@@ -159,5 +168,65 @@ mod tests {
         let prefs = MachinePrefs::default();
         save(&prefs, &path).unwrap();
         assert!(path.exists());
+    }
+
+    #[test]
+    fn is_target_disabled_checks_set() {
+        let mut prefs = MachinePrefs::default();
+        prefs.disabled_targets.insert("claude".to_string());
+        prefs.disabled_targets.insert("codex".to_string());
+
+        assert!(prefs.is_target_disabled("claude"));
+        assert!(prefs.is_target_disabled("codex"));
+        assert!(!prefs.is_target_disabled("cursor"));
+        assert!(!prefs.is_target_disabled(""));
+    }
+
+    #[test]
+    fn disabled_targets_roundtrip() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("machine.toml");
+
+        let mut prefs = MachinePrefs::default();
+        prefs.disable(SkillName::new("skill-a").unwrap());
+        prefs.disabled_targets.insert("claude".to_string());
+        prefs.disabled_targets.insert("codex".to_string());
+
+        save(&prefs, &path).unwrap();
+        let loaded = load(&path).unwrap();
+
+        assert_eq!(loaded.disabled_targets.len(), 2);
+        assert!(loaded.is_target_disabled("claude"));
+        assert!(loaded.is_target_disabled("codex"));
+        // Verify skills survived too
+        assert!(loaded.is_disabled("skill-a"));
+    }
+
+    #[test]
+    fn disabled_targets_defaults_empty() {
+        // TOML with only the disabled field — disabled_targets should default to empty
+        let toml_str = "disabled = [\"some-skill\"]\n";
+        let prefs: MachinePrefs = toml::from_str(toml_str).unwrap();
+
+        assert!(prefs.disabled_targets.is_empty());
+        assert!(!prefs.is_target_disabled("anything"));
+        assert!(prefs.is_disabled("some-skill"));
+    }
+
+    #[test]
+    fn disabled_targets_toml_format() {
+        let mut prefs = MachinePrefs::default();
+        prefs.disabled_targets.insert("claude".to_string());
+        prefs.disabled_targets.insert("windsurf".to_string());
+
+        let toml_str = toml::to_string_pretty(&prefs).unwrap();
+        assert!(toml_str.contains("disabled_targets"));
+        assert!(toml_str.contains("claude"));
+        assert!(toml_str.contains("windsurf"));
+
+        // Should be parseable back
+        let parsed: MachinePrefs = toml::from_str(&toml_str).unwrap();
+        assert!(parsed.is_target_disabled("claude"));
+        assert!(parsed.is_target_disabled("windsurf"));
     }
 }

--- a/crates/tome/src/manifest.rs
+++ b/crates/tome/src/manifest.rs
@@ -101,9 +101,9 @@ impl SkillEntry {
     }
 }
 
-/// Load the manifest from the library directory, or return an empty one if missing.
-pub fn load(library_dir: &Path) -> Result<Manifest> {
-    let path = library_dir.join(MANIFEST_FILENAME);
+/// Load the manifest from the tome home directory, or return an empty one if missing.
+pub fn load(tome_home: &Path) -> Result<Manifest> {
+    let path = tome_home.join(MANIFEST_FILENAME);
     if !path.exists() {
         return Ok(Manifest::default());
     }
@@ -114,14 +114,14 @@ pub fn load(library_dir: &Path) -> Result<Manifest> {
     Ok(manifest)
 }
 
-/// Save the manifest to the library directory.
+/// Save the manifest to the tome home directory.
 ///
 /// Uses a write-to-temp-then-rename pattern so the manifest file is never left in a partially
 /// written (corrupted) state if the process is killed mid-write. `rename` is atomic on POSIX
 /// filesystems when source and destination are on the same filesystem.
-pub fn save(manifest: &Manifest, library_dir: &Path) -> Result<()> {
-    let path = library_dir.join(MANIFEST_FILENAME);
-    let tmp_path = library_dir.join(".tome-manifest.tmp");
+pub fn save(manifest: &Manifest, tome_home: &Path) -> Result<()> {
+    let path = tome_home.join(MANIFEST_FILENAME);
+    let tmp_path = tome_home.join(".tome-manifest.tmp");
     let content = serde_json::to_string_pretty(manifest).context("failed to serialize manifest")?;
     std::fs::write(&tmp_path, &content)
         .with_context(|| format!("failed to write temporary manifest {}", tmp_path.display()))?;

--- a/crates/tome/src/status.rs
+++ b/crates/tome/src/status.rs
@@ -42,7 +42,7 @@ pub struct StatusReport {
 // -- Data gathering (pure computation, no I/O) --
 
 /// Gather status data without producing any output.
-pub fn gather(config: &Config) -> Result<StatusReport> {
+pub fn gather(config: &Config, tome_home: &Path) -> Result<StatusReport> {
     let configured = config.library_dir.is_dir() || !config.sources.is_empty();
 
     let library_count = if config.library_dir.is_dir() {
@@ -83,7 +83,7 @@ pub fn gather(config: &Config) -> Result<StatusReport> {
         .collect();
 
     let health = if config.library_dir.is_dir() {
-        count_health_issues(&config.library_dir).map_err(|e| e.to_string())
+        count_health_issues(&config.library_dir, tome_home).map_err(|e| e.to_string())
     } else {
         Ok(0)
     };
@@ -101,8 +101,8 @@ pub fn gather(config: &Config) -> Result<StatusReport> {
 // -- Rendering --
 
 /// Display the current status of the tome system.
-pub fn show(config: &Config) -> Result<()> {
-    let report = gather(config)?;
+pub fn show(config: &Config, tome_home: &Path) -> Result<()> {
+    let report = gather(config, tome_home)?;
     render_status(&report);
     Ok(())
 }
@@ -235,8 +235,8 @@ fn count_entries(dir: &Path) -> Result<usize> {
 }
 
 /// Count health issues: manifest/disk mismatches.
-fn count_health_issues(dir: &Path) -> Result<usize> {
-    let m = manifest::load(dir)?;
+fn count_health_issues(dir: &Path, tome_home: &Path) -> Result<usize> {
+    let m = manifest::load(tome_home)?;
     let mut issues = 0;
 
     // Check manifest entries exist on disk
@@ -280,7 +280,7 @@ mod tests {
             ..Config::default()
         };
 
-        let report = gather(&config).unwrap();
+        let report = gather(&config, config.library_dir.as_path()).unwrap();
         assert!(!report.configured);
         assert!(report.sources.is_empty());
         assert!(report.targets.is_empty());
@@ -300,7 +300,7 @@ mod tests {
             ..Config::default()
         };
 
-        let report = gather(&config).unwrap();
+        let report = gather(&config, config.library_dir.as_path()).unwrap();
         assert!(report.configured);
         assert_eq!(report.sources.len(), 1);
         assert_eq!(report.sources[0].name, "test");
@@ -319,7 +319,7 @@ mod tests {
             ..Config::default()
         };
 
-        let report = gather(&config).unwrap();
+        let report = gather(&config, config.library_dir.as_path()).unwrap();
         assert!(report.configured);
         assert_eq!(report.library_count.unwrap(), 2);
     }
@@ -346,7 +346,7 @@ mod tests {
             ..Config::default()
         };
 
-        let report = gather(&config).unwrap();
+        let report = gather(&config, config.library_dir.as_path()).unwrap();
         assert_eq!(report.targets.len(), 1);
         assert_eq!(report.targets[0].name, "claude");
         assert!(report.targets[0].enabled);
@@ -363,7 +363,7 @@ mod tests {
             ..Config::default()
         };
 
-        let report = gather(&config).unwrap();
+        let report = gather(&config, config.library_dir.as_path()).unwrap();
         assert_eq!(report.health.unwrap(), 1);
     }
 
@@ -376,7 +376,7 @@ mod tests {
             ..Config::default()
         };
 
-        let result = show(&config);
+        let result = show(&config, config.library_dir.as_path());
         assert!(result.is_ok());
     }
 
@@ -394,7 +394,7 @@ mod tests {
             ..Config::default()
         };
 
-        let result = show(&config);
+        let result = show(&config, config.library_dir.as_path());
         assert!(result.is_ok());
     }
 
@@ -436,7 +436,7 @@ mod tests {
             ..Config::default()
         };
 
-        let result = show(&config);
+        let result = show(&config, config.library_dir.as_path());
         assert!(result.is_ok());
     }
 
@@ -488,7 +488,7 @@ mod tests {
     #[test]
     fn count_health_issues_empty_dir() {
         let dir = tempfile::TempDir::new().unwrap();
-        assert_eq!(count_health_issues(dir.path()).unwrap(), 0);
+        assert_eq!(count_health_issues(dir.path(), dir.path()).unwrap(), 0);
     }
 
     #[test]
@@ -509,7 +509,7 @@ mod tests {
         );
         manifest::save(&m, dir.path()).unwrap();
 
-        assert_eq!(count_health_issues(dir.path()).unwrap(), 1);
+        assert_eq!(count_health_issues(dir.path(), dir.path()).unwrap(), 1);
     }
 
     #[test]
@@ -519,7 +519,7 @@ mod tests {
         // Create a directory not tracked by manifest
         std::fs::create_dir_all(dir.path().join("orphan-skill")).unwrap();
 
-        assert_eq!(count_health_issues(dir.path()).unwrap(), 1);
+        assert_eq!(count_health_issues(dir.path(), dir.path()).unwrap(), 1);
     }
 
     #[test]
@@ -546,7 +546,7 @@ mod tests {
         unix_fs::symlink("/nonexistent/source", dir.path().join("managed-skill")).unwrap();
 
         // Should count exactly 1 issue (manifest-vs-disk), not 2
-        assert_eq!(count_health_issues(dir.path()).unwrap(), 1);
+        assert_eq!(count_health_issues(dir.path(), dir.path()).unwrap(), 1);
     }
 
     #[test]
@@ -556,6 +556,6 @@ mod tests {
         // .git dir should not be counted as an orphan
         std::fs::create_dir_all(dir.path().join(".git")).unwrap();
 
-        assert_eq!(count_health_issues(dir.path()).unwrap(), 0);
+        assert_eq!(count_health_issues(dir.path(), dir.path()).unwrap(), 0);
     }
 }

--- a/crates/tome/src/wizard.rs
+++ b/crates/tome/src/wizard.rs
@@ -236,7 +236,7 @@ fn configure_library() -> Result<PathBuf> {
 
     let default = dirs::home_dir()
         .context("could not determine home directory")?
-        .join(".local/share/tome/skills");
+        .join(".tome/skills");
 
     let options = vec![
         format!("{} (default)", default.display()),

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -177,8 +177,8 @@ fn sync_copies_skills_to_library() {
     assert!(!library.join("beta").is_symlink());
     // Content should be copied
     assert!(library.join("alpha/SKILL.md").is_file());
-    // Manifest should exist
-    assert!(library.join(".tome-manifest.json").is_file());
+    // Manifest should exist at tome home (config file's parent dir)
+    assert!(tmp.path().join(".tome-manifest.json").is_file());
 }
 
 #[test]
@@ -231,7 +231,8 @@ fn sync_creates_lockfile() {
         .assert()
         .success();
 
-    let lockfile_path = tmp.path().join("library/tome.lock");
+    // Lockfile now lives at tome home (config file's parent dir), not library
+    let lockfile_path = tmp.path().join("tome.lock");
     assert!(
         lockfile_path.exists(),
         "tome.lock should be created by sync"
@@ -272,7 +273,7 @@ fn sync_dry_run_does_not_create_lockfile() {
         .success();
 
     assert!(
-        !tmp.path().join("library/tome.lock").exists(),
+        !tmp.path().join("tome.lock").exists(),
         "dry-run should not create tome.lock"
     );
 }
@@ -303,7 +304,7 @@ fn config_path_prints_default_path() {
         .args(["config", "--path"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("config.toml"));
+        .stdout(predicate::str::contains("tome.toml"));
 }
 
 // -- Sync with targets --
@@ -921,8 +922,8 @@ fn update_with_no_lockfile_works_gracefully() {
     assert!(tmp.path().join("library/my-skill").is_dir());
     // Target should have symlink
     assert!(target_dir.join("my-skill").is_symlink());
-    // Lockfile should be created
-    assert!(tmp.path().join("library/tome.lock").exists());
+    // Lockfile should be created at tome home (config file's parent dir)
+    assert!(tmp.path().join("tome.lock").exists());
 }
 
 #[test]

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -21,12 +21,12 @@ The core flow that `tome sync` and `tome init` both invoke (`lib.rs::sync`):
 ### Other Modules
 
 - `wizard.rs` — Interactive `tome init` setup using `dialoguer` (MultiSelect, Input, Confirm, Select). Auto-discovers known source locations (`~/.claude/plugins/cache`, `~/.claude/skills`, `~/.codex/skills`, `~/.gemini/antigravity/skills`).
-- `config.rs` — TOML config at `~/.config/tome/config.toml`. `Config::load_or_default` handles missing files gracefully. All path fields support `~` expansion.
+- `config.rs` — TOML config at `~/.tome/tome.toml`. `Config::load_or_default` handles missing files gracefully. All path fields support `~` expansion.
 - `doctor.rs` — Diagnoses library issues (orphan directories, missing manifest entries, broken legacy symlinks) and missing source paths; optionally repairs.
 - `status.rs` — Read-only summary of library, sources, targets, and health. Single-pass directory scan for efficiency.
 - `manifest.rs` — Library manifest (`.tome-manifest.json`): tracks provenance, content hashes, and sync timestamps for each skill. Provides `hash_directory()` for deterministic SHA-256 of directory contents.
 - `lockfile.rs` — Generates and loads `tome.lock` files. Each entry records skill name, content hash, source, and provenance metadata. Uses atomic temp+rename writes to prevent corruption.
-- `machine.rs` — Per-machine preferences (`~/.config/tome/machine.toml`). Tracks a `disabled` set of skill names. Uses atomic temp+rename writes. Loaded during sync to filter skills.
+- `machine.rs` — Per-machine preferences (`~/.config/tome/machine.toml`). Tracks a `disabled` set of skill names and a `disabled_targets` set of target names. Uses atomic temp+rename writes. Loaded during sync to filter skills.
 - `update.rs` — Implements `tome update`: loads the previous lockfile, diffs against current state, presents added/changed/removed skills interactively, and offers to disable unwanted new skills.
 - `paths.rs` — Symlink path utilities: resolves relative symlink targets to absolute paths and checks whether a symlink points to a given destination.
 

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -14,7 +14,7 @@
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--config <path>` | | Path to config file (default: `~/.config/tome/config.toml`) |
+| `--config <path>` | | Path to config file (default: `~/.tome/tome.toml`) |
 | `--machine <path>` | | Path to machine preferences file (default: `~/.config/tome/machine.toml`) |
 | `--dry-run` | | Preview changes without modifying filesystem |
 | `--verbose` | `-v` | Detailed output |

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -2,10 +2,10 @@
 
 ## Main Config
 
-TOML at `~/.config/tome/config.toml`:
+TOML at `~/.tome/tome.toml`:
 
 ```toml
-library_dir = "~/.local/share/tome/skills"
+library_dir = "~/.tome/skills"
 exclude = ["deprecated-skill"]
 
 [[sources]]
@@ -52,9 +52,15 @@ Per-machine opt-in/opt-out at `~/.config/tome/machine.toml`:
 
 ```toml
 disabled = ["noisy-skill", "work-only-skill"]
+disabled_targets = ["openclaw"]
 ```
 
-Disabled skills remain in the library but are skipped during distribution (no symlinks created in targets).
+| Field | Description |
+|-------|-------------|
+| `disabled` | List of skill names to skip during distribution (no symlinks created in targets). |
+| `disabled_targets` | List of target names to skip entirely on this machine. |
+
+Disabled skills remain in the library but are skipped during distribution.
 
 This allows sharing a single library (e.g., via git) across machines while customizing which skills are active on each one.
 
@@ -62,7 +68,7 @@ Use `tome update` to interactively review new or changed skills and disable unwa
 
 ## Lockfile
 
-`tome sync` generates a `tome.lock` file in the library directory. This lockfile captures a reproducible snapshot of all skills — their names, content hashes, sources, and provenance metadata. It is used by `tome update` to diff against the current state and surface changes.
+`tome sync` generates a `tome.lock` file in the tome home directory (`~/.tome/tome.lock`). This lockfile captures a reproducible snapshot of all skills — their names, content hashes, sources, and provenance metadata. It is used by `tome update` to diff against the current state and surface changes.
 
 The lockfile is designed to be committed to version control alongside the library, enabling multi-machine workflows where `tome update` on a new machine can detect what changed since the last sync.
 

--- a/docs/visuals/tome-architecture.html
+++ b/docs/visuals/tome-architecture.html
@@ -634,7 +634,7 @@ flowchart TD
         C2["Skip unchanged<br>update stale links"]
     end
 
-    LIB[("Library<br>~/.local/share/tome/skills/")]
+    LIB[("Library<br>~/.tome/skills/")]
 
     subgraph DIST["Stage 3 — Distribute"]
         DI1["Symlink method:<br>link into target skills dir"]
@@ -875,7 +875,7 @@ flowchart TD
       <div class="ve-card__desc">
         With the Symlink method, each skill has a two-hop symlink chain. The original file is never moved.
         <br><br>
-        <code>~/.claude/skills/my-skill</code> → <code>~/.local/share/tome/skills/my-skill</code> → <code>/original/path/my-skill</code>
+        <code>~/.claude/skills/my-skill</code> → <code>~/.tome/skills/my-skill</code> → <code>/original/path/my-skill</code>
         <br><br>
         The library is the single source of truth for which skills are active.
         Cleanup walks each hop and removes links whose target no longer exists.
@@ -889,19 +889,22 @@ flowchart TD
 
     <div class="ve-card ve-card--elevated" style="margin-bottom: 20px;">
       <div class="fs-tree">
-        <div><span class="dir">~/.config/tome/</span></div>
-        <div class="indent"><span class="file">config.toml</span> <span class="desc">— Sources, targets, exclude list, library path</span></div>
-
-        <div class="spacer-sm"></div>
-        <div><span class="dir">~/.local/share/tome/</span></div>
+        <div><span class="dir">~/.tome/</span></div>
+        <div class="indent"><span class="file">tome.toml</span> <span class="desc">— Sources, targets, exclude list, library path</span></div>
+        <div class="indent"><span class="file">tome.lock</span> <span class="desc">— Lockfile snapshot</span></div>
+        <div class="indent"><span class="file">.tome-manifest.json</span> <span class="desc">— Live provenance registry</span></div>
         <div class="indent"><span class="dir">skills/</span> <span class="desc">— The library (central skill registry)</span></div>
         <div class="indent2"><span class="file">my-skill/</span> <span class="arrow">→</span> <span class="desc">/original/source/my-skill/</span></div>
         <div class="indent2"><span class="file">another-skill/</span> <span class="arrow">→</span> <span class="desc">/other/source/another-skill/</span></div>
 
         <div class="spacer-sm"></div>
+        <div><span class="dir">~/.config/tome/</span></div>
+        <div class="indent"><span class="file">machine.toml</span> <span class="desc">— Per-machine preferences (disabled skills/targets)</span></div>
+
+        <div class="spacer-sm"></div>
         <div><span class="dir">~/.claude/</span></div>
         <div class="indent"><span class="dir">skills/</span> <span class="desc">— Claude Code target (symlinks from library)</span></div>
-        <div class="indent2"><span class="file">my-skill/</span> <span class="arrow">→</span> <span class="desc">~/.local/share/tome/skills/my-skill/</span></div>
+        <div class="indent2"><span class="file">my-skill/</span> <span class="arrow">→</span> <span class="desc">~/.tome/skills/my-skill/</span></div>
 
         <div class="spacer-sm"></div>
         <div><span class="dir">~/.gemini/antigravity/</span></div>
@@ -921,7 +924,7 @@ flowchart TD
       <div class="ve-card accent-border-gold">
         <div class="ve-card__label ve-card__label--gold">Config</div>
         <div class="ve-card__desc">
-          <code>~/.config/tome/config.toml</code><br>
+          <code>~/.tome/tome.toml</code><br>
           Defines sources (what to scan), targets (where to push), exclude list, and library path.
           <code>Config::load_or_default</code> handles missing files gracefully.
         </div>
@@ -929,7 +932,7 @@ flowchart TD
       <div class="ve-card accent-border-teal">
         <div class="ve-card__label ve-card__label--teal">Library</div>
         <div class="ve-card__desc">
-          <code>~/.local/share/tome/skills/</code><br>
+          <code>~/.tome/skills/</code><br>
           Central registry. One symlink per active skill, pointing to the original source.
           The library is the single source of truth.
         </div>


### PR DESCRIPTION
## Summary

- Move from split XDG paths (`~/.config/tome/config.toml` + `~/.local/share/tome/skills/`) to unified `~/.tome/` directory
- Lockfile and manifest move from `library_dir` to `tome_home` (derived from config path's parent)
- Add `disabled_targets` field to `machine.toml` — mirrors existing `disabled` pattern for skills
- `machine.toml` stays at `~/.config/tome/machine.toml` (per-machine, not shared)
- Hard switch, no backward compat — users move config manually

## New layout

```
~/.tome/
├── tome.toml              # config (was ~/.config/tome/config.toml)
├── tome.lock              # lockfile (was inside skills/)
├── .tome-manifest.json    # manifest (was inside skills/)
└── skills/                # skill library (was ~/.local/share/tome/skills/)

~/.config/tome/machine.toml  # stays put
```

## Test plan

- [x] `make ci` passes (fmt, clippy, 201 unit + 31 integration tests)
- [ ] Manual: `cargo run -- config` shows `~/.tome/tome.toml` as default
- [ ] Manual: `cargo run -- status` reports correct paths
- [ ] Manual: `cargo run -- sync --dry-run` — no errors, correct library path

Closes #270