### PR TITLE
test: verify tome_home / library_dir separation

### DIFF
--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -647,6 +647,46 @@ mod tests {
     // -- repair_library --
 
     #[test]
+    fn check_library_uses_tome_home_for_manifest() {
+        let tome_home = TempDir::new().unwrap();
+        let library = TempDir::new().unwrap();
+
+        // Create a skill directory in the library
+        let skill_dir = library.path().join("my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+
+        // Save manifest at tome_home (not library_dir)
+        let mut m = manifest::Manifest::default();
+        m.insert(
+            crate::discover::SkillName::new("my-skill").unwrap(),
+            manifest::SkillEntry {
+                source_path: PathBuf::from("/tmp/source/my-skill"),
+                source_name: "test".to_string(),
+                content_hash: "abc".to_string(),
+                synced_at: "2024-01-01T00:00:00Z".to_string(),
+                managed: false,
+            },
+        );
+        manifest::save(&m, tome_home.path()).unwrap();
+
+        // check_library should read manifest from tome_home, not library_dir
+        let issues = check_library(library.path(), tome_home.path()).unwrap();
+        assert!(
+            issues.is_empty(),
+            "should find no issues when manifest is at tome_home and skill exists in library"
+        );
+
+        // Verify it would fail if we pointed tome_home at the wrong place
+        // (library_dir has no manifest, so it loads an empty one and sees an orphan)
+        let issues = check_library(library.path(), library.path()).unwrap();
+        assert_eq!(
+            issues.len(),
+            1,
+            "should detect orphan when manifest is not at the given tome_home"
+        );
+    }
+
+    #[test]
     fn repair_library_removes_orphan_manifest_entry() {
         let lib = TempDir::new().unwrap();
 

--- a/crates/tome/src/library.rs
+++ b/crates/tome/src/library.rs
@@ -1125,6 +1125,33 @@ mod tests {
     }
 
     #[test]
+    fn consolidate_manifest_lives_at_tome_home() {
+        let source = TempDir::new().unwrap();
+        let tome_home = TempDir::new().unwrap();
+        let library = TempDir::new().unwrap();
+        let skill = make_skill(source.path(), "my-skill");
+
+        let (result, _manifest) =
+            consolidate(&[skill], library.path(), tome_home.path(), false, false).unwrap();
+        assert_eq!(result.created, 1);
+
+        // Manifest should live at tome_home, not library_dir
+        assert!(
+            tome_home.path().join(".tome-manifest.json").exists(),
+            "manifest should be written to tome_home"
+        );
+        assert!(
+            !library.path().join(".tome-manifest.json").exists(),
+            "manifest should NOT be written to library_dir"
+        );
+
+        // Skills should live at library_dir
+        let dest = library.path().join("my-skill");
+        assert!(dest.is_dir(), "skill should be copied to library_dir");
+        assert!(dest.join("SKILL.md").is_file());
+    }
+
+    #[test]
     fn gitignore_empty_manifest_no_tmp_entries() {
         let library = TempDir::new().unwrap();
         std::fs::create_dir_all(library.path()).unwrap();

--- a/crates/tome/src/status.rs
+++ b/crates/tome/src/status.rs
@@ -486,6 +486,43 @@ mod tests {
     // -- count_health_issues --
 
     #[test]
+    fn count_health_issues_uses_tome_home() {
+        let tome_home = tempfile::TempDir::new().unwrap();
+        let library = tempfile::TempDir::new().unwrap();
+
+        // Create a skill directory in the library
+        std::fs::create_dir_all(library.path().join("my-skill")).unwrap();
+
+        // Save manifest at tome_home (not library_dir)
+        let mut m = manifest::Manifest::default();
+        m.insert(
+            crate::discover::SkillName::new("my-skill").unwrap(),
+            manifest::SkillEntry {
+                source_path: PathBuf::from("/tmp/source/my-skill"),
+                source_name: "test".to_string(),
+                content_hash: "abc".to_string(),
+                synced_at: "2024-01-01T00:00:00Z".to_string(),
+                managed: false,
+            },
+        );
+        manifest::save(&m, tome_home.path()).unwrap();
+
+        // Should find 0 issues when manifest is at tome_home
+        assert_eq!(
+            count_health_issues(library.path(), tome_home.path()).unwrap(),
+            0,
+            "should find no issues when manifest at tome_home matches library contents"
+        );
+
+        // Should find 1 orphan when using library_dir as tome_home (no manifest there)
+        assert_eq!(
+            count_health_issues(library.path(), library.path()).unwrap(),
+            1,
+            "should detect orphan when manifest is not at the given tome_home"
+        );
+    }
+
+    #[test]
     fn count_health_issues_empty_dir() {
         let dir = tempfile::TempDir::new().unwrap();
         assert_eq!(count_health_issues(dir.path(), dir.path()).unwrap(), 0);


### PR DESCRIPTION
## Summary
- Add test in `library.rs` verifying manifest is written to `tome_home`, not `library_dir`, and skills are copied to `library_dir`
- Add test in `doctor.rs` verifying `check_library()` reads manifest from `tome_home`, not `library_dir`
- Add test in `status.rs` verifying `count_health_issues()` reads manifest from `tome_home`, not `library_dir`

All three tests use separate `TempDir` instances for `tome_home` and `library_dir` to confirm the separation introduced in PR #271.

Closes #274