### PR TITLE
feat: warn on unknown disabled_targets in machine.toml

### DIFF
--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -231,6 +231,18 @@ fn sync(
     let machine_path = resolve_machine_path(machine_override)?;
     let machine_prefs = machine::load(&machine_path)?;
 
+    // Warn about disabled_targets that don't match any configured target
+    if !quiet {
+        for name in &machine_prefs.disabled_targets {
+            if !config.targets.contains_key(name.as_str()) {
+                eprintln!(
+                    "warning: disabled target '{}' in machine.toml does not match any configured target",
+                    name
+                );
+            }
+        }
+    }
+
     // 3. Distribute to targets
     let mut distribute_results = Vec::new();
     for (name, target) in config.targets.iter() {
@@ -345,6 +357,18 @@ fn update_cmd(
     // Load per-machine preferences
     let machine_path = resolve_machine_path(machine_override)?;
     let mut machine_prefs = machine::load(&machine_path)?;
+
+    // Warn about disabled_targets that don't match any configured target
+    if !quiet {
+        for name in &machine_prefs.disabled_targets {
+            if !config.targets.contains_key(name.as_str()) {
+                eprintln!(
+                    "warning: disabled target '{}' in machine.toml does not match any configured target",
+                    name
+                );
+            }
+        }
+    }
 
     // 1. Load existing lockfile (may be committed by another machine)
     let old_lockfile = lockfile::load(tome_home)?;

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -1122,3 +1122,55 @@ fn update_disable_removes_symlink() {
         "disabled skill's symlink should be removed by update"
     );
 }
+
+#[test]
+fn sync_respects_machine_disabled_targets() {
+    // Test that sync with a disabled target does not distribute skills there,
+    // and that an unknown disabled_target produces a warning on stderr.
+    let tmp = TempDir::new().unwrap();
+    let skills_dir = tmp.path().join("skills");
+    create_skill(&skills_dir, "my-skill");
+
+    let target_dir = tmp.path().join("target");
+
+    let config = write_config_with_target(
+        tmp.path(),
+        &format!(
+            "[[sources]]\nname = \"test\"\npath = \"{}\"\ntype = \"directory\"\n",
+            skills_dir.display()
+        ),
+        &target_dir,
+    );
+
+    // Create machine.toml that disables the configured target and also lists an unknown target
+    let machine_path = tmp.path().join("machine.toml");
+    std::fs::write(
+        &machine_path,
+        "disabled_targets = [\"test-target\", \"nonexistent-target\"]\n",
+    )
+    .unwrap();
+
+    tome()
+        .args([
+            "--config",
+            config.to_str().unwrap(),
+            "--machine",
+            machine_path.to_str().unwrap(),
+            "sync",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Sync complete"))
+        .stderr(predicate::str::contains(
+            "warning: disabled target 'nonexistent-target' in machine.toml does not match any configured target",
+        ));
+
+    // The target directory should not have the skill (target is disabled)
+    assert!(
+        !target_dir.join("my-skill").exists(),
+        "disabled target should not receive skills"
+    );
+
+    // The skill should still be in the library
+    assert!(tmp.path().join("library/my-skill").is_dir());
+}


### PR DESCRIPTION
## Summary
- Add warning when `disabled_targets` in `machine.toml` don't match any configured target (in both `sync` and `update` commands)
- Add integration test `sync_respects_machine_disabled_targets` verifying disabled targets are skipped and unknown ones produce a warning

Closes #277