### PR TITLE
docs: fix stale comments after ~/.tome/ restructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Current State
 
-**v0.3.0 released** — Portable Library milestone shipped: `tome.lock` lockfile, per-machine preferences via `machine.toml`, `tome update` command with lockfile diffing and interactive triage, connector architecture with data-driven targets. Next up: **v0.4.1 Browse + Validation** (`tome browse`, `tome lint`, frontmatter parsing) and **v0.4.2 Format Transforms** (pluggable transform pipeline, Copilot/Cursor/Windsurf format support).
+**v0.3.3 released** — Portable Library milestone shipped: `tome.lock` lockfile, per-machine preferences via `machine.toml`, `tome update` command with lockfile diffing and interactive triage, connector architecture with data-driven targets. Unified home directory restructured to `~/.tome/`. Next up: **v0.4.1 Browse + Validation** (`tome browse`, `tome lint`, frontmatter parsing) and **v0.4.2 Format Transforms** (rules/instructions syncing, pluggable transform pipeline, Copilot/Cursor/Windsurf format support).
 
 ## Quick Reference
 

--- a/crates/tome/src/library.rs
+++ b/crates/tome/src/library.rs
@@ -70,6 +70,10 @@ fn record_in_manifest(manifest: &mut Manifest, skill: &DiscoveredSkill, content_
 /// A manifest tracks content hashes and provenance for idempotent updates.
 /// When `force` is true, all skills are re-synced regardless of state.
 ///
+/// `tome_home` is the top-level `~/.tome/` directory where metadata files (manifest,
+/// lockfile, config) are stored. `library_dir` is the subdirectory (typically
+/// `~/.tome/skills/`) where skill contents actually live.
+///
 /// Returns both the operation result and the (possibly updated) manifest so the
 /// caller can pass it directly to distribute/cleanup without a redundant disk read.
 /// In dry-run mode the manifest is never written to disk, so returning it here is

--- a/crates/tome/src/lockfile.rs
+++ b/crates/tome/src/lockfile.rs
@@ -27,7 +27,7 @@ pub struct Lockfile {
 /// A single skill entry in the lockfile.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LockEntry {
-    /// Config source name (maps to a `[[sources]]` entry in `config.toml`).
+    /// Config source name (maps to a `[[sources]]` entry in `tome.toml`).
     pub source_name: String,
     /// SHA-256 content hash of the skill directory.
     pub content_hash: String,

--- a/crates/tome/src/machine.rs
+++ b/crates/tome/src/machine.rs
@@ -1,7 +1,8 @@
 //! Per-machine preferences for skill management.
 //!
-//! Each machine can opt out of specific skills via `machine.toml`, which lives alongside
-//! the main `config.toml` at `~/.config/tome/machine.toml`. The library stays complete
+//! Each machine can opt out of specific skills via `machine.toml` at `~/.config/tome/machine.toml`.
+//! This is intentionally separate from `tome.toml` at `~/.tome/tome.toml` — machine-specific
+//! preferences should not live in the portable tome home directory. The library stays complete
 //! across machines; disabled skills are simply skipped during distribution.
 
 use std::collections::BTreeSet;

--- a/crates/tome/src/manifest.rs
+++ b/crates/tome/src/manifest.rs
@@ -1,6 +1,6 @@
 //! Library manifest — tracks provenance and content hashes for each skill in the library.
 //!
-//! The manifest file (`.tome-manifest.json`) lives at the library root and records where each
+//! The manifest file (`.tome-manifest.json`) lives at the tome home directory (`~/.tome/`) and records where each
 //! skill was copied from, its content hash, and when it was last synced. This enables idempotent
 //! copy-based consolidation: unchanged skills are skipped, modified skills are re-copied.
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -48,7 +48,7 @@ Targets are data-driven — any tool can be added without code changes. The `tom
 
 ## Machine Preferences
 
-Per-machine opt-in/opt-out at `~/.config/tome/machine.toml`:
+Per-machine opt-in/opt-out at `~/.config/tome/machine.toml` (intentionally kept separate from `~/.tome/` — machine-specific preferences should not be in the portable tome home directory):
 
 ```toml
 disabled = ["noisy-skill", "work-only-skill"]
@@ -78,6 +78,6 @@ The lockfile is designed to be committed to version control alongside the librar
 
 - **Managed skills** (symlinked from package managers) are gitignored — they are recreated by `tome sync`
 - **Local skills** (copied into the library) are tracked in version control
-- **Temporary files** (`.tome-manifest.tmp`, `tome.lock.tmp`) are always ignored
+- **Temporary files** (`tome.lock.tmp`) are always ignored
 
 This allows the library directory to serve as a git repository for portable skill management while keeping transient entries out of version control.

--- a/docs/visuals/tome-architecture.html
+++ b/docs/visuals/tome-architecture.html
@@ -1022,7 +1022,7 @@ impl TargetConfig {
       <div class="code-file__header"><span>Config — Top-level configuration</span></div>
       <pre class="code-file__body"><code>pub struct Config {
     pub sources: Vec&lt;Source&gt;,       // what to scan
-    pub targets: Targets,           // where to push (hardcoded struct, not Vec)
+    pub targets: BTreeMap&lt;String, TargetConfig&gt;, // data-driven targets
     pub library_dir: PathBuf,       // central library path
     pub exclude: BTreeSet&lt;SkillName&gt;, // skills to skip
 }
@@ -1031,13 +1031,6 @@ pub struct Source {
     pub name: String,
     pub path: PathBuf,
     pub source_type: SourceType,    // ClaudePlugins or Directory
-}
-
-pub struct Targets {
-    pub antigravity: Option&lt;TargetConfig&gt;,
-    pub claude: Option&lt;TargetConfig&gt;,
-    pub codex: Option&lt;TargetConfig&gt;,
-    pub openclaw: Option&lt;TargetConfig&gt;,
 }
 
 // Config::load_or_default handles missing files


### PR DESCRIPTION
## Summary
- Fix stale doc comments in manifest.rs, machine.rs, lockfile.rs, library.rs
- Update CLAUDE.md current state to v0.3.3 and mention ~/.tome/ restructure
- Add explanation for why machine.toml stays at ~/.config/tome/ in configuration.md
- Remove stale .tome-manifest.tmp from gitignore docs (manifest now lives at ~/.tome/)
- Update tome-architecture.html: fix stale hardcoded Targets struct to data-driven BTreeMap

Closes #275