### PR TITLE
feat: log disabled target skips during sync

### DIFF
--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -235,10 +235,14 @@ fn sync(
     let mut distribute_results = Vec::new();
     for (name, target) in config.targets.iter() {
         if machine_prefs.is_target_disabled(name) {
-            if !quiet {
+            if verbose {
                 eprintln!(
-                    "  Skipping target '{}' (disabled in machine preferences)",
-                    name
+                    "{}",
+                    style(format!(
+                        "Skipping target '{}' (disabled in machine preferences)",
+                        name
+                    ))
+                    .dim()
                 );
             }
             continue;
@@ -425,10 +429,14 @@ fn update_cmd(
     let mut distribute_results = Vec::new();
     for (name, target) in config.targets.iter() {
         if machine_prefs.is_target_disabled(name) {
-            if !quiet {
+            if verbose {
                 eprintln!(
-                    "  Skipping target '{}' (disabled in machine preferences)",
-                    name
+                    "{}",
+                    style(format!(
+                        "Skipping target '{}' (disabled in machine preferences)",
+                        name
+                    ))
+                    .dim()
                 );
             }
             continue;


### PR DESCRIPTION
## Summary
- Add `eprintln` feedback when targets are skipped due to being disabled in machine preferences
- Applied to both `sync()` and `update_cmd()` code paths
- Respects the `quiet` flag (suppressed when `--quiet` is passed)

Closes #273