### PR TITLE
refactor: introduce TargetName newtype

### DIFF
--- a/crates/tome/src/config.rs
+++ b/crates/tome/src/config.rs
@@ -7,6 +7,86 @@ use std::path::{Path, PathBuf};
 
 use crate::discover::SkillName;
 
+/// A validated target name.
+///
+/// Rejects empty names and path separators, matching the `SkillName` validation pattern.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize)]
+#[serde(transparent)]
+pub struct TargetName(String);
+
+impl TargetName {
+    /// Create a new target name from any string-like value.
+    ///
+    /// Rejects empty names and names containing path separators (`/` or `\`).
+    pub fn new(name: impl Into<String>) -> Result<Self> {
+        let name = name.into();
+        anyhow::ensure!(!name.is_empty(), "target name cannot be empty");
+        anyhow::ensure!(
+            !name.contains('/') && !name.contains('\\'),
+            "target name contains path separator: '{name}'"
+        );
+        Ok(Self(name))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for TargetName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for TargetName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for TargetName {
+    fn as_ref(&self) -> &Path {
+        Path::new(&self.0)
+    }
+}
+
+impl PartialEq<str> for TargetName {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<&str> for TargetName {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl std::borrow::Borrow<str> for TargetName {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for TargetName {
+    type Error = anyhow::Error;
+
+    fn try_from(s: String) -> Result<Self> {
+        Self::new(s)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for TargetName {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        TargetName::new(s).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Top-level configuration for tome.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -23,8 +103,8 @@ pub struct Config {
     pub sources: Vec<Source>,
 
     /// Distribution targets — keyed by tool name (e.g. "claude", "antigravity")
-    #[serde(default)]
-    pub targets: BTreeMap<String, TargetConfig>,
+    #[serde(default, deserialize_with = "deserialize_targets")]
+    pub targets: BTreeMap<TargetName, TargetConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -140,6 +220,22 @@ impl<'de> Deserialize<'de> for TargetConfig {
     }
 }
 
+/// Deserialize targets map from TOML, validating target names.
+fn deserialize_targets<'de, D>(
+    deserializer: D,
+) -> std::result::Result<BTreeMap<TargetName, TargetConfig>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw: BTreeMap<String, TargetConfig> = BTreeMap::deserialize(deserializer)?;
+    raw.into_iter()
+        .map(|(k, v)| {
+            let name = TargetName::new(k).map_err(serde::de::Error::custom)?;
+            Ok((name, v))
+        })
+        .collect()
+}
+
 impl Config {
     /// Load config from file, or return defaults if file doesn't exist.
     pub fn load(path: &Path) -> Result<Self> {
@@ -222,10 +318,7 @@ impl Config {
             );
         }
 
-        // Empty target names
-        for name in self.targets.keys() {
-            anyhow::ensure!(!name.is_empty(), "target name cannot be empty");
-        }
+        // TargetName validation is enforced at parse time; no additional check needed here.
 
         Ok(())
     }
@@ -391,7 +484,7 @@ mod tests {
                 source_type: SourceType::Directory,
             }],
             targets: BTreeMap::from([(
-                "antigravity".to_string(),
+                TargetName::new("antigravity").unwrap(),
                 TargetConfig {
                     enabled: true,
                     method: TargetMethod::Symlink {
@@ -532,8 +625,8 @@ skills_dir = "~/.gemini/antigravity/skills"
 
     #[test]
     fn targets_iter_includes_claude() {
-        let targets: BTreeMap<String, TargetConfig> = BTreeMap::from([(
-            "claude".to_string(),
+        let targets: BTreeMap<TargetName, TargetConfig> = BTreeMap::from([(
+            TargetName::new("claude").unwrap(),
             TargetConfig {
                 enabled: true,
                 method: TargetMethod::Symlink {
@@ -552,7 +645,7 @@ skills_dir = "~/.gemini/antigravity/skills"
             exclude: BTreeSet::new(),
             sources: Vec::new(),
             targets: BTreeMap::from([(
-                "claude".to_string(),
+                TargetName::new("claude").unwrap(),
                 TargetConfig {
                     enabled: true,
                     method: TargetMethod::Symlink {
@@ -597,23 +690,30 @@ skills_dir = "~/.amp/skills"
     }
 
     #[test]
-    fn validate_rejects_empty_target_name() {
-        let config = Config {
-            targets: BTreeMap::from([(
-                "".to_string(),
-                TargetConfig {
-                    enabled: true,
-                    method: TargetMethod::Symlink {
-                        skills_dir: PathBuf::from("/tmp/target"),
-                    },
-                },
-            )]),
-            ..Default::default()
-        };
-        let err = config.validate().unwrap_err();
-        assert!(
-            err.to_string().contains("target name cannot be empty"),
-            "unexpected error: {err}"
-        );
+    fn target_name_rejects_empty() {
+        assert!(TargetName::new("").is_err());
+    }
+
+    #[test]
+    fn target_name_rejects_path_separator() {
+        assert!(TargetName::new("foo/bar").is_err());
+        assert!(TargetName::new("foo\\bar").is_err());
+    }
+
+    #[test]
+    fn target_name_accepts_valid() {
+        let name = TargetName::new("my-target-123").unwrap();
+        assert_eq!(name.as_str(), "my-target-123");
+        assert_eq!(name.to_string(), "my-target-123");
+        assert_eq!(name, *"my-target-123");
+    }
+
+    #[test]
+    fn target_name_deserialize_rejects_empty() {
+        // TOML with an empty target key would be malformed TOML, but we can test
+        // the TargetName::new validation directly (already covered above).
+        // Instead, test that TargetName rejects empty via serde:
+        let result: std::result::Result<TargetName, _> = serde_json::from_str(r#""""#);
+        assert!(result.is_err());
     }
 }

--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -70,8 +70,8 @@ pub fn check(config: &Config, tome_home: &Path) -> Result<DoctorReport> {
     let mut target_issues = Vec::new();
     for (name, t) in config.targets.iter() {
         if t.enabled {
-            let issues = check_target_dir(name, t.skills_dir(), &config.library_dir)?;
-            target_issues.push((name.to_string(), issues));
+            let issues = check_target_dir(name.as_str(), t.skills_dir(), &config.library_dir)?;
+            target_issues.push((name.as_str().to_string(), issues));
         }
     }
 

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -251,7 +251,7 @@ fn sync(
     // 3. Distribute to targets
     let mut distribute_results = Vec::new();
     for (name, target) in config.targets.iter() {
-        if machine_prefs.is_target_disabled(name) {
+        if machine_prefs.is_target_disabled(name.as_str()) {
             if verbose {
                 eprintln!(
                     "{}",
@@ -270,7 +270,7 @@ fn sync(
         }
         let result = distribute::distribute_to_target(
             &config.library_dir,
-            name,
+            name.as_str(),
             target,
             &manifest,
             &machine_prefs,
@@ -457,7 +457,7 @@ fn update_cmd(
     // 5. Distribute (respects machine_prefs including just-disabled skills)
     let mut distribute_results = Vec::new();
     for (name, target) in config.targets.iter() {
-        if machine_prefs.is_target_disabled(name) {
+        if machine_prefs.is_target_disabled(name.as_str()) {
             if verbose {
                 eprintln!(
                     "{}",
@@ -476,7 +476,7 @@ fn update_cmd(
         }
         let result = distribute::distribute_to_target(
             &config.library_dir,
-            name,
+            name.as_str(),
             target,
             &manifest,
             &machine_prefs,

--- a/crates/tome/src/machine.rs
+++ b/crates/tome/src/machine.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+use crate::config::TargetName;
 use crate::discover::SkillName;
 
 /// Per-machine preferences — disabled skills and targets for this machine.
@@ -22,7 +23,7 @@ pub struct MachinePrefs {
 
     /// Targets to skip on this machine (e.g. machine A doesn't have a certain tool installed).
     #[serde(default)]
-    pub disabled_targets: BTreeSet<String>,
+    pub disabled_targets: BTreeSet<TargetName>,
 }
 
 impl MachinePrefs {
@@ -39,6 +40,12 @@ impl MachinePrefs {
     /// Returns true if the given target is disabled on this machine.
     pub fn is_target_disabled(&self, name: &str) -> bool {
         self.disabled_targets.contains(name)
+    }
+
+    /// Mark a target as disabled on this machine.
+    #[allow(dead_code)]
+    pub fn disable_target(&mut self, name: TargetName) {
+        self.disabled_targets.insert(name);
     }
 }
 
@@ -174,13 +181,12 @@ mod tests {
     #[test]
     fn is_target_disabled_checks_set() {
         let mut prefs = MachinePrefs::default();
-        prefs.disabled_targets.insert("claude".to_string());
-        prefs.disabled_targets.insert("codex".to_string());
+        prefs.disable_target(TargetName::new("claude").unwrap());
+        prefs.disable_target(TargetName::new("codex").unwrap());
 
         assert!(prefs.is_target_disabled("claude"));
         assert!(prefs.is_target_disabled("codex"));
         assert!(!prefs.is_target_disabled("cursor"));
-        assert!(!prefs.is_target_disabled(""));
     }
 
     #[test]
@@ -190,8 +196,8 @@ mod tests {
 
         let mut prefs = MachinePrefs::default();
         prefs.disable(SkillName::new("skill-a").unwrap());
-        prefs.disabled_targets.insert("claude".to_string());
-        prefs.disabled_targets.insert("codex".to_string());
+        prefs.disable_target(TargetName::new("claude").unwrap());
+        prefs.disable_target(TargetName::new("codex").unwrap());
 
         save(&prefs, &path).unwrap();
         let loaded = load(&path).unwrap();
@@ -217,8 +223,8 @@ mod tests {
     #[test]
     fn disabled_targets_toml_format() {
         let mut prefs = MachinePrefs::default();
-        prefs.disabled_targets.insert("claude".to_string());
-        prefs.disabled_targets.insert("windsurf".to_string());
+        prefs.disable_target(TargetName::new("claude").unwrap());
+        prefs.disable_target(TargetName::new("windsurf").unwrap());
 
         let toml_str = toml::to_string_pretty(&prefs).unwrap();
         assert!(toml_str.contains("disabled_targets"));

--- a/crates/tome/src/status.rs
+++ b/crates/tome/src/status.rs
@@ -75,7 +75,7 @@ pub fn gather(config: &Config, tome_home: &Path) -> Result<StatusReport> {
                 crate::config::TargetMethod::Symlink { .. } => "symlink",
             };
             TargetStatus {
-                name: name.to_string(),
+                name: name.as_str().to_string(),
                 enabled: t.enabled,
                 method: method.to_string(),
             }
@@ -326,7 +326,7 @@ mod tests {
 
     #[test]
     fn gather_with_targets_populates_target_status() {
-        use crate::config::{TargetConfig, TargetMethod};
+        use crate::config::{TargetConfig, TargetMethod, TargetName};
         use std::collections::BTreeMap;
 
         let lib_dir = tempfile::TempDir::new().unwrap();
@@ -335,7 +335,7 @@ mod tests {
         let config = Config {
             library_dir: lib_dir.path().to_path_buf(),
             targets: BTreeMap::from([(
-                "claude".to_string(),
+                TargetName::new("claude").unwrap(),
                 TargetConfig {
                     enabled: true,
                     method: TargetMethod::Symlink {
@@ -400,7 +400,7 @@ mod tests {
 
     #[test]
     fn status_shows_tables_with_configured_sources_and_targets() {
-        use crate::config::{Source, SourceType, TargetConfig, TargetMethod};
+        use crate::config::{Source, SourceType, TargetConfig, TargetMethod, TargetName};
         use std::collections::BTreeMap;
 
         let lib_dir = tempfile::TempDir::new().unwrap();
@@ -425,7 +425,7 @@ mod tests {
                 source_type: SourceType::Directory,
             }],
             targets: BTreeMap::from([(
-                "antigravity".to_string(),
+                TargetName::new("antigravity").unwrap(),
                 TargetConfig {
                     enabled: true,
                     method: TargetMethod::Symlink {

--- a/crates/tome/src/wizard.rs
+++ b/crates/tome/src/wizard.rs
@@ -8,7 +8,8 @@ use std::path::{Path, PathBuf};
 use std::collections::BTreeMap;
 
 use crate::config::{
-    Config, Source, SourceType, TargetConfig, TargetMethod, default_config_path, expand_tilde,
+    Config, Source, SourceType, TargetConfig, TargetMethod, TargetName, default_config_path,
+    expand_tilde,
 };
 
 /// Run the interactive setup wizard.
@@ -326,7 +327,7 @@ const KNOWN_TARGETS: &[KnownTarget] = &[
     },
 ];
 
-fn configure_targets() -> Result<BTreeMap<String, TargetConfig>> {
+fn configure_targets() -> Result<BTreeMap<TargetName, TargetConfig>> {
     step_divider("Step 3: Distribution targets");
 
     let home = dirs::home_dir().context("could not determine home directory")?;
@@ -351,7 +352,7 @@ fn configure_targets() -> Result<BTreeMap<String, TargetConfig>> {
             .interact_text()?;
 
         targets.insert(
-            known.name.to_string(),
+            TargetName::new(known.name)?,
             TargetConfig {
                 enabled: true,
                 method: TargetMethod::Symlink {
@@ -378,7 +379,7 @@ fn configure_targets() -> Result<BTreeMap<String, TargetConfig>> {
             .interact_text()?;
 
         targets.insert(
-            name,
+            TargetName::new(name)?,
             TargetConfig {
                 enabled: true,
                 method: TargetMethod::Symlink {
@@ -456,7 +457,7 @@ const KNOWN_SOURCES: &[(&str, &str, SourceType)] = &[
 /// Returns `(source_name, overlapping_path)` pairs for each conflict.
 fn find_source_target_overlaps(
     sources: &[Source],
-    targets: &BTreeMap<String, TargetConfig>,
+    targets: &BTreeMap<TargetName, TargetConfig>,
 ) -> Vec<(String, PathBuf)> {
     let target_paths: Vec<PathBuf> = targets
         .values()
@@ -566,7 +567,7 @@ mod tests {
         }];
 
         let targets = BTreeMap::from([(
-            "antigravity".to_string(),
+            TargetName::new("antigravity").unwrap(),
             TargetConfig {
                 enabled: true,
                 method: TargetMethod::Symlink {
@@ -593,7 +594,7 @@ mod tests {
         }];
 
         let targets = BTreeMap::from([(
-            "antigravity".to_string(),
+            TargetName::new("antigravity").unwrap(),
             TargetConfig {
                 enabled: true,
                 method: TargetMethod::Symlink {
@@ -615,7 +616,7 @@ mod tests {
         }];
 
         let targets = BTreeMap::from([(
-            "claude".to_string(),
+            TargetName::new("claude").unwrap(),
             TargetConfig {
                 enabled: true,
                 method: TargetMethod::Symlink {


### PR DESCRIPTION
## Summary
- Introduce `TargetName` newtype following the `SkillName` pattern
- Update `Config::targets` from `BTreeMap<String, ...>` to `BTreeMap<TargetName, ...>`
- Update `MachinePrefs::disabled_targets` from `BTreeSet<String>` to `BTreeSet<TargetName>`
- Catches invalid target names (empty, path separators) at parse time

Partially addresses #276