### PR TITLE
refactor: introduce TomePaths struct

### DIFF
--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use crate::cleanup;
 use crate::config::Config;
 use crate::manifest;
-use crate::paths::resolve_symlink_target;
+use crate::paths::{TomePaths, resolve_symlink_target};
 
 // -- Data structs --
 
@@ -53,8 +53,8 @@ impl DoctorReport {
 // -- Data gathering (pure computation, no I/O) --
 
 /// Run all diagnostic checks and return a structured report.
-pub fn check(config: &Config, tome_home: &Path) -> Result<DoctorReport> {
-    let configured = config.library_dir.is_dir() || !config.sources.is_empty();
+pub fn check(config: &Config, paths: &TomePaths) -> Result<DoctorReport> {
+    let configured = paths.library_dir.is_dir() || !config.sources.is_empty();
 
     if !configured {
         return Ok(DoctorReport {
@@ -65,12 +65,12 @@ pub fn check(config: &Config, tome_home: &Path) -> Result<DoctorReport> {
         });
     }
 
-    let library_issues = check_library(&config.library_dir, tome_home)?;
+    let library_issues = check_library(paths)?;
 
     let mut target_issues = Vec::new();
     for (name, t) in config.targets.iter() {
         if t.enabled {
-            let issues = check_target_dir(name, t.skills_dir(), &config.library_dir)?;
+            let issues = check_target_dir(name, t.skills_dir(), &paths.library_dir)?;
             target_issues.push((name.to_string(), issues));
         }
     }
@@ -88,8 +88,8 @@ pub fn check(config: &Config, tome_home: &Path) -> Result<DoctorReport> {
 // -- Rendering + control flow --
 
 /// Diagnose and optionally repair issues.
-pub fn diagnose(config: &Config, tome_home: &Path, dry_run: bool) -> Result<()> {
-    let report = check(config, tome_home)?;
+pub fn diagnose(config: &Config, paths: &TomePaths, dry_run: bool) -> Result<()> {
+    let report = check(config, paths)?;
 
     if !report.configured {
         println!("Not configured yet. Run `tome init` to get started.");
@@ -135,12 +135,12 @@ pub fn diagnose(config: &Config, tome_home: &Path, dry_run: bool) -> Result<()> 
             if confirmed {
                 println!();
                 println!("{}", style("Repairing...").bold());
-                repair_library(&config.library_dir, tome_home)?;
+                repair_library(paths)?;
 
                 for (name, t) in config.targets.iter() {
                     if t.enabled {
                         let removed =
-                            cleanup::cleanup_target(t.skills_dir(), &config.library_dir, false)?;
+                            cleanup::cleanup_target(t.skills_dir(), &paths.library_dir, false)?;
                         if removed > 0 {
                             println!(
                                 "  {} Removed {} stale symlink(s) from {}",
@@ -190,7 +190,9 @@ fn render_issues_for_target(name: &str, issues: &[DiagnosticIssue]) {
 
 // -- Check functions (return structured data) --
 
-fn check_library(library_dir: &Path, tome_home: &Path) -> Result<Vec<DiagnosticIssue>> {
+fn check_library(paths: &TomePaths) -> Result<Vec<DiagnosticIssue>> {
+    let library_dir = &paths.library_dir;
+    let tome_home = &paths.tome_home;
     let mut issues = Vec::new();
 
     if !library_dir.is_dir() {
@@ -345,7 +347,9 @@ fn check_config(config: &Config) -> Result<Vec<DiagnosticIssue>> {
 }
 
 /// Repair library issues: remove orphan manifest entries and broken symlinks.
-fn repair_library(library_dir: &Path, tome_home: &Path) -> Result<()> {
+fn repair_library(paths: &TomePaths) -> Result<()> {
+    let library_dir = &paths.library_dir;
+    let tome_home = &paths.tome_home;
     let mut m = manifest::load(tome_home).with_context(|| {
         "cannot repair: manifest is unreadable. Back up .tome-manifest.json and run sync --force"
     })?;
@@ -420,7 +424,11 @@ mod tests {
         };
 
         let tmp = TempDir::new().unwrap();
-        let report = check(&config, tmp.path()).unwrap();
+        let report = check(
+            &config,
+            &TomePaths::new(tmp.path().to_path_buf(), config.library_dir.clone()),
+        )
+        .unwrap();
         assert!(!report.configured);
         assert_eq!(report.total_issues(), 0);
     }
@@ -449,7 +457,11 @@ mod tests {
             ..Config::default()
         };
 
-        let report = check(&config, lib.path()).unwrap();
+        let report = check(
+            &config,
+            &TomePaths::new(lib.path().to_path_buf(), config.library_dir.clone()),
+        )
+        .unwrap();
         assert!(report.configured);
         assert_eq!(report.total_issues(), 0);
     }
@@ -464,7 +476,11 @@ mod tests {
             ..Config::default()
         };
 
-        let report = check(&config, lib.path()).unwrap();
+        let report = check(
+            &config,
+            &TomePaths::new(lib.path().to_path_buf(), config.library_dir.clone()),
+        )
+        .unwrap();
         assert_eq!(report.library_issues.len(), 1);
         assert_eq!(report.library_issues[0].severity, IssueSeverity::Warning);
         assert!(report.library_issues[0].message.contains("orphan"));
@@ -484,7 +500,11 @@ mod tests {
             ..Config::default()
         };
 
-        let report = check(&config, lib.path()).unwrap();
+        let report = check(
+            &config,
+            &TomePaths::new(lib.path().to_path_buf(), config.library_dir.clone()),
+        )
+        .unwrap();
         assert_eq!(report.config_issues.len(), 1);
         assert!(report.config_issues[0].message.contains("gone"));
     }
@@ -494,7 +514,11 @@ mod tests {
     #[test]
     fn check_library_missing_dir() {
         let tmp = TempDir::new().unwrap();
-        let result = check_library(Path::new("/nonexistent/library"), tmp.path()).unwrap();
+        let result = check_library(&TomePaths::new(
+            tmp.path().to_path_buf(),
+            Path::new("/nonexistent/library").to_path_buf(),
+        ))
+        .unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].severity, IssueSeverity::Warning);
     }
@@ -518,7 +542,11 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        let result = check_library(lib.path(), lib.path()).unwrap();
+        let result = check_library(&TomePaths::new(
+            lib.path().to_path_buf(),
+            lib.path().to_path_buf(),
+        ))
+        .unwrap();
         assert!(result.is_empty());
     }
 
@@ -539,7 +567,11 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        let result = check_library(lib.path(), lib.path()).unwrap();
+        let result = check_library(&TomePaths::new(
+            lib.path().to_path_buf(),
+            lib.path().to_path_buf(),
+        ))
+        .unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].severity, IssueSeverity::Error);
     }
@@ -549,7 +581,11 @@ mod tests {
         let lib = TempDir::new().unwrap();
         std::fs::create_dir_all(lib.path().join("orphan")).unwrap();
 
-        let result = check_library(lib.path(), lib.path()).unwrap();
+        let result = check_library(&TomePaths::new(
+            lib.path().to_path_buf(),
+            lib.path().to_path_buf(),
+        ))
+        .unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].severity, IssueSeverity::Warning);
     }
@@ -559,7 +595,11 @@ mod tests {
         let lib = TempDir::new().unwrap();
         unix_fs::symlink("/nonexistent/target", lib.path().join("broken")).unwrap();
 
-        let result = check_library(lib.path(), lib.path()).unwrap();
+        let result = check_library(&TomePaths::new(
+            lib.path().to_path_buf(),
+            lib.path().to_path_buf(),
+        ))
+        .unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].severity, IssueSeverity::Error);
     }
@@ -640,7 +680,11 @@ mod tests {
         };
 
         let tmp = TempDir::new().unwrap();
-        let result = diagnose(&config, tmp.path(), true);
+        let result = diagnose(
+            &config,
+            &TomePaths::new(tmp.path().to_path_buf(), config.library_dir.clone()),
+            true,
+        );
         assert!(result.is_ok());
     }
 
@@ -670,7 +714,11 @@ mod tests {
         manifest::save(&m, tome_home.path()).unwrap();
 
         // check_library should read manifest from tome_home, not library_dir
-        let issues = check_library(library.path(), tome_home.path()).unwrap();
+        let issues = check_library(&TomePaths::new(
+            tome_home.path().to_path_buf(),
+            library.path().to_path_buf(),
+        ))
+        .unwrap();
         assert!(
             issues.is_empty(),
             "should find no issues when manifest is at tome_home and skill exists in library"
@@ -678,7 +726,11 @@ mod tests {
 
         // Verify it would fail if we pointed tome_home at the wrong place
         // (library_dir has no manifest, so it loads an empty one and sees an orphan)
-        let issues = check_library(library.path(), library.path()).unwrap();
+        let issues = check_library(&TomePaths::new(
+            library.path().to_path_buf(),
+            library.path().to_path_buf(),
+        ))
+        .unwrap();
         assert_eq!(
             issues.len(),
             1,
@@ -704,7 +756,11 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        repair_library(lib.path(), lib.path()).unwrap();
+        repair_library(&TomePaths::new(
+            lib.path().to_path_buf(),
+            lib.path().to_path_buf(),
+        ))
+        .unwrap();
 
         let after = manifest::load(lib.path()).unwrap();
         assert!(
@@ -732,7 +788,11 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        repair_library(lib.path(), lib.path()).unwrap();
+        repair_library(&TomePaths::new(
+            lib.path().to_path_buf(),
+            lib.path().to_path_buf(),
+        ))
+        .unwrap();
 
         assert!(
             !lib.path().join("broken-plugin").exists(),
@@ -749,7 +809,11 @@ mod tests {
         // Broken legacy symlink (not in manifest)
         unix_fs::symlink("/nonexistent/v01/skill", lib.path().join("legacy")).unwrap();
 
-        repair_library(lib.path(), lib.path()).unwrap();
+        repair_library(&TomePaths::new(
+            lib.path().to_path_buf(),
+            lib.path().to_path_buf(),
+        ))
+        .unwrap();
 
         assert!(
             !lib.path().join("legacy").exists(),
@@ -776,7 +840,11 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        repair_library(lib.path(), lib.path()).unwrap();
+        repair_library(&TomePaths::new(
+            lib.path().to_path_buf(),
+            lib.path().to_path_buf(),
+        ))
+        .unwrap();
 
         let after = manifest::load(lib.path()).unwrap();
         assert!(after.contains_key("healthy-skill"));

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -48,6 +48,7 @@ use cli::{Cli, Command};
 use config::Config;
 use distribute::DistributeResult;
 use library::ConsolidateResult;
+pub use paths::TomePaths;
 
 /// Summary of a complete sync operation.
 pub struct SyncReport {
@@ -112,9 +113,10 @@ pub fn run(cli: Cli) -> Result<()> {
         let config = wizard::run(cli.dry_run)?;
         config.validate()?;
         if !cli.dry_run {
+            let paths = TomePaths::new(tome_home, config.library_dir.clone());
             sync(
                 &config,
-                &tome_home,
+                &paths,
                 cli.dry_run,
                 false,
                 cli.verbose,
@@ -128,12 +130,13 @@ pub fn run(cli: Cli) -> Result<()> {
     let config = Config::load_or_default(cli.config.as_deref())?;
     config.validate()?;
     let tome_home = resolve_tome_home(cli.config.as_deref())?;
+    let paths = TomePaths::new(tome_home, config.library_dir.clone());
 
     match cli.command {
         Command::Init => unreachable!(),
         Command::Sync { force } => sync(
             &config,
-            &tome_home,
+            &paths,
             cli.dry_run,
             force,
             cli.verbose,
@@ -142,14 +145,14 @@ pub fn run(cli: Cli) -> Result<()> {
         )?,
         Command::Update => update_cmd(
             &config,
-            &tome_home,
+            &paths,
             cli.dry_run,
             cli.verbose,
             cli.quiet,
             cli.machine.as_deref(),
         )?,
-        Command::Status => status::show(&config, &tome_home)?,
-        Command::Doctor => doctor::diagnose(&config, &tome_home, cli.dry_run)?,
+        Command::Status => status::show(&config, &paths)?,
+        Command::Doctor => doctor::diagnose(&config, &paths, cli.dry_run)?,
         Command::Browse => {
             let mut warnings = Vec::new();
             let skills = discover::discover_all(&config, &mut warnings)?;
@@ -174,7 +177,7 @@ pub fn run(cli: Cli) -> Result<()> {
 /// The core sync pipeline: discover → consolidate → distribute → cleanup.
 fn sync(
     config: &Config,
-    tome_home: &Path,
+    paths: &TomePaths,
     dry_run: bool,
     force: bool,
     verbose: bool,
@@ -223,8 +226,7 @@ fn sync(
     if verbose {
         eprintln!("{}", style("Consolidating to library...").dim());
     }
-    let (consolidate_result, mut manifest) =
-        library::consolidate(&skills, &config.library_dir, tome_home, dry_run, force)?;
+    let (consolidate_result, mut manifest) = library::consolidate(&skills, paths, dry_run, force)?;
     if let Some(sp) = sp {
         sp.finish_and_clear();
     }
@@ -269,7 +271,7 @@ fn sync(
             eprintln!("{}", style(format!("Distributing to {}...", name)).dim());
         }
         let result = distribute::distribute_to_target(
-            &config.library_dir,
+            &paths.library_dir,
             name,
             target,
             &manifest,
@@ -289,7 +291,7 @@ fn sync(
         eprintln!("{}", style("Cleaning up stale entries...").dim());
     }
     let cleanup_result = cleanup::cleanup_library(
-        &config.library_dir,
+        &paths.library_dir,
         &discovered_names,
         &mut manifest,
         dry_run,
@@ -299,25 +301,25 @@ fn sync(
     let mut removed_from_targets = 0usize;
     for (_name, target) in config.targets.iter() {
         let skills_dir = target.skills_dir();
-        removed_from_targets += cleanup::cleanup_target(skills_dir, &config.library_dir, dry_run)?;
+        removed_from_targets += cleanup::cleanup_target(skills_dir, &paths.library_dir, dry_run)?;
         // Also clean up symlinks for disabled skills
         removed_from_targets +=
-            cleanup_disabled_from_target(skills_dir, &config.library_dir, &machine_prefs, dry_run)?;
+            cleanup_disabled_from_target(skills_dir, &paths.library_dir, &machine_prefs, dry_run)?;
     }
     // Save manifest after cleanup (may have removed entries)
-    if !dry_run && tome_home.is_dir() {
-        manifest::save(&manifest, tome_home)?;
+    if !dry_run && paths.tome_home.is_dir() {
+        manifest::save(&manifest, &paths.tome_home)?;
     }
 
     // Generate .gitignore after cleanup so stale entries are excluded
-    if !dry_run && config.library_dir.is_dir() {
-        library::generate_gitignore(&config.library_dir, &manifest)?;
+    if !dry_run && paths.library_dir.is_dir() {
+        library::generate_gitignore(&paths.library_dir, &manifest)?;
     }
 
     // Generate lockfile for reproducibility
-    if !dry_run && tome_home.is_dir() {
+    if !dry_run && paths.tome_home.is_dir() {
         let lf = lockfile::generate(&manifest, &skills);
-        lockfile::save(&lf, tome_home)?;
+        lockfile::save(&lf, &paths.tome_home)?;
     }
 
     if let Some(sp) = sp {
@@ -339,7 +341,7 @@ fn sync(
     // Offer git commit if the library dir is a git repo with changes
     if !dry_run && !quiet {
         offer_git_commit(
-            &config.library_dir,
+            &paths.library_dir,
             &manifest,
             report.consolidate.created,
             report.consolidate.updated,
@@ -351,10 +353,9 @@ fn sync(
 }
 
 /// The update command: diff-then-distribute with interactive triage.
-#[allow(clippy::too_many_arguments)]
 fn update_cmd(
     config: &Config,
-    tome_home: &Path,
+    paths: &TomePaths,
     dry_run: bool,
     verbose: bool,
     quiet: bool,
@@ -386,7 +387,7 @@ fn update_cmd(
     }
 
     // 1. Load existing lockfile (may be committed by another machine)
-    let old_lockfile = lockfile::load(tome_home)?;
+    let old_lockfile = lockfile::load(&paths.tome_home)?;
 
     // 2. Discover
     let sp = show_progress.then(|| spinner("Discovering skills..."));
@@ -416,8 +417,7 @@ fn update_cmd(
     if verbose {
         eprintln!("{}", style("Consolidating to library...").dim());
     }
-    let (consolidate_result, mut manifest) =
-        library::consolidate(&skills, &config.library_dir, tome_home, dry_run, false)?;
+    let (consolidate_result, mut manifest) = library::consolidate(&skills, paths, dry_run, false)?;
     if let Some(sp) = sp {
         sp.finish_and_clear();
     }
@@ -475,7 +475,7 @@ fn update_cmd(
             eprintln!("{}", style(format!("Distributing to {}...", name)).dim());
         }
         let result = distribute::distribute_to_target(
-            &config.library_dir,
+            &paths.library_dir,
             name,
             target,
             &manifest,
@@ -495,7 +495,7 @@ fn update_cmd(
         eprintln!("{}", style("Cleaning up stale entries...").dim());
     }
     let cleanup_result = cleanup::cleanup_library(
-        &config.library_dir,
+        &paths.library_dir,
         &discovered_names,
         &mut manifest,
         dry_run,
@@ -505,10 +505,10 @@ fn update_cmd(
     let mut removed_from_targets = 0usize;
     for (_name, target) in config.targets.iter() {
         let skills_dir = target.skills_dir();
-        removed_from_targets += cleanup::cleanup_target(skills_dir, &config.library_dir, dry_run)?;
+        removed_from_targets += cleanup::cleanup_target(skills_dir, &paths.library_dir, dry_run)?;
         // Also clean up symlinks for disabled skills
         removed_from_targets +=
-            cleanup_disabled_from_target(skills_dir, &config.library_dir, &machine_prefs, dry_run)?;
+            cleanup_disabled_from_target(skills_dir, &paths.library_dir, &machine_prefs, dry_run)?;
     }
 
     if let Some(sp) = sp {
@@ -516,12 +516,12 @@ fn update_cmd(
     }
 
     // 7. Save lockfile + manifest
-    if !dry_run && tome_home.is_dir() {
-        manifest::save(&manifest, tome_home)?;
-        if config.library_dir.is_dir() {
-            library::generate_gitignore(&config.library_dir, &manifest)?;
+    if !dry_run && paths.tome_home.is_dir() {
+        manifest::save(&manifest, &paths.tome_home)?;
+        if paths.library_dir.is_dir() {
+            library::generate_gitignore(&paths.library_dir, &manifest)?;
         }
-        lockfile::save(&new_lockfile, tome_home)?;
+        lockfile::save(&new_lockfile, &paths.tome_home)?;
     }
 
     let report = SyncReport {
@@ -539,7 +539,7 @@ fn update_cmd(
     // Offer git commit if the library dir is a git repo with changes
     if !dry_run && !quiet {
         offer_git_commit(
-            &config.library_dir,
+            &paths.library_dir,
             &manifest,
             report.consolidate.created,
             report.consolidate.updated,

--- a/crates/tome/src/library.rs
+++ b/crates/tome/src/library.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 
 use crate::discover::DiscoveredSkill;
 use crate::manifest::{self, Manifest, SkillEntry};
-use crate::paths::symlink_points_to;
+use crate::paths::{TomePaths, symlink_points_to};
 
 /// What already exists at the library destination path.
 enum DestinationState {
@@ -70,9 +70,9 @@ fn record_in_manifest(manifest: &mut Manifest, skill: &DiscoveredSkill, content_
 /// A manifest tracks content hashes and provenance for idempotent updates.
 /// When `force` is true, all skills are re-synced regardless of state.
 ///
-/// `tome_home` is the top-level `~/.tome/` directory where metadata files (manifest,
-/// lockfile, config) are stored. `library_dir` is the subdirectory (typically
-/// `~/.tome/skills/`) where skill contents actually live.
+/// `paths.tome_home` is the top-level `~/.tome/` directory where metadata files
+/// (manifest, lockfile, config) are stored. `paths.library_dir` is the subdirectory
+/// (typically `~/.tome/skills/`) where skill contents actually live.
 ///
 /// Returns both the operation result and the (possibly updated) manifest so the
 /// caller can pass it directly to distribute/cleanup without a redundant disk read.
@@ -80,11 +80,13 @@ fn record_in_manifest(manifest: &mut Manifest, skill: &DiscoveredSkill, content_
 /// the only way downstream steps see the would-be-updated state.
 pub fn consolidate(
     skills: &[DiscoveredSkill],
-    library_dir: &Path,
-    tome_home: &Path,
+    paths: &TomePaths,
     dry_run: bool,
     force: bool,
 ) -> Result<(ConsolidateResult, Manifest)> {
+    let library_dir = &paths.library_dir;
+    let tome_home = &paths.tome_home;
+
     if !dry_run {
         std::fs::create_dir_all(library_dir)
             .with_context(|| format!("failed to create library dir {}", library_dir.display()))?;
@@ -400,8 +402,13 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        let (result, _manifest) =
-            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
+        let (result, _manifest) = consolidate(
+            &[skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.created, 1);
         assert_eq!(result.unchanged, 0);
 
@@ -419,16 +426,14 @@ mod tests {
 
         consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
         .unwrap();
         let (result, _manifest) = consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -445,16 +450,14 @@ mod tests {
 
         consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
         .unwrap();
         let (result, _manifest) = consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             true,
         )
@@ -471,8 +474,7 @@ mod tests {
 
         consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -483,8 +485,7 @@ mod tests {
 
         let (result, _manifest) = consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -502,8 +503,13 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        let (result, _manifest) =
-            consolidate(&[skill], library.path(), library.path(), true, false).unwrap();
+        let (result, _manifest) = consolidate(
+            &[skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            true,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.created, 1);
 
         // Directory should NOT exist
@@ -517,8 +523,13 @@ mod tests {
         let source = TempDir::new().unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        let (result, _manifest) =
-            consolidate(&[skill], &nonexistent_lib, &nonexistent_lib, true, false).unwrap();
+        let (result, _manifest) = consolidate(
+            &[skill],
+            &TomePaths::new(nonexistent_lib.to_path_buf(), nonexistent_lib.to_path_buf()),
+            true,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.created, 1);
         assert!(!nonexistent_lib.exists());
     }
@@ -535,8 +546,13 @@ mod tests {
         std::fs::create_dir_all(&collision).unwrap();
         std::fs::write(collision.join("README.md"), "user-created").unwrap();
 
-        let (result, _manifest) =
-            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
+        let (result, _manifest) = consolidate(
+            &[skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.created, 0);
         assert_eq!(result.unchanged, 0);
         assert_eq!(result.skipped, 1);
@@ -560,8 +576,13 @@ mod tests {
         unix_fs::symlink(&skill.path, library.path().join("my-skill")).unwrap();
         assert!(library.path().join("my-skill").is_symlink());
 
-        let (result, _manifest) =
-            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
+        let (result, _manifest) = consolidate(
+            &[skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.updated, 1, "symlink should be migrated");
 
         // Should now be a real directory, not a symlink
@@ -582,7 +603,13 @@ mod tests {
         let library = TempDir::new().unwrap();
 
         let skill1 = make_skill(source1.path(), "my-skill");
-        consolidate(&[skill1], library.path(), library.path(), false, false).unwrap();
+        consolidate(
+            &[skill1],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
 
         // New skill from a different source with different content
         let skill2_dir = source2.path().join("my-skill");
@@ -598,8 +625,7 @@ mod tests {
 
         let (result, _manifest) = consolidate(
             std::slice::from_ref(&skill2),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -616,8 +642,13 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        let (_, manifest) =
-            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
+        let (_, manifest) = consolidate(
+            &[skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(manifest.len(), 1);
         assert!(manifest.contains_key("my-skill"));
@@ -640,8 +671,13 @@ mod tests {
         )
         .unwrap();
 
-        let (result, _manifest) =
-            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
+        let (result, _manifest) = consolidate(
+            &[skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.updated, 1);
 
         let dest = library.path().join("my-skill");
@@ -669,8 +705,13 @@ mod tests {
             provenance: None,
         };
 
-        let (result, _) =
-            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
+        let (result, _) = consolidate(
+            &[skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.created, 1);
         assert!(
             library
@@ -691,8 +732,13 @@ mod tests {
         std::fs::create_dir_all(library.path()).unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        let (result, _) =
-            consolidate(&[skill], library.path(), library.path(), true, false).unwrap();
+        let (result, _) = consolidate(
+            &[skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            true,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.created, 1);
         assert!(
             !library.path().join(".tome-manifest.json").exists(),
@@ -708,14 +754,19 @@ mod tests {
 
         // First: consolidate as local (creates real copy + manifest entry)
         let local_skill = make_skill(source.path(), "my-skill");
-        consolidate(&[local_skill], library.path(), library.path(), false, false).unwrap();
+        consolidate(
+            &[local_skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
 
         // Now: dry-run consolidate the same skill as managed
         let managed_skill = make_managed_skill(source.path(), "my-skill");
         let (result, manifest) = consolidate(
             &[managed_skill],
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             true,
             false,
         )
@@ -746,8 +797,7 @@ mod tests {
 
         let (_, manifest) = consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -769,8 +819,13 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_managed_skill(source.path(), "plugin-skill");
 
-        let (result, manifest) =
-            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
+        let (result, manifest) = consolidate(
+            &[skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.created, 1);
 
         let dest = library.path().join("plugin-skill");
@@ -789,16 +844,14 @@ mod tests {
 
         consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
         .unwrap();
         let (result, _) = consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -815,14 +868,19 @@ mod tests {
         let library = TempDir::new().unwrap();
 
         let skill1 = make_managed_skill(source1.path(), "plugin-skill");
-        consolidate(&[skill1], library.path(), library.path(), false, false).unwrap();
+        consolidate(
+            &[skill1],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
 
         // Same skill name from different path
         let skill2 = make_managed_skill(source2.path(), "plugin-skill");
         let (result, _) = consolidate(
             std::slice::from_ref(&skill2),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -843,7 +901,13 @@ mod tests {
 
         // First: consolidate as local (copy)
         let local_skill = make_skill(source.path(), "my-skill");
-        consolidate(&[local_skill], library.path(), library.path(), false, false).unwrap();
+        consolidate(
+            &[local_skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
         let dest = library.path().join("my-skill");
         assert!(dest.is_dir());
         assert!(!dest.is_symlink(), "should be a real dir initially");
@@ -852,8 +916,7 @@ mod tests {
         let managed_skill = make_managed_skill(source.path(), "my-skill");
         let (result, manifest) = consolidate(
             &[managed_skill],
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -872,8 +935,7 @@ mod tests {
         let managed_skill = make_managed_skill(source.path(), "my-skill");
         consolidate(
             &[managed_skill],
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -883,8 +945,13 @@ mod tests {
 
         // Now: same skill but local
         let local_skill = make_skill(source.path(), "my-skill");
-        let (result, manifest) =
-            consolidate(&[local_skill], library.path(), library.path(), false, false).unwrap();
+        let (result, manifest) = consolidate(
+            &[local_skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.updated, 1);
         assert!(dest.is_dir());
         assert!(!dest.is_symlink(), "should now be a real directory");
@@ -897,8 +964,13 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_managed_skill(source.path(), "plugin-skill");
 
-        let (_, manifest) =
-            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
+        let (_, manifest) = consolidate(
+            &[skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
         let entry = manifest.get("plugin-skill").unwrap();
         assert!(entry.managed);
         assert!(!entry.content_hash.is_empty());
@@ -916,8 +988,7 @@ mod tests {
 
         let (_, manifest) = consolidate(
             &[managed, local],
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -941,8 +1012,7 @@ mod tests {
 
         let (_, manifest) = consolidate(
             &[managed, local],
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -962,8 +1032,13 @@ mod tests {
         let source = TempDir::new().unwrap();
 
         let managed = make_managed_skill(source.path(), "plugin-a");
-        let (_, manifest) =
-            consolidate(&[managed], library.path(), library.path(), false, false).unwrap();
+        let (_, manifest) = consolidate(
+            &[managed],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
 
         generate_gitignore(library.path(), &manifest).unwrap();
         let first = std::fs::read_to_string(library.path().join(".gitignore")).unwrap();
@@ -983,8 +1058,13 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_managed_skill(source.path(), "plugin-skill");
 
-        let (result, manifest) =
-            consolidate(&[skill], library.path(), library.path(), true, false).unwrap();
+        let (result, manifest) = consolidate(
+            &[skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            true,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.created, 1);
 
         // Symlink should NOT exist on disk
@@ -1005,16 +1085,14 @@ mod tests {
 
         consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
         .unwrap();
         let (result, _) = consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             true,
         )
@@ -1035,8 +1113,7 @@ mod tests {
         // First: consolidate normally (creates symlink)
         consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -1056,8 +1133,7 @@ mod tests {
         // Re-consolidate — should repair by replacing dir with symlink
         let (result, _) = consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -1079,8 +1155,13 @@ mod tests {
         std::fs::create_dir_all(&collision).unwrap();
         std::fs::write(collision.join("README.md"), "user-created").unwrap();
 
-        let (result, _) =
-            consolidate(&[skill], library.path(), library.path(), false, false).unwrap();
+        let (result, _) = consolidate(
+            &[skill],
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.skipped, 1);
         assert_eq!(result.created, 0);
 
@@ -1098,8 +1179,7 @@ mod tests {
 
         let (_, manifest1) = consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -1111,8 +1191,7 @@ mod tests {
 
         let (result, manifest2) = consolidate(
             std::slice::from_ref(&skill),
-            library.path(),
-            library.path(),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
             false,
             false,
         )
@@ -1135,8 +1214,13 @@ mod tests {
         let library = TempDir::new().unwrap();
         let skill = make_skill(source.path(), "my-skill");
 
-        let (result, _manifest) =
-            consolidate(&[skill], library.path(), tome_home.path(), false, false).unwrap();
+        let (result, _manifest) = consolidate(
+            &[skill],
+            &TomePaths::new(tome_home.path().to_path_buf(), library.path().to_path_buf()),
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.created, 1);
 
         // Manifest should live at tome_home, not library_dir

--- a/crates/tome/src/paths.rs
+++ b/crates/tome/src/paths.rs
@@ -1,6 +1,43 @@
 //! Symlink path utilities — resolving relative symlink targets and comparing symlink destinations.
+//!
+//! Also defines [`TomePaths`], a struct that groups `tome_home` and `library_dir`
+//! to prevent accidental parameter swaps.
 
 use std::path::{Path, PathBuf};
+
+/// Resolved filesystem paths for a tome instance.
+///
+/// Groups `tome_home` (metadata directory, `~/.tome/`) and `library_dir`
+/// (skill storage, typically `~/.tome/skills/`) into a single value to
+/// prevent accidental parameter swaps.
+#[derive(Debug, Clone)]
+pub struct TomePaths {
+    /// Top-level directory for metadata (manifest, lockfile, config).
+    /// Typically `~/.tome/`.
+    pub tome_home: PathBuf,
+    /// Directory where skill contents are stored.
+    /// Typically `~/.tome/skills/`.
+    pub library_dir: PathBuf,
+}
+
+impl TomePaths {
+    pub fn new(tome_home: PathBuf, library_dir: PathBuf) -> Self {
+        Self {
+            tome_home,
+            library_dir,
+        }
+    }
+
+    /// Path to the manifest file.
+    pub fn manifest_path(&self) -> PathBuf {
+        self.tome_home.join(".tome-manifest.json")
+    }
+
+    /// Path to the lockfile.
+    pub fn lockfile_path(&self) -> PathBuf {
+        self.tome_home.join("tome.lock")
+    }
+}
 
 /// Resolve a symlink's raw target to an absolute path.
 ///
@@ -98,5 +135,39 @@ mod tests {
         unix_fs::symlink(&target_a, &link).unwrap();
 
         assert!(!symlink_points_to(&link, &target_b));
+    }
+
+    #[test]
+    fn tome_paths_new_stores_fields() {
+        let paths = TomePaths::new(
+            PathBuf::from("/home/.tome"),
+            PathBuf::from("/home/.tome/skills"),
+        );
+        assert_eq!(paths.tome_home, PathBuf::from("/home/.tome"));
+        assert_eq!(paths.library_dir, PathBuf::from("/home/.tome/skills"));
+    }
+
+    #[test]
+    fn tome_paths_manifest_path() {
+        let paths = TomePaths::new(
+            PathBuf::from("/home/.tome"),
+            PathBuf::from("/home/.tome/skills"),
+        );
+        assert_eq!(
+            paths.manifest_path(),
+            PathBuf::from("/home/.tome/.tome-manifest.json")
+        );
+    }
+
+    #[test]
+    fn tome_paths_lockfile_path() {
+        let paths = TomePaths::new(
+            PathBuf::from("/home/.tome"),
+            PathBuf::from("/home/.tome/skills"),
+        );
+        assert_eq!(
+            paths.lockfile_path(),
+            PathBuf::from("/home/.tome/tome.lock")
+        );
     }
 }

--- a/crates/tome/src/status.rs
+++ b/crates/tome/src/status.rs
@@ -8,6 +8,7 @@ use tabled::settings::{Modify, Style, object::Rows};
 use crate::config::Config;
 use crate::discover;
 use crate::manifest;
+use crate::paths::TomePaths;
 
 // -- Data structs --
 
@@ -42,11 +43,11 @@ pub struct StatusReport {
 // -- Data gathering (pure computation, no I/O) --
 
 /// Gather status data without producing any output.
-pub fn gather(config: &Config, tome_home: &Path) -> Result<StatusReport> {
-    let configured = config.library_dir.is_dir() || !config.sources.is_empty();
+pub fn gather(config: &Config, paths: &TomePaths) -> Result<StatusReport> {
+    let configured = paths.library_dir.is_dir() || !config.sources.is_empty();
 
-    let library_count = if config.library_dir.is_dir() {
-        count_entries(&config.library_dir).map_err(|e| e.to_string())
+    let library_count = if paths.library_dir.is_dir() {
+        count_entries(&paths.library_dir).map_err(|e| e.to_string())
     } else {
         Ok(0)
     };
@@ -82,15 +83,15 @@ pub fn gather(config: &Config, tome_home: &Path) -> Result<StatusReport> {
         })
         .collect();
 
-    let health = if config.library_dir.is_dir() {
-        count_health_issues(&config.library_dir, tome_home).map_err(|e| e.to_string())
+    let health = if paths.library_dir.is_dir() {
+        count_health_issues(&paths.library_dir, &paths.tome_home).map_err(|e| e.to_string())
     } else {
         Ok(0)
     };
 
     Ok(StatusReport {
         configured,
-        library_dir: config.library_dir.clone(),
+        library_dir: paths.library_dir.clone(),
         library_count,
         sources,
         targets,
@@ -101,8 +102,8 @@ pub fn gather(config: &Config, tome_home: &Path) -> Result<StatusReport> {
 // -- Rendering --
 
 /// Display the current status of the tome system.
-pub fn show(config: &Config, tome_home: &Path) -> Result<()> {
-    let report = gather(config, tome_home)?;
+pub fn show(config: &Config, paths: &TomePaths) -> Result<()> {
+    let report = gather(config, paths)?;
     render_status(&report);
     Ok(())
 }
@@ -280,7 +281,11 @@ mod tests {
             ..Config::default()
         };
 
-        let report = gather(&config, config.library_dir.as_path()).unwrap();
+        let report = gather(
+            &config,
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+        )
+        .unwrap();
         assert!(!report.configured);
         assert!(report.sources.is_empty());
         assert!(report.targets.is_empty());
@@ -300,7 +305,11 @@ mod tests {
             ..Config::default()
         };
 
-        let report = gather(&config, config.library_dir.as_path()).unwrap();
+        let report = gather(
+            &config,
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+        )
+        .unwrap();
         assert!(report.configured);
         assert_eq!(report.sources.len(), 1);
         assert_eq!(report.sources[0].name, "test");
@@ -319,7 +328,11 @@ mod tests {
             ..Config::default()
         };
 
-        let report = gather(&config, config.library_dir.as_path()).unwrap();
+        let report = gather(
+            &config,
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+        )
+        .unwrap();
         assert!(report.configured);
         assert_eq!(report.library_count.unwrap(), 2);
     }
@@ -346,7 +359,11 @@ mod tests {
             ..Config::default()
         };
 
-        let report = gather(&config, config.library_dir.as_path()).unwrap();
+        let report = gather(
+            &config,
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+        )
+        .unwrap();
         assert_eq!(report.targets.len(), 1);
         assert_eq!(report.targets[0].name, "claude");
         assert!(report.targets[0].enabled);
@@ -363,7 +380,11 @@ mod tests {
             ..Config::default()
         };
 
-        let report = gather(&config, config.library_dir.as_path()).unwrap();
+        let report = gather(
+            &config,
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+        )
+        .unwrap();
         assert_eq!(report.health.unwrap(), 1);
     }
 
@@ -376,7 +397,10 @@ mod tests {
             ..Config::default()
         };
 
-        let result = show(&config, config.library_dir.as_path());
+        let result = show(
+            &config,
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+        );
         assert!(result.is_ok());
     }
 
@@ -394,7 +418,10 @@ mod tests {
             ..Config::default()
         };
 
-        let result = show(&config, config.library_dir.as_path());
+        let result = show(
+            &config,
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+        );
         assert!(result.is_ok());
     }
 
@@ -436,7 +463,10 @@ mod tests {
             ..Config::default()
         };
 
-        let result = show(&config, config.library_dir.as_path());
+        let result = show(
+            &config,
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+        );
         assert!(result.is_ok());
     }
 


### PR DESCRIPTION
## Summary
- Introduce `TomePaths` struct in `paths.rs` grouping `tome_home` and `library_dir` with named fields
- Refactor `library::consolidate`, `doctor::check/diagnose/check_library/repair_library`, and `status::gather/show` to accept `&TomePaths` instead of separate `&Path` params
- Update `lib.rs` `sync()` and `update_cmd()` to construct `TomePaths` and pass it through the pipeline
- Add `manifest_path()` and `lockfile_path()` convenience methods
- Functions that only need one path (`distribute`, `cleanup`, `manifest::load/save`, `lockfile::load/save`) still take `&Path` directly

## Test plan
- [x] All 208 unit tests pass
- [x] All 32 integration tests pass
- [x] `make ci` passes (fmt-check + clippy + tests)
- [x] New unit tests for `TomePaths::new`, `manifest_path()`, `lockfile_path()`

Partially addresses #276