### PR TITLE
fix: reject dot-special and whitespace names

### DIFF
--- a/crates/tome/src/config.rs
+++ b/crates/tome/src/config.rs
@@ -22,6 +22,14 @@ impl TargetName {
         let name = name.into();
         anyhow::ensure!(!name.is_empty(), "target name cannot be empty");
         anyhow::ensure!(
+            name != "." && name != "..",
+            "target name cannot be '.' or '..'"
+        );
+        anyhow::ensure!(
+            !name.chars().all(|c| c.is_whitespace()) && name.trim() == name,
+            "target name cannot be whitespace-only or have leading/trailing whitespace: '{name}'"
+        );
+        anyhow::ensure!(
             !name.contains('/') && !name.contains('\\'),
             "target name contains path separator: '{name}'"
         );
@@ -706,6 +714,19 @@ skills_dir = "~/.amp/skills"
         assert_eq!(name.as_str(), "my-target-123");
         assert_eq!(name.to_string(), "my-target-123");
         assert_eq!(name, *"my-target-123");
+    }
+
+    #[test]
+    fn target_name_rejects_dot_special() {
+        assert!(TargetName::new(".").is_err());
+        assert!(TargetName::new("..").is_err());
+    }
+
+    #[test]
+    fn target_name_rejects_whitespace() {
+        assert!(TargetName::new("  ").is_err());
+        assert!(TargetName::new(" leading").is_err());
+        assert!(TargetName::new("trailing ").is_err());
     }
 
     #[test]

--- a/crates/tome/src/discover.rs
+++ b/crates/tome/src/discover.rs
@@ -36,6 +36,14 @@ impl SkillName {
         let name = name.into();
         anyhow::ensure!(!name.is_empty(), "skill name cannot be empty");
         anyhow::ensure!(
+            name != "." && name != "..",
+            "skill name cannot be '.' or '..'"
+        );
+        anyhow::ensure!(
+            !name.chars().all(|c| c.is_whitespace()) && name.trim() == name,
+            "skill name cannot be whitespace-only or have leading/trailing whitespace: '{name}'"
+        );
+        anyhow::ensure!(
             !name.contains('/') && !name.contains('\\'),
             "skill name contains path separator: '{name}'"
         );
@@ -714,6 +722,19 @@ mod tests {
         assert_eq!(name.as_str(), "my-skill-123");
         assert_eq!(name.to_string(), "my-skill-123");
         assert_eq!(name, *"my-skill-123");
+    }
+
+    #[test]
+    fn skill_name_rejects_dot_special() {
+        assert!(SkillName::new(".").is_err());
+        assert!(SkillName::new("..").is_err());
+    }
+
+    #[test]
+    fn skill_name_rejects_whitespace() {
+        assert!(SkillName::new("  ").is_err());
+        assert!(SkillName::new(" leading").is_err());
+        assert!(SkillName::new("trailing ").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Reject `.`, `..` in both `TargetName` and `SkillName` (path traversal risk)
- Reject whitespace-only and leading/trailing whitespace names
- Add unit tests for all new validation cases

Closes #289