### PR TITLE
refactor: extract warning helper + add missing tests

### DIFF
--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -739,6 +739,42 @@ mod tests {
     }
 
     #[test]
+    fn repair_library_uses_tome_home_for_manifest() {
+        // Verify that repair_library reads the manifest from tome_home
+        // and operates on the separate library_dir.
+        let tome_home = TempDir::new().unwrap();
+        let library = TempDir::new().unwrap();
+
+        // Create a manifest at tome_home with an orphan entry (no dir in library)
+        let mut m = manifest::Manifest::default();
+        m.insert(
+            crate::discover::SkillName::new("orphan-skill").unwrap(),
+            manifest::SkillEntry {
+                source_path: PathBuf::from("/tmp/source/orphan-skill"),
+                source_name: "test".to_string(),
+                content_hash: "abc".to_string(),
+                synced_at: "2024-01-01T00:00:00Z".to_string(),
+                managed: false,
+            },
+        );
+        manifest::save(&m, tome_home.path()).unwrap();
+
+        // Repair should read manifest from tome_home and check library_dir
+        repair_library(&TomePaths::new(
+            tome_home.path().to_path_buf(),
+            library.path().to_path_buf(),
+        ))
+        .unwrap();
+
+        // The orphan entry should be removed from the manifest at tome_home
+        let after = manifest::load(tome_home.path()).unwrap();
+        assert!(
+            !after.contains_key("orphan-skill"),
+            "repair should remove orphan manifest entry when using separate tome_home"
+        );
+    }
+
+    #[test]
     fn repair_library_removes_orphan_manifest_entry() {
         let lib = TempDir::new().unwrap();
 

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -174,6 +174,19 @@ pub fn run(cli: Cli) -> Result<()> {
     Ok(())
 }
 
+/// Warn about `disabled_targets` entries in machine.toml that don't match any
+/// configured target name. Helps catch typos and stale entries.
+fn warn_unknown_disabled_targets(machine_prefs: &machine::MachinePrefs, config: &Config) {
+    for name in &machine_prefs.disabled_targets {
+        if !config.targets.contains_key(name.as_str()) {
+            eprintln!(
+                "warning: disabled target '{}' in machine.toml does not match any configured target",
+                name
+            );
+        }
+    }
+}
+
 /// The core sync pipeline: discover → consolidate → distribute → cleanup.
 fn sync(
     config: &Config,
@@ -240,14 +253,7 @@ fn sync(
 
     // Warn about disabled_targets that don't match any configured target
     if !quiet {
-        for name in &machine_prefs.disabled_targets {
-            if !config.targets.contains_key(name.as_str()) {
-                eprintln!(
-                    "warning: disabled target '{}' in machine.toml does not match any configured target",
-                    name
-                );
-            }
-        }
+        warn_unknown_disabled_targets(&machine_prefs, config);
     }
 
     // 3. Distribute to targets
@@ -376,14 +382,7 @@ fn update_cmd(
 
     // Warn about disabled_targets that don't match any configured target
     if !quiet {
-        for name in &machine_prefs.disabled_targets {
-            if !config.targets.contains_key(name.as_str()) {
-                eprintln!(
-                    "warning: disabled target '{}' in machine.toml does not match any configured target",
-                    name
-                );
-            }
-        }
+        warn_unknown_disabled_targets(&machine_prefs, config);
     }
 
     // 1. Load existing lockfile (may be committed by another machine)

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -1174,3 +1174,51 @@ fn sync_respects_machine_disabled_targets() {
     // The skill should still be in the library
     assert!(tmp.path().join("library/my-skill").is_dir());
 }
+
+#[test]
+fn update_warns_unknown_disabled_targets() {
+    // Test that `tome update` warns about disabled_targets in machine.toml
+    // that don't match any configured target.
+    let tmp = TempDir::new().unwrap();
+    let skills_dir = tmp.path().join("skills");
+    create_skill(&skills_dir, "my-skill");
+
+    let target_dir = tmp.path().join("target");
+
+    let config = write_config_with_target(
+        tmp.path(),
+        &format!(
+            "[[sources]]\nname = \"test\"\npath = \"{}\"\ntype = \"directory\"\n",
+            skills_dir.display()
+        ),
+        &target_dir,
+    );
+
+    // Initial sync so library and lockfile exist
+    tome()
+        .args(["--config", config.to_str().unwrap(), "sync"])
+        .assert()
+        .success();
+
+    // Create machine.toml with an unknown disabled target
+    let machine_path = tmp.path().join("machine.toml");
+    std::fs::write(
+        &machine_path,
+        "disabled_targets = [\"nonexistent-target\"]\n",
+    )
+    .unwrap();
+
+    tome()
+        .args([
+            "--config",
+            config.to_str().unwrap(),
+            "--machine",
+            machine_path.to_str().unwrap(),
+            "update",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "warning: disabled target 'nonexistent-target' in machine.toml does not match any configured target",
+        ));
+}


### PR DESCRIPTION
## Summary
- Extract `warn_unknown_disabled_targets()` helper to DRY up duplicated warning loop in `sync()` and `update_cmd()`
- Add integration test `update_warns_unknown_disabled_targets` in `cli.rs`
- Add `repair_library_uses_tome_home_for_manifest` unit test in `doctor.rs`

Closes #290