### PR TITLE
refactor: harden TomePaths

### DIFF
--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -54,7 +54,7 @@ impl DoctorReport {
 
 /// Run all diagnostic checks and return a structured report.
 pub fn check(config: &Config, paths: &TomePaths) -> Result<DoctorReport> {
-    let configured = paths.library_dir.is_dir() || !config.sources.is_empty();
+    let configured = paths.library_dir().is_dir() || !config.sources.is_empty();
 
     if !configured {
         return Ok(DoctorReport {
@@ -70,7 +70,7 @@ pub fn check(config: &Config, paths: &TomePaths) -> Result<DoctorReport> {
     let mut target_issues = Vec::new();
     for (name, t) in config.targets.iter() {
         if t.enabled {
-            let issues = check_target_dir(name.as_str(), t.skills_dir(), &paths.library_dir)?;
+            let issues = check_target_dir(name.as_str(), t.skills_dir(), paths.library_dir())?;
             target_issues.push((name.as_str().to_string(), issues));
         }
     }
@@ -140,7 +140,7 @@ pub fn diagnose(config: &Config, paths: &TomePaths, dry_run: bool) -> Result<()>
                 for (name, t) in config.targets.iter() {
                     if t.enabled {
                         let removed =
-                            cleanup::cleanup_target(t.skills_dir(), &paths.library_dir, false)?;
+                            cleanup::cleanup_target(t.skills_dir(), paths.library_dir(), false)?;
                         if removed > 0 {
                             println!(
                                 "  {} Removed {} stale symlink(s) from {}",
@@ -191,8 +191,8 @@ fn render_issues_for_target(name: &str, issues: &[DiagnosticIssue]) {
 // -- Check functions (return structured data) --
 
 fn check_library(paths: &TomePaths) -> Result<Vec<DiagnosticIssue>> {
-    let library_dir = &paths.library_dir;
-    let tome_home = &paths.tome_home;
+    let library_dir = paths.library_dir();
+    let tome_home = paths.tome_home();
     let mut issues = Vec::new();
 
     if !library_dir.is_dir() {
@@ -348,8 +348,8 @@ fn check_config(config: &Config) -> Result<Vec<DiagnosticIssue>> {
 
 /// Repair library issues: remove orphan manifest entries and broken symlinks.
 fn repair_library(paths: &TomePaths) -> Result<()> {
-    let library_dir = &paths.library_dir;
-    let tome_home = &paths.tome_home;
+    let library_dir = paths.library_dir();
+    let tome_home = paths.tome_home();
     let mut m = manifest::load(tome_home).with_context(|| {
         "cannot repair: manifest is unreadable. Back up .tome-manifest.json and run sync --force"
     })?;
@@ -426,7 +426,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let report = check(
             &config,
-            &TomePaths::new(tmp.path().to_path_buf(), config.library_dir.clone()),
+            &TomePaths::new(tmp.path().to_path_buf(), config.library_dir.clone()).unwrap(),
         )
         .unwrap();
         assert!(!report.configured);
@@ -459,7 +459,7 @@ mod tests {
 
         let report = check(
             &config,
-            &TomePaths::new(lib.path().to_path_buf(), config.library_dir.clone()),
+            &TomePaths::new(lib.path().to_path_buf(), config.library_dir.clone()).unwrap(),
         )
         .unwrap();
         assert!(report.configured);
@@ -478,7 +478,7 @@ mod tests {
 
         let report = check(
             &config,
-            &TomePaths::new(lib.path().to_path_buf(), config.library_dir.clone()),
+            &TomePaths::new(lib.path().to_path_buf(), config.library_dir.clone()).unwrap(),
         )
         .unwrap();
         assert_eq!(report.library_issues.len(), 1);
@@ -502,7 +502,7 @@ mod tests {
 
         let report = check(
             &config,
-            &TomePaths::new(lib.path().to_path_buf(), config.library_dir.clone()),
+            &TomePaths::new(lib.path().to_path_buf(), config.library_dir.clone()).unwrap(),
         )
         .unwrap();
         assert_eq!(report.config_issues.len(), 1);
@@ -514,10 +514,13 @@ mod tests {
     #[test]
     fn check_library_missing_dir() {
         let tmp = TempDir::new().unwrap();
-        let result = check_library(&TomePaths::new(
-            tmp.path().to_path_buf(),
-            Path::new("/nonexistent/library").to_path_buf(),
-        ))
+        let result = check_library(
+            &TomePaths::new(
+                tmp.path().to_path_buf(),
+                Path::new("/nonexistent/library").to_path_buf(),
+            )
+            .unwrap(),
+        )
         .unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].severity, IssueSeverity::Warning);
@@ -542,10 +545,9 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        let result = check_library(&TomePaths::new(
-            lib.path().to_path_buf(),
-            lib.path().to_path_buf(),
-        ))
+        let result = check_library(
+            &TomePaths::new(lib.path().to_path_buf(), lib.path().to_path_buf()).unwrap(),
+        )
         .unwrap();
         assert!(result.is_empty());
     }
@@ -567,10 +569,9 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        let result = check_library(&TomePaths::new(
-            lib.path().to_path_buf(),
-            lib.path().to_path_buf(),
-        ))
+        let result = check_library(
+            &TomePaths::new(lib.path().to_path_buf(), lib.path().to_path_buf()).unwrap(),
+        )
         .unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].severity, IssueSeverity::Error);
@@ -581,10 +582,9 @@ mod tests {
         let lib = TempDir::new().unwrap();
         std::fs::create_dir_all(lib.path().join("orphan")).unwrap();
 
-        let result = check_library(&TomePaths::new(
-            lib.path().to_path_buf(),
-            lib.path().to_path_buf(),
-        ))
+        let result = check_library(
+            &TomePaths::new(lib.path().to_path_buf(), lib.path().to_path_buf()).unwrap(),
+        )
         .unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].severity, IssueSeverity::Warning);
@@ -595,10 +595,9 @@ mod tests {
         let lib = TempDir::new().unwrap();
         unix_fs::symlink("/nonexistent/target", lib.path().join("broken")).unwrap();
 
-        let result = check_library(&TomePaths::new(
-            lib.path().to_path_buf(),
-            lib.path().to_path_buf(),
-        ))
+        let result = check_library(
+            &TomePaths::new(lib.path().to_path_buf(), lib.path().to_path_buf()).unwrap(),
+        )
         .unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].severity, IssueSeverity::Error);
@@ -682,7 +681,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let result = diagnose(
             &config,
-            &TomePaths::new(tmp.path().to_path_buf(), config.library_dir.clone()),
+            &TomePaths::new(tmp.path().to_path_buf(), config.library_dir.clone()).unwrap(),
             true,
         );
         assert!(result.is_ok());
@@ -714,10 +713,9 @@ mod tests {
         manifest::save(&m, tome_home.path()).unwrap();
 
         // check_library should read manifest from tome_home, not library_dir
-        let issues = check_library(&TomePaths::new(
-            tome_home.path().to_path_buf(),
-            library.path().to_path_buf(),
-        ))
+        let issues = check_library(
+            &TomePaths::new(tome_home.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
+        )
         .unwrap();
         assert!(
             issues.is_empty(),
@@ -726,10 +724,9 @@ mod tests {
 
         // Verify it would fail if we pointed tome_home at the wrong place
         // (library_dir has no manifest, so it loads an empty one and sees an orphan)
-        let issues = check_library(&TomePaths::new(
-            library.path().to_path_buf(),
-            library.path().to_path_buf(),
-        ))
+        let issues = check_library(
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
+        )
         .unwrap();
         assert_eq!(
             issues.len(),
@@ -756,10 +753,9 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        repair_library(&TomePaths::new(
-            lib.path().to_path_buf(),
-            lib.path().to_path_buf(),
-        ))
+        repair_library(
+            &TomePaths::new(lib.path().to_path_buf(), lib.path().to_path_buf()).unwrap(),
+        )
         .unwrap();
 
         let after = manifest::load(lib.path()).unwrap();
@@ -788,10 +784,9 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        repair_library(&TomePaths::new(
-            lib.path().to_path_buf(),
-            lib.path().to_path_buf(),
-        ))
+        repair_library(
+            &TomePaths::new(lib.path().to_path_buf(), lib.path().to_path_buf()).unwrap(),
+        )
         .unwrap();
 
         assert!(
@@ -809,10 +804,9 @@ mod tests {
         // Broken legacy symlink (not in manifest)
         unix_fs::symlink("/nonexistent/v01/skill", lib.path().join("legacy")).unwrap();
 
-        repair_library(&TomePaths::new(
-            lib.path().to_path_buf(),
-            lib.path().to_path_buf(),
-        ))
+        repair_library(
+            &TomePaths::new(lib.path().to_path_buf(), lib.path().to_path_buf()).unwrap(),
+        )
         .unwrap();
 
         assert!(
@@ -840,10 +834,9 @@ mod tests {
         );
         manifest::save(&m, lib.path()).unwrap();
 
-        repair_library(&TomePaths::new(
-            lib.path().to_path_buf(),
-            lib.path().to_path_buf(),
-        ))
+        repair_library(
+            &TomePaths::new(lib.path().to_path_buf(), lib.path().to_path_buf()).unwrap(),
+        )
         .unwrap();
 
         let after = manifest::load(lib.path()).unwrap();

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -113,7 +113,7 @@ pub fn run(cli: Cli) -> Result<()> {
         let config = wizard::run(cli.dry_run)?;
         config.validate()?;
         if !cli.dry_run {
-            let paths = TomePaths::new(tome_home, config.library_dir.clone());
+            let paths = TomePaths::new(tome_home, config.library_dir.clone())?;
             sync(
                 &config,
                 &paths,
@@ -130,7 +130,7 @@ pub fn run(cli: Cli) -> Result<()> {
     let config = Config::load_or_default(cli.config.as_deref())?;
     config.validate()?;
     let tome_home = resolve_tome_home(cli.config.as_deref())?;
-    let paths = TomePaths::new(tome_home, config.library_dir.clone());
+    let paths = TomePaths::new(tome_home, config.library_dir.clone())?;
 
     match cli.command {
         Command::Init => unreachable!(),
@@ -271,7 +271,7 @@ fn sync(
             eprintln!("{}", style(format!("Distributing to {}...", name)).dim());
         }
         let result = distribute::distribute_to_target(
-            &paths.library_dir,
+            paths.library_dir(),
             name.as_str(),
             target,
             &manifest,
@@ -291,7 +291,7 @@ fn sync(
         eprintln!("{}", style("Cleaning up stale entries...").dim());
     }
     let cleanup_result = cleanup::cleanup_library(
-        &paths.library_dir,
+        paths.library_dir(),
         &discovered_names,
         &mut manifest,
         dry_run,
@@ -301,25 +301,25 @@ fn sync(
     let mut removed_from_targets = 0usize;
     for (_name, target) in config.targets.iter() {
         let skills_dir = target.skills_dir();
-        removed_from_targets += cleanup::cleanup_target(skills_dir, &paths.library_dir, dry_run)?;
+        removed_from_targets += cleanup::cleanup_target(skills_dir, paths.library_dir(), dry_run)?;
         // Also clean up symlinks for disabled skills
         removed_from_targets +=
-            cleanup_disabled_from_target(skills_dir, &paths.library_dir, &machine_prefs, dry_run)?;
+            cleanup_disabled_from_target(skills_dir, paths.library_dir(), &machine_prefs, dry_run)?;
     }
     // Save manifest after cleanup (may have removed entries)
-    if !dry_run && paths.tome_home.is_dir() {
-        manifest::save(&manifest, &paths.tome_home)?;
+    if !dry_run && paths.tome_home().is_dir() {
+        manifest::save(&manifest, paths.tome_home())?;
     }
 
     // Generate .gitignore after cleanup so stale entries are excluded
-    if !dry_run && paths.library_dir.is_dir() {
-        library::generate_gitignore(&paths.library_dir, &manifest)?;
+    if !dry_run && paths.library_dir().is_dir() {
+        library::generate_gitignore(paths.library_dir(), &manifest)?;
     }
 
     // Generate lockfile for reproducibility
-    if !dry_run && paths.tome_home.is_dir() {
+    if !dry_run && paths.tome_home().is_dir() {
         let lf = lockfile::generate(&manifest, &skills);
-        lockfile::save(&lf, &paths.tome_home)?;
+        lockfile::save(&lf, paths.tome_home())?;
     }
 
     if let Some(sp) = sp {
@@ -341,7 +341,7 @@ fn sync(
     // Offer git commit if the library dir is a git repo with changes
     if !dry_run && !quiet {
         offer_git_commit(
-            &paths.library_dir,
+            paths.library_dir(),
             &manifest,
             report.consolidate.created,
             report.consolidate.updated,
@@ -387,7 +387,7 @@ fn update_cmd(
     }
 
     // 1. Load existing lockfile (may be committed by another machine)
-    let old_lockfile = lockfile::load(&paths.tome_home)?;
+    let old_lockfile = lockfile::load(paths.tome_home())?;
 
     // 2. Discover
     let sp = show_progress.then(|| spinner("Discovering skills..."));
@@ -475,7 +475,7 @@ fn update_cmd(
             eprintln!("{}", style(format!("Distributing to {}...", name)).dim());
         }
         let result = distribute::distribute_to_target(
-            &paths.library_dir,
+            paths.library_dir(),
             name.as_str(),
             target,
             &manifest,
@@ -495,7 +495,7 @@ fn update_cmd(
         eprintln!("{}", style("Cleaning up stale entries...").dim());
     }
     let cleanup_result = cleanup::cleanup_library(
-        &paths.library_dir,
+        paths.library_dir(),
         &discovered_names,
         &mut manifest,
         dry_run,
@@ -505,10 +505,10 @@ fn update_cmd(
     let mut removed_from_targets = 0usize;
     for (_name, target) in config.targets.iter() {
         let skills_dir = target.skills_dir();
-        removed_from_targets += cleanup::cleanup_target(skills_dir, &paths.library_dir, dry_run)?;
+        removed_from_targets += cleanup::cleanup_target(skills_dir, paths.library_dir(), dry_run)?;
         // Also clean up symlinks for disabled skills
         removed_from_targets +=
-            cleanup_disabled_from_target(skills_dir, &paths.library_dir, &machine_prefs, dry_run)?;
+            cleanup_disabled_from_target(skills_dir, paths.library_dir(), &machine_prefs, dry_run)?;
     }
 
     if let Some(sp) = sp {
@@ -516,12 +516,12 @@ fn update_cmd(
     }
 
     // 7. Save lockfile + manifest
-    if !dry_run && paths.tome_home.is_dir() {
-        manifest::save(&manifest, &paths.tome_home)?;
-        if paths.library_dir.is_dir() {
-            library::generate_gitignore(&paths.library_dir, &manifest)?;
+    if !dry_run && paths.tome_home().is_dir() {
+        manifest::save(&manifest, paths.tome_home())?;
+        if paths.library_dir().is_dir() {
+            library::generate_gitignore(paths.library_dir(), &manifest)?;
         }
-        lockfile::save(&new_lockfile, &paths.tome_home)?;
+        lockfile::save(&new_lockfile, paths.tome_home())?;
     }
 
     let report = SyncReport {
@@ -539,7 +539,7 @@ fn update_cmd(
     // Offer git commit if the library dir is a git repo with changes
     if !dry_run && !quiet {
         offer_git_commit(
-            &paths.library_dir,
+            paths.library_dir(),
             &manifest,
             report.consolidate.created,
             report.consolidate.updated,

--- a/crates/tome/src/library.rs
+++ b/crates/tome/src/library.rs
@@ -84,8 +84,8 @@ pub fn consolidate(
     dry_run: bool,
     force: bool,
 ) -> Result<(ConsolidateResult, Manifest)> {
-    let library_dir = &paths.library_dir;
-    let tome_home = &paths.tome_home;
+    let library_dir = paths.library_dir();
+    let tome_home = paths.tome_home();
 
     if !dry_run {
         std::fs::create_dir_all(library_dir)
@@ -404,7 +404,7 @@ mod tests {
 
         let (result, _manifest) = consolidate(
             &[skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -426,14 +426,14 @@ mod tests {
 
         consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
         .unwrap();
         let (result, _manifest) = consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -450,14 +450,14 @@ mod tests {
 
         consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
         .unwrap();
         let (result, _manifest) = consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             true,
         )
@@ -474,7 +474,7 @@ mod tests {
 
         consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -485,7 +485,7 @@ mod tests {
 
         let (result, _manifest) = consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -505,7 +505,7 @@ mod tests {
 
         let (result, _manifest) = consolidate(
             &[skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             true,
             false,
         )
@@ -525,7 +525,7 @@ mod tests {
 
         let (result, _manifest) = consolidate(
             &[skill],
-            &TomePaths::new(nonexistent_lib.to_path_buf(), nonexistent_lib.to_path_buf()),
+            &TomePaths::new(nonexistent_lib.to_path_buf(), nonexistent_lib.to_path_buf()).unwrap(),
             true,
             false,
         )
@@ -548,7 +548,7 @@ mod tests {
 
         let (result, _manifest) = consolidate(
             &[skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -578,7 +578,7 @@ mod tests {
 
         let (result, _manifest) = consolidate(
             &[skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -605,7 +605,7 @@ mod tests {
         let skill1 = make_skill(source1.path(), "my-skill");
         consolidate(
             &[skill1],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -625,7 +625,7 @@ mod tests {
 
         let (result, _manifest) = consolidate(
             std::slice::from_ref(&skill2),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -644,7 +644,7 @@ mod tests {
 
         let (_, manifest) = consolidate(
             &[skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -673,7 +673,7 @@ mod tests {
 
         let (result, _manifest) = consolidate(
             &[skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -707,7 +707,7 @@ mod tests {
 
         let (result, _) = consolidate(
             &[skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -734,7 +734,7 @@ mod tests {
 
         let (result, _) = consolidate(
             &[skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             true,
             false,
         )
@@ -756,7 +756,7 @@ mod tests {
         let local_skill = make_skill(source.path(), "my-skill");
         consolidate(
             &[local_skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -766,7 +766,7 @@ mod tests {
         let managed_skill = make_managed_skill(source.path(), "my-skill");
         let (result, manifest) = consolidate(
             &[managed_skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             true,
             false,
         )
@@ -797,7 +797,7 @@ mod tests {
 
         let (_, manifest) = consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -821,7 +821,7 @@ mod tests {
 
         let (result, manifest) = consolidate(
             &[skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -844,14 +844,14 @@ mod tests {
 
         consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
         .unwrap();
         let (result, _) = consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -870,7 +870,7 @@ mod tests {
         let skill1 = make_managed_skill(source1.path(), "plugin-skill");
         consolidate(
             &[skill1],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -880,7 +880,7 @@ mod tests {
         let skill2 = make_managed_skill(source2.path(), "plugin-skill");
         let (result, _) = consolidate(
             std::slice::from_ref(&skill2),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -903,7 +903,7 @@ mod tests {
         let local_skill = make_skill(source.path(), "my-skill");
         consolidate(
             &[local_skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -916,7 +916,7 @@ mod tests {
         let managed_skill = make_managed_skill(source.path(), "my-skill");
         let (result, manifest) = consolidate(
             &[managed_skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -935,7 +935,7 @@ mod tests {
         let managed_skill = make_managed_skill(source.path(), "my-skill");
         consolidate(
             &[managed_skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -947,7 +947,7 @@ mod tests {
         let local_skill = make_skill(source.path(), "my-skill");
         let (result, manifest) = consolidate(
             &[local_skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -966,7 +966,7 @@ mod tests {
 
         let (_, manifest) = consolidate(
             &[skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -988,7 +988,7 @@ mod tests {
 
         let (_, manifest) = consolidate(
             &[managed, local],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -1012,7 +1012,7 @@ mod tests {
 
         let (_, manifest) = consolidate(
             &[managed, local],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -1034,7 +1034,7 @@ mod tests {
         let managed = make_managed_skill(source.path(), "plugin-a");
         let (_, manifest) = consolidate(
             &[managed],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -1060,7 +1060,7 @@ mod tests {
 
         let (result, manifest) = consolidate(
             &[skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             true,
             false,
         )
@@ -1085,14 +1085,14 @@ mod tests {
 
         consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
         .unwrap();
         let (result, _) = consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             true,
         )
@@ -1113,7 +1113,7 @@ mod tests {
         // First: consolidate normally (creates symlink)
         consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -1133,7 +1133,7 @@ mod tests {
         // Re-consolidate — should repair by replacing dir with symlink
         let (result, _) = consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -1157,7 +1157,7 @@ mod tests {
 
         let (result, _) = consolidate(
             &[skill],
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -1179,7 +1179,7 @@ mod tests {
 
         let (_, manifest1) = consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -1191,7 +1191,7 @@ mod tests {
 
         let (result, manifest2) = consolidate(
             std::slice::from_ref(&skill),
-            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(library.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )
@@ -1216,7 +1216,7 @@ mod tests {
 
         let (result, _manifest) = consolidate(
             &[skill],
-            &TomePaths::new(tome_home.path().to_path_buf(), library.path().to_path_buf()),
+            &TomePaths::new(tome_home.path().to_path_buf(), library.path().to_path_buf()).unwrap(),
             false,
             false,
         )

--- a/crates/tome/src/lockfile.rs
+++ b/crates/tome/src/lockfile.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::discover::DiscoveredSkill;
 use crate::manifest::Manifest;
 
-const LOCKFILE_NAME: &str = "tome.lock";
+pub(crate) const LOCKFILE_NAME: &str = "tome.lock";
 
 /// Top-level lockfile structure.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/crates/tome/src/manifest.rs
+++ b/crates/tome/src/manifest.rs
@@ -14,7 +14,7 @@ use walkdir::WalkDir;
 
 use crate::discover::SkillName;
 
-const MANIFEST_FILENAME: &str = ".tome-manifest.json";
+pub(crate) const MANIFEST_FILENAME: &str = ".tome-manifest.json";
 
 /// The library manifest, tracking all skills and their provenance.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/tome/src/paths.rs
+++ b/crates/tome/src/paths.rs
@@ -5,6 +5,8 @@
 
 use std::path::{Path, PathBuf};
 
+use anyhow::Result;
+
 /// Resolved filesystem paths for a tome instance.
 ///
 /// Groups `tome_home` (metadata directory, `~/.tome/`) and `library_dir`
@@ -14,28 +16,56 @@ use std::path::{Path, PathBuf};
 pub struct TomePaths {
     /// Top-level directory for metadata (manifest, lockfile, config).
     /// Typically `~/.tome/`.
-    pub tome_home: PathBuf,
+    tome_home: PathBuf,
     /// Directory where skill contents are stored.
     /// Typically `~/.tome/skills/`.
-    pub library_dir: PathBuf,
+    library_dir: PathBuf,
 }
 
 impl TomePaths {
-    pub fn new(tome_home: PathBuf, library_dir: PathBuf) -> Self {
-        Self {
+    pub fn new(tome_home: PathBuf, library_dir: PathBuf) -> Result<Self> {
+        anyhow::ensure!(
+            !tome_home.as_os_str().is_empty(),
+            "tome_home path cannot be empty"
+        );
+        anyhow::ensure!(
+            !library_dir.as_os_str().is_empty(),
+            "library_dir path cannot be empty"
+        );
+        anyhow::ensure!(
+            tome_home.is_absolute(),
+            "tome_home must be an absolute path: {}",
+            tome_home.display()
+        );
+        anyhow::ensure!(
+            library_dir.is_absolute(),
+            "library_dir must be an absolute path: {}",
+            library_dir.display()
+        );
+        Ok(Self {
             tome_home,
             library_dir,
-        }
+        })
+    }
+
+    /// Returns the tome home directory path.
+    pub fn tome_home(&self) -> &Path {
+        &self.tome_home
+    }
+
+    /// Returns the library directory path.
+    pub fn library_dir(&self) -> &Path {
+        &self.library_dir
     }
 
     /// Path to the manifest file.
     pub fn manifest_path(&self) -> PathBuf {
-        self.tome_home.join(".tome-manifest.json")
+        self.tome_home.join(crate::manifest::MANIFEST_FILENAME)
     }
 
     /// Path to the lockfile.
     pub fn lockfile_path(&self) -> PathBuf {
-        self.tome_home.join("tome.lock")
+        self.tome_home.join(crate::lockfile::LOCKFILE_NAME)
     }
 }
 
@@ -142,9 +172,10 @@ mod tests {
         let paths = TomePaths::new(
             PathBuf::from("/home/.tome"),
             PathBuf::from("/home/.tome/skills"),
-        );
-        assert_eq!(paths.tome_home, PathBuf::from("/home/.tome"));
-        assert_eq!(paths.library_dir, PathBuf::from("/home/.tome/skills"));
+        )
+        .unwrap();
+        assert_eq!(paths.tome_home(), Path::new("/home/.tome"));
+        assert_eq!(paths.library_dir(), Path::new("/home/.tome/skills"));
     }
 
     #[test]
@@ -152,7 +183,8 @@ mod tests {
         let paths = TomePaths::new(
             PathBuf::from("/home/.tome"),
             PathBuf::from("/home/.tome/skills"),
-        );
+        )
+        .unwrap();
         assert_eq!(
             paths.manifest_path(),
             PathBuf::from("/home/.tome/.tome-manifest.json")
@@ -164,10 +196,71 @@ mod tests {
         let paths = TomePaths::new(
             PathBuf::from("/home/.tome"),
             PathBuf::from("/home/.tome/skills"),
-        );
+        )
+        .unwrap();
         assert_eq!(
             paths.lockfile_path(),
             PathBuf::from("/home/.tome/tome.lock")
         );
+    }
+
+    #[test]
+    fn tome_paths_rejects_empty_tome_home() {
+        let result = TomePaths::new(PathBuf::from(""), PathBuf::from("/home/.tome/skills"));
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("tome_home path cannot be empty")
+        );
+    }
+
+    #[test]
+    fn tome_paths_rejects_empty_library_dir() {
+        let result = TomePaths::new(PathBuf::from("/home/.tome"), PathBuf::from(""));
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("library_dir path cannot be empty")
+        );
+    }
+
+    #[test]
+    fn tome_paths_rejects_relative_tome_home() {
+        let result = TomePaths::new(
+            PathBuf::from("relative/path"),
+            PathBuf::from("/home/.tome/skills"),
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("tome_home must be an absolute path")
+        );
+    }
+
+    #[test]
+    fn tome_paths_rejects_relative_library_dir() {
+        let result = TomePaths::new(PathBuf::from("/home/.tome"), PathBuf::from("relative/path"));
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("library_dir must be an absolute path")
+        );
+    }
+
+    #[test]
+    fn tome_paths_accepts_both_absolute() {
+        let result = TomePaths::new(
+            PathBuf::from("/home/.tome"),
+            PathBuf::from("/home/.tome/skills"),
+        );
+        assert!(result.is_ok());
     }
 }

--- a/crates/tome/src/status.rs
+++ b/crates/tome/src/status.rs
@@ -44,10 +44,10 @@ pub struct StatusReport {
 
 /// Gather status data without producing any output.
 pub fn gather(config: &Config, paths: &TomePaths) -> Result<StatusReport> {
-    let configured = paths.library_dir.is_dir() || !config.sources.is_empty();
+    let configured = paths.library_dir().is_dir() || !config.sources.is_empty();
 
-    let library_count = if paths.library_dir.is_dir() {
-        count_entries(&paths.library_dir).map_err(|e| e.to_string())
+    let library_count = if paths.library_dir().is_dir() {
+        count_entries(paths.library_dir()).map_err(|e| e.to_string())
     } else {
         Ok(0)
     };
@@ -83,15 +83,15 @@ pub fn gather(config: &Config, paths: &TomePaths) -> Result<StatusReport> {
         })
         .collect();
 
-    let health = if paths.library_dir.is_dir() {
-        count_health_issues(&paths.library_dir, &paths.tome_home).map_err(|e| e.to_string())
+    let health = if paths.library_dir().is_dir() {
+        count_health_issues(paths.library_dir(), paths.tome_home()).map_err(|e| e.to_string())
     } else {
         Ok(0)
     };
 
     Ok(StatusReport {
         configured,
-        library_dir: paths.library_dir.clone(),
+        library_dir: paths.library_dir().to_path_buf(),
         library_count,
         sources,
         targets,
@@ -283,7 +283,7 @@ mod tests {
 
         let report = gather(
             &config,
-            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()).unwrap(),
         )
         .unwrap();
         assert!(!report.configured);
@@ -307,7 +307,7 @@ mod tests {
 
         let report = gather(
             &config,
-            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()).unwrap(),
         )
         .unwrap();
         assert!(report.configured);
@@ -330,7 +330,7 @@ mod tests {
 
         let report = gather(
             &config,
-            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()).unwrap(),
         )
         .unwrap();
         assert!(report.configured);
@@ -361,7 +361,7 @@ mod tests {
 
         let report = gather(
             &config,
-            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()).unwrap(),
         )
         .unwrap();
         assert_eq!(report.targets.len(), 1);
@@ -382,7 +382,7 @@ mod tests {
 
         let report = gather(
             &config,
-            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()).unwrap(),
         )
         .unwrap();
         assert_eq!(report.health.unwrap(), 1);
@@ -399,7 +399,7 @@ mod tests {
 
         let result = show(
             &config,
-            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()).unwrap(),
         );
         assert!(result.is_ok());
     }
@@ -420,7 +420,7 @@ mod tests {
 
         let result = show(
             &config,
-            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()).unwrap(),
         );
         assert!(result.is_ok());
     }
@@ -465,7 +465,7 @@ mod tests {
 
         let result = show(
             &config,
-            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()),
+            &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()).unwrap(),
         );
         assert!(result.is_ok());
     }


### PR DESCRIPTION
## Summary
- Private fields with `tome_home()` / `library_dir()` accessors returning `&Path`
- Constructor validates non-empty + absolute paths, returns `Result`
- Import `MANIFEST_FILENAME` and `LOCKFILE_NAME` constants from `manifest.rs` / `lockfile.rs` instead of duplicating string literals
- Unit tests for all validation error cases

Closes #288