### PR TITLE
fix: correct `tome config` help text

### DIFF
--- a/crates/tome/src/cli.rs
+++ b/crates/tome/src/cli.rs
@@ -67,7 +67,7 @@ pub enum Command {
     /// Interactively browse discovered skills
     Browse,
 
-    /// Show or edit configuration
+    /// Show configuration
     Config {
         /// Print config file path only
         #[arg(long)]


### PR DESCRIPTION
Closes #258

Updates the `tome config` subcommand doc comment from "Show or edit configuration" to "Show configuration", since `tome config` is read-only and does not support editing.