### PR TITLE
fix: apply tilde expansion in config test

### DIFF
--- a/crates/tome/src/config.rs
+++ b/crates/tome/src/config.rs
@@ -677,10 +677,22 @@ enabled = true
 method = "symlink"
 skills_dir = "~/.claude/skills"
 "#;
-        let config: Config = toml::from_str(toml_str).unwrap();
+        let mut config: Config = toml::from_str(toml_str).unwrap();
+        config.expand_tildes().unwrap();
         let claude = config.targets.get("claude").expect("claude target missing");
         assert!(claude.enabled);
-        assert_eq!(claude.skills_dir(), Path::new("~/.claude/skills"));
+        let home = dirs::home_dir().expect("home dir not found");
+        assert!(
+            claude.skills_dir().starts_with(&home),
+            "Expected skills_dir to start with home dir {:?}, got {:?}",
+            home,
+            claude.skills_dir()
+        );
+        assert!(
+            claude.skills_dir().ends_with(".claude/skills"),
+            "Expected skills_dir to end with .claude/skills, got {:?}",
+            claude.skills_dir()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix `config_parses_arbitrary_target_name` test to actually verify tilde expansion works
- The test was using `toml::from_str()` which skips `expand_tildes()`, then asserting `skills_dir()` equals the literal `"~/.amp/skills"` — meaning the tilde was never expanded
- Now calls `config.expand_tildes()` after parsing and asserts the resolved path starts with the user's home directory and ends with `.amp/skills`

Closes #207

## Test plan

- [x] `cargo test config_parses_arbitrary` passes
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes