### PR TITLE
fix: sort tome list output by name for deterministic ordering

### DIFF
--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -653,7 +653,8 @@ fn render_sync_report(report: &SyncReport) {
 /// List all discovered skills.
 fn list(config: &Config, quiet: bool, json: bool) -> Result<()> {
     let mut warnings = Vec::new();
-    let skills = discover::discover_all(config, &mut warnings)?;
+    let mut skills = discover::discover_all(config, &mut warnings)?;
+    skills.sort_by(|a, b| a.name.as_str().cmp(b.name.as_str()));
     if !quiet {
         for w in &warnings {
             eprintln!("warning: {}", w);


### PR DESCRIPTION
Closes #313

## Summary

- `tome list` now sorts skills by name before rendering (both table and JSON paths)
- Filesystem iteration order differs between macOS (APFS) and Linux (ext4), causing the `list_table_two_skills` snapshot test to fail on `ubuntu-latest` CI

## Test plan

- [x] `make ci` passes locally (36/36 tests)
- [x] CI should pass on both ubuntu and macos