### PR TITLE
fix: strip trailing whitespace in snapshots for cross-platform stability

### DIFF
--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -24,6 +24,7 @@ fn snapshot_settings(tmp: &TempDir) -> Settings {
         })
         .collect::<String>();
     settings.add_filter(&escaped, "[TMPDIR]");
+    settings.add_filter(r" +\n", "\n");
     settings.set_snapshot_path("snapshots");
     settings
 }

--- a/crates/tome/tests/snapshots/cli__list_table_two_skills.snap
+++ b/crates/tome/tests/snapshots/cli__list_table_two_skills.snap
@@ -2,8 +2,8 @@
 source: crates/tome/tests/cli.rs
 expression: stdout
 ---
- SKILL         SOURCE   PATH                                                                           
- my-skill      test     [TMPDIR]/skills/my-skill    
- other-skill   test     [TMPDIR]/skills/other-skill 
+ SKILL         SOURCE   PATH
+ my-skill      test     [TMPDIR]/skills/my-skill
+ other-skill   test     [TMPDIR]/skills/other-skill
 
 2 skill(s) total


### PR DESCRIPTION
## Summary

- `tabled` sizes table columns from the real tmpdir path before `insta` redacts it to `[TMPDIR]`
- macOS tmpdirs (`/private/var/folders/...`) are longer than Linux (`/tmp/...`), producing different trailing spaces in the header row
- Add `settings.add_filter(r" +\n", "\n")` to `snapshot_settings()` to strip trailing whitespace from all snapshots
- Update `cli__list_table_two_skills.snap` accordingly

## Test plan

- [x] 36/36 tests pass locally
- [x] Snapshot is now platform-independent