### PR TITLE
fix: correct wizard 'how it works' description for v0.2+ copy model

### DIFF
--- a/crates/tome/src/wizard.rs
+++ b/crates/tome/src/wizard.rs
@@ -20,9 +20,10 @@ pub fn run(dry_run: bool) -> Result<Config> {
     println!();
 
     println!("{}", style("How it works:").bold());
-    println!("  Tome uses symlinks — your original files are never moved or copied.");
-    println!("  The library and targets contain links pointing back to where your skills");
-    println!("  actually live. Removing tome leaves all your original files untouched.");
+    println!("  Tome copies your local skills into a central library for safekeeping.");
+    println!("  Managed skills (e.g. installed plugins) are symlinked there instead.");
+    println!("  Each target tool receives symlinks into the library — your originals");
+    println!("  are never touched. Removing tome leaves all source files untouched.");
     println!();
 
     // Step 1: Discover and select sources


### PR DESCRIPTION
## Summary

The wizard welcome screen described the sync model as pure symlinks, which was accurate before v0.2 but wrong since then:

- **Before (wrong):** "Tome uses symlinks — your original files are never moved or copied."
- **After (correct):** local skills are **copied** into the library; managed/plugin skills are **symlinked**; targets get symlinks into the library

Updated the three lines to accurately reflect the copy+symlink two-tier model.

## Test plan

- [x] No logic changed — UI text only
- [x] Docs audit confirmed all other documentation is already accurate