### PR TITLE
fix: correct codex-skills source path from .agents/skills to .codex/skills

### DIFF
--- a/crates/tome/src/wizard.rs
+++ b/crates/tome/src/wizard.rs
@@ -431,7 +431,7 @@ const KNOWN_SOURCES: &[(&str, &str, SourceType)] = &[
         SourceType::ClaudePlugins,
     ),
     ("claude-skills", ".claude/skills", SourceType::Directory),
-    ("codex-skills", ".agents/skills", SourceType::Directory),
+    ("codex-skills", ".codex/skills", SourceType::Directory),
     (
         "antigravity-skills",
         ".gemini/antigravity/skills",


### PR DESCRIPTION
## Summary

`codex-skills` was pointing to `.agents/skills`, the same path as `agents-skills`, causing `~/.agents/skills` to appear twice in the wizard source selector.

Codex CLI's home-dir discovery path is `$HOME/.agents/skills/` (covered by `agents-skills`), but Codex also maintains `~/.codex/skills/` as a distinct directory. Correcting `codex-skills` to `.codex/skills` eliminates the duplicate and adds the actual Codex-specific path.

## Test plan

- [x] 267/267 tests pass
- [x] No more duplicate entry in wizard source list