### PR TITLE
fix: improve error propagation — replace silent fallbacks with warnings and error context

### DIFF
--- a/crates/tome/src/discover.rs
+++ b/crates/tome/src/discover.rs
@@ -214,14 +214,10 @@ fn discover_claude_plugins(
     // Look for installed_plugins.json in multiple locations:
     // 1. Directly in source.path (e.g. ~/.claude/plugins/)
     // 2. Parent directory (when source.path points to cache subdir, e.g. ~/.claude/plugins/cache/)
-    let candidates = [
-        source.path.join("installed_plugins.json"),
-        source
-            .path
-            .parent()
-            .map(|p| p.join("installed_plugins.json"))
-            .unwrap_or_default(),
-    ];
+    let mut candidates = vec![source.path.join("installed_plugins.json")];
+    if let Some(parent) = source.path.parent() {
+        candidates.push(parent.join("installed_plugins.json"));
+    }
 
     for candidate in &candidates {
         if candidate.exists() {
@@ -386,7 +382,7 @@ fn scan_for_skills(
     }
 
     for entry in entries {
-        let entry = entry.unwrap();
+        let entry = entry.expect("BUG: entries vec was filtered to Ok variants by partition above");
         if entry.file_name() == "SKILL.md"
             && entry.file_type().is_file()
             && let Some(skill_dir) = entry.path().parent()

--- a/crates/tome/src/library.rs
+++ b/crates/tome/src/library.rs
@@ -294,7 +294,13 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
 
     for entry in walkdir::WalkDir::new(src).follow_links(false).into_iter() {
         let entry = entry.with_context(|| format!("failed to walk directory {}", src.display()))?;
-        let rel = entry.path().strip_prefix(src).unwrap_or(entry.path());
+        let rel = entry.path().strip_prefix(src).with_context(|| {
+            format!(
+                "BUG: WalkDir yielded path {} not under root {}",
+                entry.path().display(),
+                src.display()
+            )
+        })?;
         let target = dst.join(rel);
 
         if entry.file_type().is_dir() {

--- a/crates/tome/src/manifest.rs
+++ b/crates/tome/src/manifest.rs
@@ -147,7 +147,13 @@ pub fn hash_directory(dir: &Path) -> Result<String> {
             let rel = entry
                 .path()
                 .strip_prefix(dir)
-                .unwrap_or(entry.path())
+                .with_context(|| {
+                    format!(
+                        "BUG: WalkDir yielded path {} not under root {}",
+                        entry.path().display(),
+                        dir.display()
+                    )
+                })?
                 .to_string_lossy()
                 .to_string();
             entries.push((rel, entry.path().to_path_buf()));
@@ -174,7 +180,10 @@ pub fn now_iso8601() -> String {
     // Use std::time for a simple UTC timestamp without pulling in chrono
     let duration = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
+        .unwrap_or_else(|e| {
+            eprintln!("warning: system clock appears to be set before Unix epoch: {e}");
+            std::time::Duration::ZERO
+        });
     let secs = duration.as_secs();
 
     // Manual UTC formatting: YYYY-MM-DDTHH:MM:SSZ

--- a/crates/tome/src/paths.rs
+++ b/crates/tome/src/paths.rs
@@ -92,10 +92,26 @@ pub fn symlink_points_to(link_path: &Path, expected_target: &Path) -> bool {
         Err(_) => return false,
     };
 
-    let resolved = std::fs::canonicalize(link_path)
-        .unwrap_or_else(|_| resolve_symlink_target(link_path, &raw_target));
-    let expected =
-        std::fs::canonicalize(expected_target).unwrap_or_else(|_| expected_target.to_path_buf());
+    let resolved = std::fs::canonicalize(link_path).unwrap_or_else(|e| {
+        if link_path.exists() {
+            eprintln!(
+                "warning: could not canonicalize {}: {}",
+                link_path.display(),
+                e
+            );
+        }
+        resolve_symlink_target(link_path, &raw_target)
+    });
+    let expected = std::fs::canonicalize(expected_target).unwrap_or_else(|e| {
+        if expected_target.exists() {
+            eprintln!(
+                "warning: could not canonicalize {}: {}",
+                expected_target.display(),
+                e
+            );
+        }
+        expected_target.to_path_buf()
+    });
 
     resolved == expected
 }

--- a/crates/tome/src/wizard.rs
+++ b/crates/tome/src/wizard.rs
@@ -422,7 +422,15 @@ fn configure_exclusions(
 
     let exclude = selections
         .iter()
-        .filter_map(|&i| crate::discover::SkillName::new(labels[i].clone()).ok())
+        .filter_map(
+            |&i| match crate::discover::SkillName::new(labels[i].clone()) {
+                Ok(name) => Some(name),
+                Err(e) => {
+                    eprintln!("warning: could not parse skill name '{}': {e}", labels[i]);
+                    None
+                }
+            },
+        )
         .collect();
     println!();
     Ok(exclude)


### PR DESCRIPTION
## Summary

- **library.rs**: `copy_dir_recursive` `strip_prefix` now uses `with_context` instead of `unwrap_or`, surfacing a clear BUG message if WalkDir yields a path outside the root
- **manifest.rs**: `hash_directory` `strip_prefix` uses `with_context` instead of `unwrap_or` (same pattern)
- **manifest.rs**: `now_iso8601` warns on stderr if system clock is before Unix epoch instead of silently defaulting
- **paths.rs**: `symlink_points_to` warns on stderr for non-ENOENT canonicalize errors instead of silently falling back
- **discover.rs**: `unwrap()` on pre-partitioned vec replaced with `expect()` documenting the partition invariant
- **discover.rs**: `Path::parent().unwrap_or_default()` replaced with conditional `Vec` push (avoids empty-path sentinel)
- **wizard.rs**: `SkillName` validation errors are logged to stderr instead of silently dropped via `.ok()`

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 287 tests pass (231 unit + 56 integration)