### PR TITLE
refactor: type system improvements

### DIFF
--- a/crates/tome/src/config.rs
+++ b/crates/tome/src/config.rs
@@ -20,19 +20,7 @@ impl TargetName {
     /// Rejects empty names and names containing path separators (`/` or `\`).
     pub fn new(name: impl Into<String>) -> Result<Self> {
         let name = name.into();
-        anyhow::ensure!(!name.is_empty(), "target name cannot be empty");
-        anyhow::ensure!(
-            name != "." && name != "..",
-            "target name cannot be '.' or '..'"
-        );
-        anyhow::ensure!(
-            !name.chars().all(|c| c.is_whitespace()) && name.trim() == name,
-            "target name cannot be whitespace-only or have leading/trailing whitespace: '{name}'"
-        );
-        anyhow::ensure!(
-            !name.contains('/') && !name.contains('\\'),
-            "target name contains path separator: '{name}'"
-        );
+        crate::validation::validate_identifier(&name, "target name")?;
         Ok(Self(name))
     }
 

--- a/crates/tome/src/discover.rs
+++ b/crates/tome/src/discover.rs
@@ -34,19 +34,7 @@ impl SkillName {
     /// ```
     pub fn new(name: impl Into<String>) -> Result<Self> {
         let name = name.into();
-        anyhow::ensure!(!name.is_empty(), "skill name cannot be empty");
-        anyhow::ensure!(
-            name != "." && name != "..",
-            "skill name cannot be '.' or '..'"
-        );
-        anyhow::ensure!(
-            !name.chars().all(|c| c.is_whitespace()) && name.trim() == name,
-            "skill name cannot be whitespace-only or have leading/trailing whitespace: '{name}'"
-        );
-        anyhow::ensure!(
-            !name.contains('/') && !name.contains('\\'),
-            "skill name contains path separator: '{name}'"
-        );
+        crate::validation::validate_identifier(&name, "skill name")?;
         Ok(Self(name))
     }
 
@@ -122,8 +110,8 @@ impl<'de> serde::Deserialize<'de> for SkillName {
 pub struct SkillProvenance {
     /// Registry identifier (e.g. "my-plugin@npm")
     pub registry_id: String,
-    /// Version string (e.g. "1.2.0")
-    pub version: String,
+    /// Version string (e.g. "1.2.0"). `None` when not available.
+    pub version: Option<String>,
 }
 
 /// A discovered skill with its metadata.
@@ -309,8 +297,8 @@ fn scan_install_records(
                     let version = record
                         .get("version")
                         .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
+                        .filter(|v| !v.is_empty())
+                        .map(|v| v.to_string());
                     let prov = SkillProvenance {
                         registry_id: reg_id.to_string(),
                         version,
@@ -618,7 +606,7 @@ mod tests {
             .as_ref()
             .expect("v2 should have provenance");
         assert_eq!(prov.registry_id, "swift-skill@swift-registry");
-        assert_eq!(prov.version, "1.0.0");
+        assert_eq!(prov.version.as_deref(), Some("1.0.0"));
 
         let rust_s = skills.iter().find(|s| s.name == "rust-skill").unwrap();
         let prov = rust_s
@@ -626,7 +614,7 @@ mod tests {
             .as_ref()
             .expect("v2 should have provenance");
         assert_eq!(prov.registry_id, "rust-skill@rust-registry");
-        assert_eq!(prov.version, "2.0.0");
+        assert_eq!(prov.version.as_deref(), Some("2.0.0"));
     }
 
     #[test]

--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -351,7 +351,10 @@ fn repair_library(paths: &TomePaths) -> Result<()> {
     let library_dir = paths.library_dir();
     let tome_home = paths.tome_home();
     let mut m = manifest::load(tome_home).with_context(|| {
-        "cannot repair: manifest is unreadable. Back up .tome-manifest.json and run sync --force"
+        format!(
+            "cannot repair: manifest is unreadable. Back up {} and run sync --force",
+            crate::manifest::MANIFEST_FILENAME
+        )
     })?;
     let mut fixed = 0;
 

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -32,6 +32,7 @@ pub(crate) mod manifest;
 pub(crate) mod paths;
 pub(crate) mod status;
 pub(crate) mod update;
+pub(crate) mod validation;
 pub(crate) mod wizard;
 
 use std::collections::HashSet;

--- a/crates/tome/src/lockfile.rs
+++ b/crates/tome/src/lockfile.rs
@@ -53,14 +53,7 @@ pub fn generate(manifest: &Manifest, skills: &[DiscoveredSkill]) -> Lockfile {
         let (registry_id, version) = skill_map
             .get(name.as_str())
             .and_then(|s| s.provenance.as_ref())
-            .map(|p| {
-                let version = if p.version.is_empty() {
-                    None
-                } else {
-                    Some(p.version.clone())
-                };
-                (Some(p.registry_id.clone()), version)
-            })
+            .map(|p| (Some(p.registry_id.clone()), p.version.clone()))
             .unwrap_or((None, None));
 
         entries.insert(
@@ -142,9 +135,13 @@ mod tests {
             path: PathBuf::from(format!("/tmp/{name}")),
             source_name: source.to_string(),
             managed: provenance.is_some(),
-            provenance: provenance.map(|(reg, ver)| SkillProvenance {
+            provenance: provenance.map(|(reg, ver): (&str, &str)| SkillProvenance {
                 registry_id: reg.to_string(),
-                version: ver.to_string(),
+                version: if ver.is_empty() {
+                    None
+                } else {
+                    Some(ver.to_string())
+                },
             }),
         }
     }

--- a/crates/tome/src/machine.rs
+++ b/crates/tome/src/machine.rs
@@ -19,11 +19,11 @@ use crate::discover::SkillName;
 pub struct MachinePrefs {
     /// Skills that should not be distributed to targets on this machine.
     #[serde(default)]
-    pub disabled: BTreeSet<SkillName>,
+    pub(crate) disabled: BTreeSet<SkillName>,
 
     /// Targets to skip on this machine (e.g. machine A doesn't have a certain tool installed).
     #[serde(default)]
-    pub disabled_targets: BTreeSet<TargetName>,
+    pub(crate) disabled_targets: BTreeSet<TargetName>,
 }
 
 impl MachinePrefs {

--- a/crates/tome/src/manifest.rs
+++ b/crates/tome/src/manifest.rs
@@ -54,13 +54,13 @@ impl Manifest {
     }
 
     /// Returns true if the manifest has no entries.
-    #[cfg(test)]
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.skills.is_empty()
     }
 
     /// Returns the number of entries in the manifest.
-    #[cfg(test)]
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.skills.len()
     }
@@ -170,7 +170,7 @@ pub fn hash_directory(dir: &Path) -> Result<String> {
 }
 
 /// Get the current timestamp as an ISO 8601 string (UTC, second precision).
-pub fn now_iso8601() -> String {
+pub(crate) fn now_iso8601() -> String {
     // Use std::time for a simple UTC timestamp without pulling in chrono
     let duration = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/crates/tome/src/validation.rs
+++ b/crates/tome/src/validation.rs
@@ -1,0 +1,58 @@
+//! Shared validation logic for identifier types (skill names, target names).
+
+use anyhow::Result;
+
+/// Validate an identifier string used for skill or target names.
+///
+/// Rejects empty names, `.`/`..`, whitespace-only or leading/trailing whitespace,
+/// and names containing path separators (`/` or `\`).
+///
+/// The `kind` parameter is used in error messages (e.g. "skill name", "target name").
+pub(crate) fn validate_identifier(name: &str, kind: &str) -> Result<()> {
+    anyhow::ensure!(!name.is_empty(), "{kind} cannot be empty");
+    anyhow::ensure!(name != "." && name != "..", "{kind} cannot be '.' or '..'");
+    anyhow::ensure!(
+        !name.chars().all(|c| c.is_whitespace()) && name.trim() == name,
+        "{kind} cannot be whitespace-only or have leading/trailing whitespace: '{name}'"
+    );
+    anyhow::ensure!(
+        !name.contains('/') && !name.contains('\\'),
+        "{kind} contains path separator: '{name}'"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_empty() {
+        assert!(validate_identifier("", "test name").is_err());
+    }
+
+    #[test]
+    fn rejects_dots() {
+        assert!(validate_identifier(".", "test name").is_err());
+        assert!(validate_identifier("..", "test name").is_err());
+    }
+
+    #[test]
+    fn rejects_whitespace() {
+        assert!(validate_identifier("  ", "test name").is_err());
+        assert!(validate_identifier(" leading", "test name").is_err());
+        assert!(validate_identifier("trailing ", "test name").is_err());
+    }
+
+    #[test]
+    fn rejects_path_separators() {
+        assert!(validate_identifier("foo/bar", "test name").is_err());
+        assert!(validate_identifier("foo\\bar", "test name").is_err());
+    }
+
+    #[test]
+    fn accepts_valid() {
+        assert!(validate_identifier("my-skill-123", "test name").is_ok());
+        assert!(validate_identifier("My_Skill", "test name").is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

- **SkillProvenance.version**: `String` → `Option<String>` — empty versions are now `None` at the source (discover.rs), removing the empty-string-to-None conversion in lockfile generation
- **Shared validation**: Extracted `validate_identifier()` into new `validation.rs` module, used by both `SkillName::new()` and `TargetName::new()`
- **Visibility fixes**: `now_iso8601()` → `pub(crate)`, `MachinePrefs.disabled`/`disabled_targets` → `pub(crate)`
- **Removed `#[cfg(test)]`** gate from `Manifest::is_empty()` and `len()` (with `#[allow(dead_code)]`)
- **doctor.rs**: Replaced hardcoded `".tome-manifest.json"` with `MANIFEST_FILENAME` constant

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — all 292 tests pass (236 unit + 56 integration)

Beads: tome-2ap, tome-xf8, tome-vlh, tome-ae0, tome-4bg, tome-db0