### PR TITLE
test: fill coverage gaps across 6 modules

### DIFF
--- a/crates/tome/src/cleanup.rs
+++ b/crates/tome/src/cleanup.rs
@@ -322,6 +322,32 @@ mod tests {
     }
 
     #[test]
+    fn cleanup_dry_run_preserves_managed_symlink() {
+        let library = TempDir::new().unwrap();
+
+        // Create a broken symlink simulating a managed skill whose source was removed
+        unix_fs::symlink("/nonexistent", library.path().join("stale-skill")).unwrap();
+        assert!(library.path().join("stale-skill").is_symlink());
+
+        // Manifest has NO entry for stale-skill — it is stale
+        let mut manifest = Manifest::default();
+        let discovered: HashSet<String> = HashSet::new();
+
+        let result =
+            cleanup_library(library.path(), &discovered, &mut manifest, true, false).unwrap();
+
+        // Dry-run should report it would clean up but not actually remove
+        assert!(
+            result.removed_from_library > 0,
+            "dry-run should count the stale symlink as would-be-removed"
+        );
+        assert!(
+            library.path().join("stale-skill").is_symlink(),
+            "dry-run should preserve the symlink on disk"
+        );
+    }
+
+    #[test]
     fn cleanup_removes_managed_symlink() {
         let library = TempDir::new().unwrap();
         let source = tempfile::TempDir::new().unwrap();

--- a/crates/tome/src/discover.rs
+++ b/crates/tome/src/discover.rs
@@ -777,6 +777,40 @@ mod tests {
     }
 
     #[test]
+    fn discover_claude_plugins_parent_path_json() {
+        let tmp = TempDir::new().unwrap();
+
+        // source.path points to a cache/ subdirectory
+        let cache_dir = tmp.path().join("cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        // installed_plugins.json is in the PARENT directory (not in cache/)
+        let plugin_dir = tmp.path().join("my-plugin");
+        create_skill(&plugin_dir.join("skills"), "parent-skill");
+
+        let json = serde_json::json!([
+            { "installPath": plugin_dir.to_str().unwrap() }
+        ]);
+        std::fs::write(
+            tmp.path().join("installed_plugins.json"),
+            serde_json::to_string(&json).unwrap(),
+        )
+        .unwrap();
+
+        // Verify the JSON is NOT in the cache dir itself
+        assert!(!cache_dir.join("installed_plugins.json").exists());
+
+        let source = Source {
+            name: "plugins".into(),
+            path: cache_dir,
+            source_type: SourceType::ClaudePlugins,
+        };
+        let skills = discover_claude_plugins(&source, &mut Vec::new()).unwrap();
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "parent-skill");
+    }
+
+    #[test]
     fn discover_all_collects_naming_warnings() {
         let tmp = TempDir::new().unwrap();
         create_skill(tmp.path(), "My_Unconventional");

--- a/crates/tome/src/library.rs
+++ b/crates/tome/src/library.rs
@@ -1267,4 +1267,66 @@ mod tests {
             "lockfile tmp files now live at tome home, not in library"
         );
     }
+
+    #[test]
+    fn consolidate_managed_replaces_local_dir_with_symlink() {
+        let source = TempDir::new().unwrap();
+        let library = TempDir::new().unwrap();
+
+        // Create a real skill directory in the library (simulating a previously-local skill)
+        let dest = library.path().join("skill-a");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join("SKILL.md"), "# local version").unwrap();
+        assert!(dest.is_dir() && !dest.is_symlink());
+
+        // Add a manifest entry for skill-a with managed: false
+        let mut manifest = Manifest::default();
+        manifest.insert(
+            crate::discover::SkillName::new("skill-a").unwrap(),
+            SkillEntry {
+                source_path: std::path::PathBuf::from("/tmp/old-source/skill-a"),
+                source_name: "old-source".to_string(),
+                content_hash: "stale-hash".to_string(),
+                synced_at: "2024-01-01T00:00:00Z".to_string(),
+                managed: false,
+            },
+        );
+
+        // Create a source directory with the skill
+        let source_skill = source.path().join("skill-a");
+        std::fs::create_dir_all(&source_skill).unwrap();
+        std::fs::write(source_skill.join("SKILL.md"), "# managed version").unwrap();
+
+        // Build a DiscoveredSkill with managed: true
+        let skill = DiscoveredSkill {
+            name: crate::discover::SkillName::new("skill-a").unwrap(),
+            path: source_skill.clone(),
+            source_name: "plugins".into(),
+            managed: true,
+            provenance: None,
+        };
+
+        // Call consolidate_managed directly
+        let mut result = ConsolidateResult::default();
+        consolidate_managed(&skill, &dest, &mut manifest, &mut result, false, false).unwrap();
+
+        // Assert: the real directory was replaced with a symlink pointing to the source
+        assert!(
+            dest.is_symlink(),
+            "real directory should be replaced with a symlink"
+        );
+        let target = std::fs::read_link(&dest).unwrap();
+        assert_eq!(
+            target, source_skill,
+            "symlink should point to the source skill dir"
+        );
+
+        // Assert: the manifest entry is now managed: true
+        let entry = manifest.get("skill-a").expect("manifest should have entry");
+        assert!(
+            entry.managed,
+            "manifest entry should be updated to managed: true"
+        );
+        assert_eq!(result.updated, 1);
+    }
 }

--- a/crates/tome/src/lockfile.rs
+++ b/crates/tome/src/lockfile.rs
@@ -278,6 +278,34 @@ mod tests {
     }
 
     #[test]
+    fn load_accepts_unknown_version() {
+        // Documents current behavior: Lockfile::load() silently accepts
+        // a version number it doesn't know about. The `version` field is
+        // deserialized but not validated, so version 999 loads without error.
+        let tmp = TempDir::new().unwrap();
+        let json = serde_json::json!({
+            "version": 999,
+            "skills": {
+                "some-skill": {
+                    "source_name": "test",
+                    "content_hash": "abc123"
+                }
+            }
+        });
+        std::fs::write(
+            tmp.path().join("tome.lock"),
+            serde_json::to_string_pretty(&json).unwrap(),
+        )
+        .unwrap();
+
+        let result = load(tmp.path()).unwrap();
+        let lockfile = result.expect("should load successfully despite unknown version");
+        assert_eq!(lockfile.version, 999);
+        assert_eq!(lockfile.skills.len(), 1);
+        assert!(lockfile.skills.contains_key("some-skill"));
+    }
+
+    #[test]
     fn load_corrupt_file_returns_error() {
         let tmp = TempDir::new().unwrap();
         std::fs::write(tmp.path().join("tome.lock"), "not valid json {{{").unwrap();

--- a/crates/tome/src/manifest.rs
+++ b/crates/tome/src/manifest.rs
@@ -305,4 +305,45 @@ mod tests {
         assert_eq!(&ts[4..5], "-");
         assert_eq!(&ts[10..11], "T");
     }
+
+    #[test]
+    fn days_to_ymd_epoch() {
+        // Day 0 = Jan 1, 1970
+        let (y, m, d) = days_to_ymd(0);
+        assert_eq!((y, m, d), (1970, 1, 1));
+    }
+
+    #[test]
+    fn days_to_ymd_leap_year_century_exception() {
+        // Feb 29, 2000 — leap year AND century exception (divisible by 400)
+        // 2000-02-29 is day 11016 since epoch
+        let (y, m, d) = days_to_ymd(11016);
+        assert_eq!((y, m, d), (2000, 2, 29));
+    }
+
+    #[test]
+    fn days_to_ymd_end_of_first_year() {
+        // Dec 31, 1970 = day 364
+        let (y, m, d) = days_to_ymd(364);
+        assert_eq!((y, m, d), (1970, 12, 31));
+    }
+
+    #[test]
+    fn days_to_ymd_start_of_2024() {
+        // Jan 1, 2024 = day 19723
+        let (y, m, d) = days_to_ymd(19723);
+        assert_eq!((y, m, d), (2024, 1, 1));
+    }
+
+    #[test]
+    fn now_iso8601_returns_plausible_current_date() {
+        // Verify that the year from now_iso8601 is 2025 or later,
+        // confirming days_to_ymd works for dates beyond 2024.
+        let ts = now_iso8601();
+        let year: u64 = ts[..4].parse().expect("year should be numeric");
+        assert!(
+            year >= 2025,
+            "expected current year >= 2025, got {year} from timestamp '{ts}'"
+        );
+    }
 }

--- a/crates/tome/src/update.rs
+++ b/crates/tome/src/update.rs
@@ -253,6 +253,55 @@ mod tests {
     }
 
     #[test]
+    fn diff_returns_structured_changes() {
+        // Verify the structure of UpdateDiff returned by diff():
+        // each change type carries the expected LockEntry data.
+        //
+        // Note: present_changes() in quiet/non-TTY mode is exercised by
+        // integration tests (crates/tome/tests/cli.rs) because it relies on
+        // dialoguer which requires a real TTY for interactive prompts.
+        let old = lockfile(vec![
+            ("kept", entry("src", "aaa")),
+            ("updated", entry("src", "old-hash")),
+            ("deleted", managed_entry("plugins", "ccc", "pkg@npm")),
+        ]);
+        let new = lockfile(vec![
+            ("kept", entry("src", "aaa")),
+            ("updated", entry("src", "new-hash")),
+            ("fresh", managed_entry("plugins", "ddd", "new-pkg@npm")),
+        ]);
+
+        let d = diff(&old, &new);
+        assert_eq!(d.changes.len(), 3, "should have 3 changes (no unchanged)");
+        assert!(!d.is_empty());
+
+        // Verify Added carries the new entry
+        if let SkillChange::Added(ref e) = d.changes["fresh"] {
+            assert_eq!(e.source_name, "plugins");
+            assert_eq!(e.content_hash, "ddd");
+            assert_eq!(e.registry_id.as_deref(), Some("new-pkg@npm"));
+        } else {
+            panic!("expected Added for 'fresh'");
+        }
+
+        // Verify Changed carries both old and new entries
+        if let SkillChange::Changed { ref old, ref new } = d.changes["updated"] {
+            assert_eq!(old.content_hash, "old-hash");
+            assert_eq!(new.content_hash, "new-hash");
+        } else {
+            panic!("expected Changed for 'updated'");
+        }
+
+        // Verify Removed carries the old entry
+        if let SkillChange::Removed(ref e) = d.changes["deleted"] {
+            assert_eq!(e.content_hash, "ccc");
+            assert_eq!(e.registry_id.as_deref(), Some("pkg@npm"));
+        } else {
+            panic!("expected Removed for 'deleted'");
+        }
+    }
+
+    #[test]
     fn diff_same_hash_different_source_is_unchanged() {
         // Source name change alone doesn't trigger a diff (hash is what matters)
         let old = lockfile(vec![("skill-a", entry("old-source", "same-hash"))]);


### PR DESCRIPTION
## Summary

- **library.rs**: Test `consolidate_managed()` replaces a local directory with a symlink when strategy transitions from local to managed (tome-suj)
- **cleanup.rs**: Test dry-run preserves broken managed symlinks while reporting would-be cleanup count (tome-byn)
- **manifest.rs**: Tests for `days_to_ymd` correctness — epoch, leap year, year-end, 2024, and plausible current date (tome-c57)
- **discover.rs**: Test parent-path fallback for `installed_plugins.json` when source points to a `cache/` subdirectory (tome-15g)
- **lockfile.rs**: Document that `Lockfile::load()` silently accepts unknown version numbers (tome-4oj)
- **update.rs**: Test `diff()` returns structured `UpdateDiff` with correct `Added`/`Changed`/`Removed` entries and metadata (tome-b7u)

## Test plan

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — all 241 unit + 56 integration tests pass