### PR TITLE
refactor: replace DiscoveredSkill managed+provenance with SkillOrigin enum

### DIFF
--- a/crates/tome/src/discover.rs
+++ b/crates/tome/src/discover.rs
@@ -114,6 +114,28 @@ pub struct SkillProvenance {
     pub version: Option<String>,
 }
 
+/// How a skill was sourced — determines consolidation strategy.
+#[derive(Debug, Clone)]
+pub enum SkillOrigin {
+    /// Managed by a package manager; library entry is a symlink to source dir.
+    Managed { provenance: Option<SkillProvenance> },
+    /// Local skill; library entry is a copy of the source.
+    Local,
+}
+
+impl SkillOrigin {
+    pub fn is_managed(&self) -> bool {
+        matches!(self, Self::Managed { .. })
+    }
+
+    pub fn provenance(&self) -> Option<&SkillProvenance> {
+        match self {
+            Self::Managed { provenance } => provenance.as_ref(),
+            Self::Local => None,
+        }
+    }
+}
+
 /// A discovered skill with its metadata.
 #[derive(Debug, Clone)]
 pub struct DiscoveredSkill {
@@ -123,11 +145,8 @@ pub struct DiscoveredSkill {
     pub path: PathBuf,
     /// Which source this skill came from
     pub source_name: String,
-    /// Whether this skill is managed by a package manager (symlinked, not copied).
-    /// `true` for `ClaudePlugins` sources, `false` for `Directory` sources.
-    pub managed: bool,
-    /// Provenance from package manager (v2 `installed_plugins.json`). `None` for local skills.
-    pub provenance: Option<SkillProvenance>,
+    /// How this skill was sourced (managed vs local), with optional provenance metadata.
+    pub origin: SkillOrigin,
 }
 
 /// Discover all skills from configured sources.
@@ -288,21 +307,19 @@ fn scan_install_records(
         if let Some(install_path) = record.get("installPath").and_then(|v| v.as_str()) {
             let skills_dir = PathBuf::from(install_path).join("skills");
             if skills_dir.is_dir() {
-                let mut found = scan_for_skills(&skills_dir, source_name, true, warnings)?;
-                if let Some(reg_id) = registry_id {
+                let provenance = registry_id.map(|reg_id| {
                     let version = record
                         .get("version")
                         .and_then(|v| v.as_str())
                         .filter(|v| !v.is_empty())
                         .map(|v| v.to_string());
-                    let prov = SkillProvenance {
+                    SkillProvenance {
                         registry_id: reg_id.to_string(),
                         version,
-                    };
-                    for skill in &mut found {
-                        skill.provenance = Some(prov.clone());
                     }
-                }
+                });
+                let mut found =
+                    scan_for_skills(&skills_dir, source_name, Some(provenance), warnings)?;
                 skills.append(&mut found);
             }
         }
@@ -330,14 +347,18 @@ fn discover_directory(source: &Source, warnings: &mut Vec<String>) -> Result<Vec
         return Ok(Vec::new());
     }
 
-    scan_for_skills(&source.path, &source.name, false, warnings)
+    scan_for_skills(&source.path, &source.name, None, warnings)
 }
 
 /// Scan a directory for skill subdirectories containing SKILL.md.
+///
+/// When `managed_provenance` is `Some`, skills are marked as `Managed` with the
+/// given provenance (which itself may be `None` for v1 plugins). When
+/// `managed_provenance` is `None`, skills are marked as `Local`.
 fn scan_for_skills(
     dir: &Path,
     source_name: &str,
-    managed: bool,
+    managed_provenance: Option<Option<SkillProvenance>>,
     warnings: &mut Vec<String>,
 ) -> Result<Vec<DiscoveredSkill>> {
     let mut skills = Vec::new();
@@ -379,12 +400,17 @@ fn scan_for_skills(
         {
             match SkillName::new(name_str) {
                 Ok(name) => {
+                    let origin = match &managed_provenance {
+                        Some(prov) => SkillOrigin::Managed {
+                            provenance: prov.clone(),
+                        },
+                        None => SkillOrigin::Local,
+                    };
                     skills.push(DiscoveredSkill {
                         name,
                         path: skill_dir.to_path_buf(),
                         source_name: source_name.to_string(),
-                        managed,
-                        provenance: None,
+                        origin,
                     });
                 }
                 Err(e) => {
@@ -598,16 +624,16 @@ mod tests {
         // v2 format should capture provenance metadata
         let swift = skills.iter().find(|s| s.name == "swift-skill").unwrap();
         let prov = swift
-            .provenance
-            .as_ref()
+            .origin
+            .provenance()
             .expect("v2 should have provenance");
         assert_eq!(prov.registry_id, "swift-skill@swift-registry");
         assert_eq!(prov.version.as_deref(), Some("1.0.0"));
 
         let rust_s = skills.iter().find(|s| s.name == "rust-skill").unwrap();
         let prov = rust_s
-            .provenance
-            .as_ref()
+            .origin
+            .provenance()
             .expect("v2 should have provenance");
         assert_eq!(prov.registry_id, "rust-skill@rust-registry");
         assert_eq!(prov.version.as_deref(), Some("2.0.0"));
@@ -636,7 +662,7 @@ mod tests {
         let skills = discover_claude_plugins(&source, &mut Vec::new()).unwrap();
         assert_eq!(skills.len(), 1);
         assert!(
-            skills[0].provenance.is_none(),
+            skills[0].origin.provenance().is_none(),
             "v1 format should not have provenance"
         );
     }

--- a/crates/tome/src/library.rs
+++ b/crates/tome/src/library.rs
@@ -59,7 +59,7 @@ fn record_in_manifest(manifest: &mut Manifest, skill: &DiscoveredSkill, content_
             skill.path.clone(),
             skill.source_name.clone(),
             content_hash,
-            skill.managed,
+            skill.origin.is_managed(),
         ),
     );
 }
@@ -103,7 +103,7 @@ pub fn consolidate(
     for skill in skills {
         let dest = library_dir.join(skill.name.as_str());
 
-        if skill.managed {
+        if skill.origin.is_managed() {
             consolidate_managed(skill, &dest, &mut manifest, &mut result, dry_run, force)?;
         } else {
             consolidate_local(
@@ -378,14 +378,22 @@ mod tests {
     use tempfile::TempDir;
 
     fn make_skill(dir: &Path, name: &str) -> DiscoveredSkill {
-        make_skill_with_managed(dir, name, false)
+        make_skill_with_origin(dir, name, crate::discover::SkillOrigin::Local)
     }
 
     fn make_managed_skill(dir: &Path, name: &str) -> DiscoveredSkill {
-        make_skill_with_managed(dir, name, true)
+        make_skill_with_origin(
+            dir,
+            name,
+            crate::discover::SkillOrigin::Managed { provenance: None },
+        )
     }
 
-    fn make_skill_with_managed(dir: &Path, name: &str, managed: bool) -> DiscoveredSkill {
+    fn make_skill_with_origin(
+        dir: &Path,
+        name: &str,
+        origin: crate::discover::SkillOrigin,
+    ) -> DiscoveredSkill {
         let skill_dir = dir.join(name);
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(skill_dir.join("SKILL.md"), "# test").unwrap();
@@ -393,8 +401,7 @@ mod tests {
             name: crate::discover::SkillName::new(name).unwrap(),
             path: skill_dir,
             source_name: "test".into(),
-            managed,
-            provenance: None,
+            origin,
         }
     }
 
@@ -624,8 +631,7 @@ mod tests {
             name: crate::discover::SkillName::new("my-skill").unwrap(),
             path: skill2_dir,
             source_name: "test2".into(),
-            managed: false,
-            provenance: None,
+            origin: crate::discover::SkillOrigin::Local,
         };
 
         let (result, _manifest) = consolidate(
@@ -706,8 +712,7 @@ mod tests {
             name: crate::discover::SkillName::new("deep-skill").unwrap(),
             path: skill_dir,
             source_name: "test".into(),
-            managed: false,
-            provenance: None,
+            origin: crate::discover::SkillOrigin::Local,
         };
 
         let (result, _) = consolidate(
@@ -1303,13 +1308,12 @@ mod tests {
         std::fs::create_dir_all(&source_skill).unwrap();
         std::fs::write(source_skill.join("SKILL.md"), "# managed version").unwrap();
 
-        // Build a DiscoveredSkill with managed: true
+        // Build a DiscoveredSkill with Managed origin
         let skill = DiscoveredSkill {
             name: crate::discover::SkillName::new("skill-a").unwrap(),
             path: source_skill.clone(),
             source_name: "plugins".into(),
-            managed: true,
-            provenance: None,
+            origin: crate::discover::SkillOrigin::Managed { provenance: None },
         };
 
         // Call consolidate_managed directly

--- a/crates/tome/src/lockfile.rs
+++ b/crates/tome/src/lockfile.rs
@@ -52,7 +52,7 @@ pub fn generate(manifest: &Manifest, skills: &[DiscoveredSkill]) -> Lockfile {
     for (name, entry) in manifest.iter() {
         let (registry_id, version) = skill_map
             .get(name.as_str())
-            .and_then(|s| s.provenance.as_ref())
+            .and_then(|s| s.origin.provenance())
             .map(|p| (Some(p.registry_id.clone()), p.version.clone()))
             .unwrap_or((None, None));
 
@@ -104,7 +104,7 @@ pub fn save(lockfile: &Lockfile, tome_home: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::discover::{SkillName, SkillProvenance};
+    use crate::discover::SkillName;
     use crate::manifest::SkillEntry;
     use std::path::PathBuf;
     use tempfile::TempDir;
@@ -130,19 +130,25 @@ mod tests {
         source: &str,
         provenance: Option<(&str, &str)>,
     ) -> DiscoveredSkill {
+        use crate::discover::{SkillOrigin, SkillProvenance};
+        let origin = match provenance {
+            Some((reg, ver)) => SkillOrigin::Managed {
+                provenance: Some(SkillProvenance {
+                    registry_id: reg.to_string(),
+                    version: if ver.is_empty() {
+                        None
+                    } else {
+                        Some(ver.to_string())
+                    },
+                }),
+            },
+            None => SkillOrigin::Local,
+        };
         DiscoveredSkill {
             name: SkillName::new(name).unwrap(),
             path: PathBuf::from(format!("/tmp/{name}")),
             source_name: source.to_string(),
-            managed: provenance.is_some(),
-            provenance: provenance.map(|(reg, ver): (&str, &str)| SkillProvenance {
-                registry_id: reg.to_string(),
-                version: if ver.is_empty() {
-                    None
-                } else {
-                    Some(ver.to_string())
-                },
-            }),
+            origin,
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace the two inconsistent fields `managed: bool` and `provenance: Option<SkillProvenance>` on `DiscoveredSkill` with a single `origin: SkillOrigin` enum
- `SkillOrigin::Managed { provenance }` encodes managed skills with optional provenance metadata
- `SkillOrigin::Local` encodes local/copied skills
- Helper methods `is_managed()` and `provenance()` keep callsites clean
- Makes invalid states unrepresentable (e.g. `managed=false` with provenance set)
- `manifest::SkillEntry::managed` is intentionally unchanged (separate persistence concern)

## Test plan

- [x] All 302 existing tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt` applied