### PR TITLE
refactor: type-system cleanup

### DIFF
--- a/crates/tome/src/config.rs
+++ b/crates/tome/src/config.rs
@@ -88,32 +88,32 @@ impl<'de> serde::Deserialize<'de> for TargetName {
 pub struct Config {
     /// Where the consolidated skill library lives
     #[serde(default = "defaults::library_dir")]
-    pub library_dir: PathBuf,
+    pub(crate) library_dir: PathBuf,
 
     /// Skills to exclude by name
     #[serde(default)]
-    pub exclude: BTreeSet<SkillName>,
+    pub(crate) exclude: BTreeSet<SkillName>,
 
     /// Skill sources — order determines priority for duplicates
     #[serde(default)]
-    pub sources: Vec<Source>,
+    pub(crate) sources: Vec<Source>,
 
     /// Distribution targets — keyed by tool name (e.g. "claude", "antigravity")
     #[serde(default, deserialize_with = "deserialize_targets")]
-    pub targets: BTreeMap<TargetName, TargetConfig>,
+    pub(crate) targets: BTreeMap<TargetName, TargetConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Source {
     /// Display name for this source
-    pub name: String,
+    pub(crate) name: String,
 
     /// Path to the source directory
-    pub path: PathBuf,
+    pub(crate) path: PathBuf,
 
     /// How to discover skills in this source
     #[serde(rename = "type")]
-    pub source_type: SourceType,
+    pub(crate) source_type: SourceType,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/tome/src/distribute.rs
+++ b/crates/tome/src/distribute.rs
@@ -4,13 +4,13 @@ use anyhow::{Context, Result};
 use std::os::unix::fs as unix_fs;
 use std::path::Path;
 
-use crate::config::{TargetConfig, TargetMethod};
+use crate::config::{TargetConfig, TargetMethod, TargetName};
 use crate::machine::MachinePrefs;
 use crate::manifest::Manifest;
 use crate::paths::symlink_points_to;
 
 /// Result of distributing skills to a single target.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct DistributeResult {
     pub changed: usize,
     pub unchanged: usize,
@@ -18,7 +18,7 @@ pub struct DistributeResult {
     pub skipped: usize,
     /// Skills skipped because they are disabled in machine preferences.
     pub disabled: usize,
-    pub target_name: String,
+    pub target_name: TargetName,
 }
 
 /// Distribute skills from the library to a target tool.
@@ -36,8 +36,11 @@ pub fn distribute_to_target(
 ) -> Result<DistributeResult> {
     if !target.enabled {
         return Ok(DistributeResult {
-            target_name: target_name.to_string(),
-            ..Default::default()
+            target_name: TargetName::new(target_name)?,
+            changed: 0,
+            unchanged: 0,
+            skipped: 0,
+            disabled: 0,
         });
     }
 
@@ -70,8 +73,11 @@ fn distribute_symlinks(
     }
 
     let mut result = DistributeResult {
-        target_name: target_name.to_string(),
-        ..Default::default()
+        target_name: TargetName::new(target_name)?,
+        changed: 0,
+        unchanged: 0,
+        skipped: 0,
+        disabled: 0,
     };
 
     // Library may not exist yet on a first dry-run (consolidate skips creating it).

--- a/crates/tome/src/paths.rs
+++ b/crates/tome/src/paths.rs
@@ -43,6 +43,15 @@ impl TomePaths {
             "library_dir must be an absolute path: {}",
             library_dir.display()
         );
+        // Soft invariant: library_dir is typically under tome_home.
+        // Not enforced as a hard error because users may intentionally separate them.
+        if !library_dir.starts_with(&tome_home) {
+            eprintln!(
+                "warning: library_dir ({}) is not under tome_home ({}) — this is unusual but allowed",
+                library_dir.display(),
+                tome_home.display()
+            );
+        }
         Ok(Self {
             tome_home,
             library_dir,

--- a/crates/tome/src/status.rs
+++ b/crates/tome/src/status.rs
@@ -406,11 +406,12 @@ mod tests {
             ..Config::default()
         };
 
-        let result = show(
+        let report = gather(
             &config,
             &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()).unwrap(),
-        );
-        assert!(result.is_ok());
+        )
+        .unwrap();
+        assert!(!report.configured);
     }
 
     #[test]
@@ -427,11 +428,13 @@ mod tests {
             ..Config::default()
         };
 
-        let result = show(
+        let report = gather(
             &config,
             &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()).unwrap(),
-        );
-        assert!(result.is_ok());
+        )
+        .unwrap();
+        assert!(report.configured);
+        assert_eq!(report.sources.len(), 1);
     }
 
     #[test]
@@ -472,11 +475,14 @@ mod tests {
             ..Config::default()
         };
 
-        let result = show(
+        let report = gather(
             &config,
             &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()).unwrap(),
-        );
-        assert!(result.is_ok());
+        )
+        .unwrap();
+        assert!(report.configured);
+        assert_eq!(report.sources.len(), 1);
+        assert_eq!(report.targets.len(), 1);
     }
 
     // -- count_entries --


### PR DESCRIPTION
## Summary

- **DistributeResult.target_name**: Changed from `String` to `TargetName` for type safety in distribute.rs
- **TomePaths soft invariant**: Added warning when `library_dir` is not under `tome_home` (unusual but allowed)
- **status.rs tests**: Converted 3 legacy `show()` tests to call `gather()` directly with meaningful assertions
- **Config/Source visibility**: Narrowed all `Config` and `Source` struct fields from `pub` to `pub(crate)`

Beads: tome-dhm, tome-zpc, tome-bwg, tome-047

## Test plan

- [x] `make ci` passes (fmt, clippy, 302 tests all green)