### PR TITLE
refactor: typed map keys (SkillName) and ContentHash newtype

### DIFF
--- a/crates/tome/src/cleanup.rs
+++ b/crates/tome/src/cleanup.rs
@@ -185,7 +185,7 @@ mod tests {
             crate::manifest::SkillEntry {
                 source_path: std::path::PathBuf::from("/tmp/source/old-skill"),
                 source_name: "test".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },
@@ -214,7 +214,7 @@ mod tests {
             crate::manifest::SkillEntry {
                 source_path: std::path::PathBuf::from("/tmp/source/keep-me"),
                 source_name: "test".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },
@@ -241,7 +241,7 @@ mod tests {
             crate::manifest::SkillEntry {
                 source_path: std::path::PathBuf::from("/tmp/source/stale"),
                 source_name: "test".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },
@@ -364,7 +364,7 @@ mod tests {
             crate::manifest::SkillEntry {
                 source_path: skill_source,
                 source_name: "plugins".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: true,
             },

--- a/crates/tome/src/distribute.rs
+++ b/crates/tome/src/distribute.rs
@@ -553,7 +553,7 @@ mod tests {
             SkillEntry {
                 source_path: skill_dir.clone(),
                 source_name: "test".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },

--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -454,7 +454,7 @@ mod tests {
             manifest::SkillEntry {
                 source_path: PathBuf::from("/tmp/source/my-skill"),
                 source_name: "test".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },
@@ -547,7 +547,7 @@ mod tests {
             manifest::SkillEntry {
                 source_path: PathBuf::from("/tmp/source/my-skill"),
                 source_name: "test".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },
@@ -571,7 +571,7 @@ mod tests {
             manifest::SkillEntry {
                 source_path: PathBuf::from("/tmp/source/gone"),
                 source_name: "test".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },
@@ -714,7 +714,7 @@ mod tests {
             manifest::SkillEntry {
                 source_path: PathBuf::from("/tmp/source/my-skill"),
                 source_name: "test".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },
@@ -758,7 +758,7 @@ mod tests {
             manifest::SkillEntry {
                 source_path: PathBuf::from("/tmp/source/orphan-skill"),
                 source_name: "test".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },
@@ -790,7 +790,7 @@ mod tests {
             manifest::SkillEntry {
                 source_path: PathBuf::from("/tmp/source/ghost"),
                 source_name: "test".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },
@@ -821,7 +821,7 @@ mod tests {
             manifest::SkillEntry {
                 source_path: PathBuf::from("/nonexistent/source"),
                 source_name: "plugins".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: true,
             },
@@ -871,7 +871,7 @@ mod tests {
             manifest::SkillEntry {
                 source_path: PathBuf::from("/tmp/source/healthy-skill"),
                 source_name: "test".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },

--- a/crates/tome/src/library.rs
+++ b/crates/tome/src/library.rs
@@ -52,7 +52,11 @@ fn create_symlink(src: &Path, dest: &Path) -> Result<()> {
 }
 
 /// Record a skill in the manifest after consolidation.
-fn record_in_manifest(manifest: &mut Manifest, skill: &DiscoveredSkill, content_hash: String) {
+fn record_in_manifest(
+    manifest: &mut Manifest,
+    skill: &DiscoveredSkill,
+    content_hash: crate::validation::ContentHash,
+) {
     manifest.insert(
         skill.name.clone(),
         SkillEntry::new(
@@ -658,7 +662,7 @@ mod tests {
         assert_eq!(manifest.len(), 1);
         assert!(manifest.contains_key("my-skill"));
         let entry = manifest.get("my-skill").unwrap();
-        assert!(!entry.content_hash.is_empty());
+        assert_eq!(entry.content_hash.as_str().len(), 64);
         assert!(!entry.synced_at.is_empty());
     }
 
@@ -980,7 +984,7 @@ mod tests {
         .unwrap();
         let entry = manifest.get("plugin-skill").unwrap();
         assert!(entry.managed);
-        assert!(!entry.content_hash.is_empty());
+        assert_eq!(entry.content_hash.as_str().len(), 64);
     }
 
     // -- .gitignore generation tests --
@@ -1292,7 +1296,7 @@ mod tests {
             SkillEntry {
                 source_path: std::path::PathBuf::from("/tmp/old-source/skill-a"),
                 source_name: "old-source".to_string(),
-                content_hash: "stale-hash".to_string(),
+                content_hash: crate::validation::test_hash("stale-hash"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },

--- a/crates/tome/src/lockfile.rs
+++ b/crates/tome/src/lockfile.rs
@@ -10,8 +10,9 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::discover::DiscoveredSkill;
+use crate::discover::{DiscoveredSkill, SkillName};
 use crate::manifest::Manifest;
+use crate::validation::ContentHash;
 
 pub(crate) const LOCKFILE_NAME: &str = "tome.lock";
 
@@ -21,7 +22,7 @@ pub struct Lockfile {
     /// Schema version (currently 1).
     pub version: u32,
     /// One entry per skill, keyed by skill name.
-    pub skills: BTreeMap<String, LockEntry>,
+    pub skills: BTreeMap<SkillName, LockEntry>,
 }
 
 /// A single skill entry in the lockfile.
@@ -30,7 +31,7 @@ pub struct LockEntry {
     /// Config source name (maps to a `[[sources]]` entry in `tome.toml`).
     pub source_name: String,
     /// SHA-256 content hash of the skill directory.
-    pub content_hash: String,
+    pub content_hash: ContentHash,
     /// Registry identifier (e.g. "my-plugin@npm"). Present for managed plugins.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub registry_id: Option<String>,
@@ -57,7 +58,7 @@ pub fn generate(manifest: &Manifest, skills: &[DiscoveredSkill]) -> Lockfile {
             .unwrap_or((None, None));
 
         entries.insert(
-            name.to_string(),
+            name.clone(),
             LockEntry {
                 source_name: entry.source_name.clone(),
                 content_hash: entry.content_hash.clone(),
@@ -106,18 +107,19 @@ mod tests {
     use super::*;
     use crate::discover::{SkillName, SkillProvenance};
     use crate::manifest::SkillEntry;
+    use crate::validation::test_hash;
     use std::path::PathBuf;
     use tempfile::TempDir;
 
     fn make_manifest(entries: &[(&str, &str, &str, bool)]) -> Manifest {
         let mut manifest = Manifest::default();
-        for &(name, source, hash, managed) in entries {
+        for &(name, source, hash_seed, managed) in entries {
             manifest.insert(
                 SkillName::new(name).unwrap(),
                 SkillEntry::new(
                     PathBuf::from(format!("/tmp/{name}")),
                     source.to_string(),
-                    hash.to_string(),
+                    test_hash(hash_seed),
                     managed,
                 ),
             );
@@ -155,9 +157,10 @@ mod tests {
         assert_eq!(lockfile.version, 1);
         assert_eq!(lockfile.skills.len(), 1);
 
-        let entry = &lockfile.skills["my-skill"];
+        let key = SkillName::new("my-skill").unwrap();
+        let entry = &lockfile.skills[&key];
         assert_eq!(entry.source_name, "standalone");
-        assert_eq!(entry.content_hash, "abc123");
+        assert_eq!(entry.content_hash, test_hash("abc123"));
         assert!(entry.registry_id.is_none());
         assert!(entry.version.is_none());
     }
@@ -172,7 +175,8 @@ mod tests {
         )];
 
         let lockfile = generate(&manifest, &skills);
-        let entry = &lockfile.skills["swift-format"];
+        let key = SkillName::new("swift-format").unwrap();
+        let entry = &lockfile.skills[&key];
         assert_eq!(entry.registry_id.as_deref(), Some("swift-format@npm"));
         assert_eq!(entry.version.as_deref(), Some("1.2.0"));
     }
@@ -190,9 +194,11 @@ mod tests {
 
         let lockfile = generate(&manifest, &skills);
         assert_eq!(lockfile.skills.len(), 2);
-        assert!(lockfile.skills["local-skill"].registry_id.is_none());
+        let local_key = SkillName::new("local-skill").unwrap();
+        let managed_key = SkillName::new("managed-skill").unwrap();
+        assert!(lockfile.skills[&local_key].registry_id.is_none());
         assert_eq!(
-            lockfile.skills["managed-skill"].registry_id.as_deref(),
+            lockfile.skills[&managed_key].registry_id.as_deref(),
             Some("pkg@npm")
         );
     }
@@ -259,10 +265,10 @@ mod tests {
         let lockfile = Lockfile {
             version: 1,
             skills: BTreeMap::from([(
-                "my-skill".to_string(),
+                SkillName::new("my-skill").unwrap(),
                 LockEntry {
                     source_name: "test".to_string(),
-                    content_hash: "abc123".to_string(),
+                    content_hash: test_hash("abc123"),
                     registry_id: None,
                     version: None,
                 },
@@ -280,12 +286,13 @@ mod tests {
         // a version number it doesn't know about. The `version` field is
         // deserialized but not validated, so version 999 loads without error.
         let tmp = TempDir::new().unwrap();
+        let valid_hash = "a".repeat(64);
         let json = serde_json::json!({
             "version": 999,
             "skills": {
                 "some-skill": {
                     "source_name": "test",
-                    "content_hash": "abc123"
+                    "content_hash": valid_hash
                 }
             }
         });
@@ -299,7 +306,8 @@ mod tests {
         let lockfile = result.expect("should load successfully despite unknown version");
         assert_eq!(lockfile.version, 999);
         assert_eq!(lockfile.skills.len(), 1);
-        assert!(lockfile.skills.contains_key("some-skill"));
+        let key = SkillName::new("some-skill").unwrap();
+        assert!(lockfile.skills.contains_key(&key));
     }
 
     #[test]
@@ -329,7 +337,7 @@ mod tests {
 
         // BTreeMap guarantees alphabetical order
         let lockfile = generate(&manifest, &skills);
-        let keys: Vec<&String> = lockfile.skills.keys().collect();
+        let keys: Vec<&str> = lockfile.skills.keys().map(|k| k.as_str()).collect();
         assert_eq!(keys, vec!["a-skill", "m-skill", "z-skill"]);
     }
 
@@ -344,13 +352,15 @@ mod tests {
         let lockfile = generate(&manifest, &skills);
         assert_eq!(lockfile.skills.len(), 2);
 
-        let a = &lockfile.skills["a-skill"];
+        let a_key = SkillName::new("a-skill").unwrap();
+        let a = &lockfile.skills[&a_key];
         assert_eq!(a.source_name, "src");
-        assert_eq!(a.content_hash, "hash_a");
+        assert_eq!(a.content_hash, test_hash("hash_a"));
 
-        let b = &lockfile.skills["b-skill"];
+        let b_key = SkillName::new("b-skill").unwrap();
+        let b = &lockfile.skills[&b_key];
         assert_eq!(b.source_name, "src");
-        assert_eq!(b.content_hash, "hash_b");
+        assert_eq!(b.content_hash, test_hash("hash_b"));
         assert!(b.registry_id.is_none());
         assert!(b.version.is_none());
     }
@@ -375,9 +385,11 @@ mod tests {
 
         let lockfile = generate(&manifest, &skills);
         assert_eq!(lockfile.skills.len(), 1);
-        assert!(lockfile.skills.contains_key("a-skill"));
+        let a_key = SkillName::new("a-skill").unwrap();
+        let extra_key = SkillName::new("extra-skill").unwrap();
+        assert!(lockfile.skills.contains_key(&a_key));
         assert!(
-            !lockfile.skills.contains_key("extra-skill"),
+            !lockfile.skills.contains_key(&extra_key),
             "skills not in manifest should not appear in lockfile"
         );
     }
@@ -392,7 +404,8 @@ mod tests {
         )];
 
         let lockfile = generate(&manifest, &skills);
-        let entry = &lockfile.skills["my-plugin"];
+        let key = SkillName::new("my-plugin").unwrap();
+        let entry = &lockfile.skills[&key];
         assert_eq!(entry.registry_id.as_deref(), Some("my-plugin@npm"));
         assert!(
             entry.version.is_none(),
@@ -424,13 +437,13 @@ mod tests {
         // Check the skill entry doesn't contain a "version" key.
         // The top-level "version": 1 is expected, so we check within the skill object.
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
-        let skill = &parsed["skills"]["my-skill"];
+        let my_skill = &parsed["skills"]["my-skill"];
         assert!(
-            skill.get("registry_id").is_none(),
+            my_skill.get("registry_id").is_none(),
             "should omit null registry_id in JSON"
         );
         assert!(
-            skill.get("version").is_none(),
+            my_skill.get("version").is_none(),
             "should omit null version in JSON"
         );
     }

--- a/crates/tome/src/manifest.rs
+++ b/crates/tome/src/manifest.rs
@@ -13,6 +13,7 @@ use sha2::{Digest, Sha256};
 use walkdir::WalkDir;
 
 use crate::discover::SkillName;
+use crate::validation::ContentHash;
 
 pub(crate) const MANIFEST_FILENAME: &str = ".tome-manifest.json";
 
@@ -74,7 +75,7 @@ pub struct SkillEntry {
     /// Which source config entry contributed this skill.
     pub source_name: String,
     /// SHA-256 hex digest of the directory contents.
-    pub content_hash: String,
+    pub content_hash: ContentHash,
     /// ISO 8601 timestamp of when this skill was last synced.
     pub synced_at: String,
     /// Whether this skill is managed by a package manager (symlinked, not copied).
@@ -88,7 +89,7 @@ impl SkillEntry {
     pub fn new(
         source_path: PathBuf,
         source_name: String,
-        content_hash: String,
+        content_hash: ContentHash,
         managed: bool,
     ) -> Self {
         Self {
@@ -138,7 +139,7 @@ pub fn save(manifest: &Manifest, tome_home: &Path) -> Result<()> {
 ///
 /// Walks all files in sorted order by relative path, hashing each file's
 /// relative path and content into a single digest.
-pub fn hash_directory(dir: &Path) -> Result<String> {
+pub fn hash_directory(dir: &Path) -> Result<ContentHash> {
     let mut entries: Vec<(String, PathBuf)> = Vec::new();
 
     for entry in WalkDir::new(dir).follow_links(false).into_iter() {
@@ -172,7 +173,8 @@ pub fn hash_directory(dir: &Path) -> Result<String> {
         hasher.update(&content);
     }
 
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(ContentHash::new(format!("{:x}", hasher.finalize()))
+        .expect("SHA-256 always produces 64 valid hex characters"))
 }
 
 /// Get the current timestamp as an ISO 8601 string (UTC, second precision).
@@ -220,6 +222,7 @@ fn days_to_ymd(days: u64) -> (u64, u64, u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::test_hash;
     use tempfile::TempDir;
 
     #[test]
@@ -251,7 +254,7 @@ mod tests {
         std::fs::write(tmp.path().join("sub/nested.txt"), "deep").unwrap();
 
         let h1 = hash_directory(tmp.path()).unwrap();
-        assert!(!h1.is_empty());
+        assert_eq!(h1.as_str().len(), 64);
     }
 
     #[test]
@@ -259,12 +262,13 @@ mod tests {
         let tmp = TempDir::new().unwrap();
 
         let mut manifest = Manifest::default();
+        let hash = test_hash("my-skill");
         manifest.insert(
             crate::discover::SkillName::new("my-skill").unwrap(),
             SkillEntry {
                 source_path: PathBuf::from("/tmp/source/my-skill"),
                 source_name: "test".to_string(),
-                content_hash: "abc123".to_string(),
+                content_hash: hash.clone(),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },
@@ -273,7 +277,7 @@ mod tests {
         save(&manifest, tmp.path()).unwrap();
         let loaded = load(tmp.path()).unwrap();
         assert_eq!(loaded.len(), 1);
-        assert_eq!(loaded.get("my-skill").unwrap().content_hash, "abc123");
+        assert_eq!(loaded.get("my-skill").unwrap().content_hash, hash);
     }
 
     #[test]

--- a/crates/tome/src/status.rs
+++ b/crates/tome/src/status.rs
@@ -539,7 +539,7 @@ mod tests {
             manifest::SkillEntry {
                 source_path: PathBuf::from("/tmp/source/my-skill"),
                 source_name: "test".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },
@@ -578,7 +578,7 @@ mod tests {
             manifest::SkillEntry {
                 source_path: PathBuf::from("/tmp/source"),
                 source_name: "test".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: false,
             },
@@ -611,7 +611,7 @@ mod tests {
             manifest::SkillEntry {
                 source_path: PathBuf::from("/tmp/source"),
                 source_name: "plugins".to_string(),
-                content_hash: "abc".to_string(),
+                content_hash: crate::validation::test_hash("abc"),
                 synced_at: "2024-01-01T00:00:00Z".to_string(),
                 managed: true,
             },

--- a/crates/tome/src/update.rs
+++ b/crates/tome/src/update.rs
@@ -24,7 +24,7 @@ pub enum SkillChange {
 /// The diff between two lockfile versions.
 #[derive(Debug)]
 pub struct UpdateDiff {
-    pub changes: BTreeMap<String, SkillChange>,
+    pub changes: BTreeMap<SkillName, SkillChange>,
 }
 
 impl UpdateDiff {
@@ -77,7 +77,7 @@ pub fn present_changes(
 ) -> Result<Vec<SkillName>> {
     let interactive = std::io::stdin().is_terminal() && !quiet;
 
-    let mut added_names: Vec<String> = Vec::new();
+    let mut added_names: Vec<SkillName> = Vec::new();
 
     for (name, change) in &diff.changes {
         match change {
@@ -124,14 +124,15 @@ pub fn present_changes(
     // Only offer to disable added skills interactively
     if interactive && !added_names.is_empty() {
         println!();
+        let display_names: Vec<&str> = added_names.iter().map(|n| n.as_str()).collect();
         let selections = dialoguer::MultiSelect::new()
             .with_prompt("Disable any of these new skills on this machine?")
-            .items(&added_names)
+            .items(&display_names)
             .interact_opt()?;
 
         if let Some(indices) = selections {
             for idx in indices {
-                let name = SkillName::new(&added_names[idx])?;
+                let name = added_names[idx].clone();
                 machine_prefs.disable(name.clone());
                 newly_disabled.push(name);
             }
@@ -145,20 +146,21 @@ pub fn present_changes(
 mod tests {
     use super::*;
     use crate::lockfile::LockEntry;
+    use crate::validation::test_hash;
 
-    fn entry(source: &str, hash: &str) -> LockEntry {
+    fn entry(source: &str, hash_seed: &str) -> LockEntry {
         LockEntry {
             source_name: source.to_string(),
-            content_hash: hash.to_string(),
+            content_hash: test_hash(hash_seed),
             registry_id: None,
             version: None,
         }
     }
 
-    fn managed_entry(source: &str, hash: &str, registry_id: &str) -> LockEntry {
+    fn managed_entry(source: &str, hash_seed: &str, registry_id: &str) -> LockEntry {
         LockEntry {
             source_name: source.to_string(),
-            content_hash: hash.to_string(),
+            content_hash: test_hash(hash_seed),
             registry_id: Some(registry_id.to_string()),
             version: Some("1.0.0".to_string()),
         }
@@ -169,7 +171,7 @@ mod tests {
             version: 1,
             skills: entries
                 .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
+                .map(|(k, v)| (SkillName::new(k).unwrap(), v))
                 .collect(),
         }
     }
@@ -278,7 +280,7 @@ mod tests {
         // Verify Added carries the new entry
         if let SkillChange::Added(ref e) = d.changes["fresh"] {
             assert_eq!(e.source_name, "plugins");
-            assert_eq!(e.content_hash, "ddd");
+            assert_eq!(e.content_hash, test_hash("ddd"));
             assert_eq!(e.registry_id.as_deref(), Some("new-pkg@npm"));
         } else {
             panic!("expected Added for 'fresh'");
@@ -286,15 +288,15 @@ mod tests {
 
         // Verify Changed carries both old and new entries
         if let SkillChange::Changed { ref old, ref new } = d.changes["updated"] {
-            assert_eq!(old.content_hash, "old-hash");
-            assert_eq!(new.content_hash, "new-hash");
+            assert_eq!(old.content_hash, test_hash("old-hash"));
+            assert_eq!(new.content_hash, test_hash("new-hash"));
         } else {
             panic!("expected Changed for 'updated'");
         }
 
         // Verify Removed carries the old entry
         if let SkillChange::Removed(ref e) = d.changes["deleted"] {
-            assert_eq!(e.content_hash, "ccc");
+            assert_eq!(e.content_hash, test_hash("ccc"));
             assert_eq!(e.registry_id.as_deref(), Some("pkg@npm"));
         } else {
             panic!("expected Removed for 'deleted'");

--- a/crates/tome/src/validation.rs
+++ b/crates/tome/src/validation.rs
@@ -1,7 +1,7 @@
-//! Shared validation logic for identifier types (skill names, target names).
+//! Shared validation logic for identifier types (skill names, target names)
+//! and the `ContentHash` newtype for compile-time hash safety.
 
 use anyhow::Result;
-
 /// Validate an identifier string used for skill or target names.
 ///
 /// Rejects empty names, `.`/`..`, whitespace-only or leading/trailing whitespace,
@@ -20,6 +20,51 @@ pub(crate) fn validate_identifier(name: &str, kind: &str) -> Result<()> {
         "{kind} contains path separator: '{name}'"
     );
     Ok(())
+}
+
+/// A validated SHA-256 content hash (64 hex characters).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
+#[serde(transparent)]
+pub struct ContentHash(String);
+
+impl ContentHash {
+    pub fn new(hash: impl Into<String>) -> Result<Self> {
+        let hash = hash.into();
+        if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+            anyhow::bail!("invalid content hash: expected 64 hex characters, got '{hash}'");
+        }
+        // Normalize to lowercase
+        Ok(Self(hash.to_ascii_lowercase()))
+    }
+
+    #[allow(dead_code)]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ContentHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ContentHash {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        ContentHash::new(s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Create a test ContentHash by hashing a seed string with SHA-256.
+#[cfg(test)]
+pub fn test_hash(seed: &str) -> ContentHash {
+    use sha2::{Digest, Sha256};
+    let hash = format!("{:x}", Sha256::digest(seed.as_bytes()));
+    ContentHash::new(hash).unwrap()
 }
 
 #[cfg(test)]
@@ -54,5 +99,66 @@ mod tests {
     fn accepts_valid() {
         assert!(validate_identifier("my-skill-123", "test name").is_ok());
         assert!(validate_identifier("My_Skill", "test name").is_ok());
+    }
+
+    // -- ContentHash tests --
+
+    #[test]
+    fn content_hash_valid() {
+        let hash = "a".repeat(64);
+        let ch = ContentHash::new(hash).unwrap();
+        assert_eq!(ch.as_str().len(), 64);
+    }
+
+    #[test]
+    fn content_hash_too_short() {
+        assert!(ContentHash::new("abc123").is_err());
+    }
+
+    #[test]
+    fn content_hash_too_long() {
+        let hash = "a".repeat(65);
+        assert!(ContentHash::new(hash).is_err());
+    }
+
+    #[test]
+    fn content_hash_non_hex() {
+        let hash = "g".repeat(64);
+        assert!(ContentHash::new(hash).is_err());
+    }
+
+    #[test]
+    fn content_hash_normalizes_uppercase() {
+        let hash = "A".repeat(64);
+        let ch = ContentHash::new(hash).unwrap();
+        assert_eq!(ch.as_str(), "a".repeat(64));
+    }
+
+    #[test]
+    fn content_hash_display() {
+        let hash = "b".repeat(64);
+        let ch = ContentHash::new(hash.clone()).unwrap();
+        assert_eq!(format!("{ch}"), hash);
+    }
+
+    #[test]
+    fn content_hash_serde_roundtrip() {
+        let ch = test_hash("test-seed");
+        let json = serde_json::to_string(&ch).unwrap();
+        let parsed: ContentHash = serde_json::from_str(&json).unwrap();
+        assert_eq!(ch, parsed);
+    }
+
+    #[test]
+    fn content_hash_deserialize_rejects_invalid() {
+        let result: std::result::Result<ContentHash, _> = serde_json::from_str(r#""not-a-hash""#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_hash_helper_produces_valid_hash() {
+        let h = test_hash("anything");
+        assert_eq!(h.as_str().len(), 64);
+        assert!(h.as_str().chars().all(|c| c.is_ascii_hexdigit()));
     }
 }


### PR DESCRIPTION
## Summary

- **Part A**: Replace `String` keys in `Lockfile.skills` and `UpdateDiff.changes` with `SkillName`, providing compile-time enforcement that map keys are validated skill names.
- **Part B**: Introduce `ContentHash` newtype in `validation.rs` — a validated 64-char hex SHA-256 hash with serde support. Used in `SkillEntry.content_hash`, `LockEntry.content_hash`, and `hash_directory()` return type.
- Updated ~30 test sites across 9 modules. All 311 tests pass, clippy clean, no formatting issues.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — 255 unit + 56 integration tests pass
- [x] Serde roundtrip: ContentHash serializes/deserializes through JSON correctly
- [x] ContentHash rejects invalid inputs (too short, non-hex, wrong length)
- [x] ContentHash normalizes uppercase to lowercase
- [x] Lockfile with SkillName keys serializes to same JSON structure (transparent serde)