### PR TITLE
fix: v0.4.1 quick wins — plugin cache wording + enhanced status display

### DIFF
--- a/crates/tome/src/paths.rs
+++ b/crates/tome/src/paths.rs
@@ -125,6 +125,17 @@ pub fn symlink_points_to(link_path: &Path, expected_target: &Path) -> bool {
     resolved == expected
 }
 
+/// Collapse the user's home directory prefix to `~/` for display.
+pub(crate) fn collapse_home(path: &Path) -> String {
+    if let Ok(home) = std::env::var("HOME") {
+        let home_path = Path::new(&home);
+        if let Ok(rel) = path.strip_prefix(home_path) {
+            return format!("~/{}", rel.display());
+        }
+    }
+    path.display().to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tome/src/status.rs
+++ b/crates/tome/src/status.rs
@@ -122,16 +122,20 @@ fn render_status(report: &StatusReport) {
     println!(
         "{} {}",
         style("Library:").bold(),
-        report.library_dir.display()
+        crate::paths::collapse_home(&report.library_dir)
     );
-    let lib_count = match &report.library_count {
-        Ok(n) => format!("{}", n),
+    let (lib_count, lib_indicator) = match &report.library_count {
+        Ok(n) => (format!("{}", n), style("✓").green()),
         Err(e) => {
             eprintln!("warning: could not read library: {}", e);
-            "?".to_string()
+            ("?".to_string(), style("✗").red())
         }
     };
-    println!("  {} skills consolidated", style(lib_count).cyan());
+    println!(
+        "  {} {} skills consolidated",
+        lib_indicator,
+        style(lib_count).cyan()
+    );
     println!();
 
     // Sources
@@ -148,19 +152,19 @@ fn render_status(report: &StatusReport) {
         ]);
         for source in &report.sources {
             let count = match &source.skill_count {
-                Ok(n) => format!("{}", n),
+                Ok(n) => format!("✓ {}", n),
                 Err(e) => {
                     eprintln!(
                         "warning: could not discover skills from '{}': {}",
                         source.name, e
                     );
-                    "?".to_string()
+                    "✗ ?".to_string()
                 }
             };
             rows.push([
                 source.name.clone(),
                 source.source_type.clone(),
-                source.path.clone(),
+                crate::paths::collapse_home(std::path::Path::new(&source.path)),
                 count,
             ]);
         }
@@ -214,11 +218,15 @@ fn render_status(report: &StatusReport) {
 
     // Health
     let health = match &report.health {
-        Ok(0) => format!("{}", style("All good").green()),
-        Ok(n) => format!("{}", style(format!("{} issue(s)", n)).red()),
+        Ok(0) => format!("{} {}", style("✓").green(), style("All good").green()),
+        Ok(n) => format!(
+            "{} {}",
+            style("⚠").yellow(),
+            style(format!("{} issue(s) — run `tome doctor` for details", n)).yellow()
+        ),
         Err(e) => {
             eprintln!("warning: could not check library health: {}", e);
-            format!("{}", style("unknown").yellow())
+            format!("{} {}", style("✗").red(), style("unknown").red())
         }
     };
     println!("{} {}", style("Health:").bold(), health);

--- a/crates/tome/src/wizard.rs
+++ b/crates/tome/src/wizard.rs
@@ -21,7 +21,9 @@ pub fn run(dry_run: bool) -> Result<Config> {
 
     println!("{}", style("How it works:").bold());
     println!("  Tome copies your local skills into a central library for safekeeping.");
-    println!("  Managed skills (e.g. installed plugins) are symlinked there instead.");
+    println!(
+        "  Managed skills (e.g. plugins installed from the Claude Code marketplace) are symlinked there instead."
+    );
     println!("  Each target tool receives symlinks into the library — your originals");
     println!("  are never touched. Removing tome leaves all source files untouched.");
     println!();
@@ -178,7 +180,10 @@ fn configure_sources() -> Result<Vec<Source>> {
             .iter()
             .map(|s| match s.source_type {
                 SourceType::ClaudePlugins => {
-                    format!("{} — installed marketplace plugins", s.path.display())
+                    format!(
+                        "{} — active plugins installed from Claude Code marketplace",
+                        s.path.display()
+                    )
                 }
                 SourceType::Directory => {
                     format!("{} ({})", s.path.display(), s.source_type)

--- a/crates/tome/tests/snapshots/cli__status_empty_library.snap
+++ b/crates/tome/tests/snapshots/cli__status_empty_library.snap
@@ -3,7 +3,7 @@ source: crates/tome/tests/cli.rs
 expression: stdout
 ---
 Library: [TMPDIR]/library
-  0 skills consolidated
+  ✓ 0 skills consolidated
 
 Sources:
   (none configured)
@@ -11,4 +11,4 @@ Sources:
 Targets:
   (none configured)
 
-Health: All good
+Health: ✓ All good


### PR DESCRIPTION
Closes #312, closes #168

- **#312**: Clarify that plugin cache source refers to active Claude Code marketplace plugins
- **#168**: Enhanced `tome status` with ✓/✗/⚠ health indicators, tilde-collapsed paths, and better health messaging
- Added `collapse_home()` utility in `paths.rs` for path display