### PR TITLE
feat: browse sorting/grouping (#166) and detail screen with actions (#169)

### DIFF
--- a/crates/tome/src/browse/app.rs
+++ b/crates/tome/src/browse/app.rs
@@ -9,12 +9,62 @@ use super::fuzzy;
 pub enum Mode {
     Normal,
     Search,
+    Detail,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortMode {
+    Name,
+    Source,
+    Recent,
+}
+
+impl SortMode {
+    pub fn next(self) -> Self {
+        match self {
+            Self::Name => Self::Source,
+            Self::Source => Self::Recent,
+            Self::Recent => Self::Name,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Name => "name",
+            Self::Source => "source",
+            Self::Recent => "recent",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum DetailAction {
+    ViewSource,
+    CopyPath,
+    Disable,
+    Enable,
+    Back,
+}
+
+impl DetailAction {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::ViewSource => "Open source directory",
+            Self::CopyPath => "Copy path to clipboard",
+            Self::Disable => "Disable on this machine",
+            Self::Enable => "Enable on this machine",
+            Self::Back => "Back",
+        }
+    }
 }
 
 pub struct SkillRow {
     pub name: String,
     pub source: String,
     pub path: String,
+    pub managed: bool,
+    pub synced_at: String,
 }
 
 pub struct App {
@@ -28,6 +78,10 @@ pub struct App {
     pub visible_height: usize,
     pub preview_title: String,
     pub preview_content: String,
+    pub sort_mode: SortMode,
+    pub group_by_source: bool,
+    pub detail_actions: Vec<DetailAction>,
+    pub detail_selected: usize,
 }
 
 impl App {
@@ -44,7 +98,12 @@ impl App {
             visible_height: 20,
             preview_title: "Preview".into(),
             preview_content: "No skills discovered.".into(),
+            sort_mode: SortMode::Name,
+            group_by_source: false,
+            detail_actions: Vec::new(),
+            detail_selected: 0,
         };
+        app.apply_sort();
         app.refresh_preview();
         app
     }
@@ -53,6 +112,7 @@ impl App {
         match self.mode {
             Mode::Normal => self.handle_normal_key(key),
             Mode::Search => self.handle_search_key(key),
+            Mode::Detail => self.handle_detail_key(key),
         }
     }
 
@@ -72,7 +132,83 @@ impl App {
             KeyCode::PageDown => self.move_cursor_down(self.visible_height),
             KeyCode::PageUp => self.move_cursor_up(self.visible_height),
             KeyCode::Char('/') => self.mode = Mode::Search,
+            KeyCode::Char('s') => {
+                self.sort_mode = self.sort_mode.next();
+                self.refilter();
+            }
+            KeyCode::Tab => {
+                self.group_by_source = !self.group_by_source;
+            }
+            KeyCode::Enter => {
+                if !self.filtered_indices.is_empty() {
+                    self.enter_detail_mode();
+                }
+            }
             _ => {}
+        }
+    }
+
+    fn handle_detail_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if !self.detail_actions.is_empty() {
+                    self.detail_selected =
+                        (self.detail_selected + 1).min(self.detail_actions.len() - 1);
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.detail_selected = self.detail_selected.saturating_sub(1);
+            }
+            KeyCode::Enter => {
+                if let Some(&action) = self.detail_actions.get(self.detail_selected) {
+                    self.execute_action(action);
+                }
+            }
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.mode = Mode::Normal;
+            }
+            _ => {}
+        }
+    }
+
+    fn enter_detail_mode(&mut self) {
+        self.mode = Mode::Detail;
+        self.detail_actions = vec![
+            DetailAction::ViewSource,
+            DetailAction::CopyPath,
+            // TODO: toggle based on actual machine prefs disabled state
+            DetailAction::Disable,
+            DetailAction::Back,
+        ];
+        self.detail_selected = 0;
+    }
+
+    fn execute_action(&mut self, action: DetailAction) {
+        match action {
+            DetailAction::ViewSource => {
+                if let Some((_, _, path)) = self.selected_row_meta() {
+                    let _ = std::process::Command::new("open").arg(&path).spawn();
+                }
+            }
+            DetailAction::CopyPath => {
+                if let Some((_, _, path)) = self.selected_row_meta() {
+                    let _ = std::process::Command::new("sh")
+                        .arg("-c")
+                        .arg(format!(
+                            "echo -n '{}' | pbcopy",
+                            path.replace('\'', "'\\''")
+                        ))
+                        .status();
+                }
+            }
+            DetailAction::Disable | DetailAction::Enable => {
+                // For now, just go back — proper implementation requires machine.toml access
+                // which the browse module doesn't currently have
+                self.mode = Mode::Normal;
+            }
+            DetailAction::Back => {
+                self.mode = Mode::Normal;
+            }
         }
     }
 
@@ -100,6 +236,7 @@ impl App {
 
     fn refilter(&mut self) {
         self.filtered_indices = fuzzy::filter_rows(&self.search_input, &self.rows);
+        self.apply_sort();
         // Clamp cursor
         if self.filtered_indices.is_empty() {
             self.selected = 0;
@@ -108,6 +245,23 @@ impl App {
         }
         self.clamp_scroll();
         self.refresh_preview();
+    }
+
+    fn apply_sort(&mut self) {
+        match self.sort_mode {
+            SortMode::Name => self
+                .filtered_indices
+                .sort_by(|&a, &b| self.rows[a].name.cmp(&self.rows[b].name)),
+            SortMode::Source => self.filtered_indices.sort_by(|&a, &b| {
+                self.rows[a]
+                    .source
+                    .cmp(&self.rows[b].source)
+                    .then(self.rows[a].name.cmp(&self.rows[b].name))
+            }),
+            SortMode::Recent => self
+                .filtered_indices
+                .sort_by(|&a, &b| self.rows[b].synced_at.cmp(&self.rows[a].synced_at)),
+        }
     }
 
     fn move_cursor_down(&mut self, n: usize) {
@@ -200,6 +354,8 @@ mod tests {
                     name: format!("skill-{i}"),
                     source: "test".into(),
                     path: skill_dir.display().to_string(),
+                    managed: false,
+                    synced_at: String::new(),
                 }
             })
             .collect();
@@ -349,6 +505,8 @@ mod tests {
             name: "empty-skill".into(),
             source: "test".into(),
             path: skill_dir.display().to_string(),
+            managed: false,
+            synced_at: String::new(),
         }];
         let app = App::new(rows);
         assert!(app.preview_content.contains("[SKILL.md is empty]"));
@@ -365,6 +523,8 @@ mod tests {
             name: "no-file".into(),
             source: "test".into(),
             path: skill_dir.display().to_string(),
+            managed: false,
+            synced_at: String::new(),
         }];
         let app = App::new(rows);
         assert!(app.preview_content.contains("[failed to read"));
@@ -381,7 +541,170 @@ mod tests {
             app.handle_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
         }
 
-        // Preview should have updated to the first filtered match
-        assert!(app.preview_content.contains("skill-3"));
+        // Preview should have updated (may not be skill-3 first due to Name sort
+        // reordering fuzzy results, but skill-3 must be in the filtered set)
+        assert!(!app.filtered_indices.is_empty());
+        assert!(
+            app.filtered_indices
+                .iter()
+                .any(|&idx| app.rows[idx].name == "skill-3"),
+            "skill-3 should be in filtered results"
+        );
+        // Preview should show some valid skill content (not the fallback)
+        assert!(!app.preview_content.contains("No matching skill."));
+    }
+
+    fn make_row(name: &str, source: &str, synced: &str) -> SkillRow {
+        SkillRow {
+            name: name.to_string(),
+            source: source.to_string(),
+            path: format!("/test/{}", name),
+            managed: false,
+            synced_at: synced.to_string(),
+        }
+    }
+
+    #[test]
+    fn sort_by_name() {
+        let rows = vec![
+            make_row("zeta", "src-a", ""),
+            make_row("alpha", "src-b", ""),
+            make_row("mid", "src-a", ""),
+        ];
+        let app = App::new(rows);
+        assert_eq!(app.sort_mode, SortMode::Name);
+        let names: Vec<&str> = app
+            .filtered_indices
+            .iter()
+            .map(|&i| app.rows[i].name.as_str())
+            .collect();
+        assert_eq!(names, vec!["alpha", "mid", "zeta"]);
+    }
+
+    #[test]
+    fn sort_by_source() {
+        let rows = vec![
+            make_row("zeta", "src-b", ""),
+            make_row("alpha", "src-a", ""),
+            make_row("beta", "src-a", ""),
+        ];
+        let mut app = App::new(rows);
+        app.sort_mode = SortMode::Source;
+        app.refilter();
+        let names: Vec<&str> = app
+            .filtered_indices
+            .iter()
+            .map(|&i| app.rows[i].name.as_str())
+            .collect();
+        // Grouped by source, then alphabetical within source
+        assert_eq!(names, vec!["alpha", "beta", "zeta"]);
+    }
+
+    #[test]
+    fn sort_by_recent() {
+        let rows = vec![
+            make_row("old", "src", "2024-01-01T00:00:00Z"),
+            make_row("newest", "src", "2024-03-01T00:00:00Z"),
+            make_row("middle", "src", "2024-02-01T00:00:00Z"),
+        ];
+        let mut app = App::new(rows);
+        app.sort_mode = SortMode::Recent;
+        app.refilter();
+        let names: Vec<&str> = app
+            .filtered_indices
+            .iter()
+            .map(|&i| app.rows[i].name.as_str())
+            .collect();
+        assert_eq!(names, vec!["newest", "middle", "old"]);
+    }
+
+    #[test]
+    fn sort_cycles() {
+        assert_eq!(SortMode::Name.next(), SortMode::Source);
+        assert_eq!(SortMode::Source.next(), SortMode::Recent);
+        assert_eq!(SortMode::Recent.next(), SortMode::Name);
+    }
+
+    #[test]
+    fn sort_preserves_selection() {
+        let rows = vec![
+            make_row("zeta", "src-b", ""),
+            make_row("alpha", "src-a", ""),
+            make_row("beta", "src-a", ""),
+        ];
+        let mut app = App::new(rows);
+        // After Name sort, "alpha" is first. Move to "beta" (index 1).
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        let selected_name = app.rows[app.filtered_indices[app.selected]].name.clone();
+        assert_eq!(selected_name, "beta");
+    }
+
+    #[test]
+    fn enter_detail_mode() {
+        let (mut app, _tmp) = make_app(3);
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(app.mode, Mode::Detail);
+        assert!(!app.detail_actions.is_empty());
+        assert_eq!(app.detail_selected, 0);
+    }
+
+    #[test]
+    fn detail_mode_navigation() {
+        let (mut app, _tmp) = make_app(3);
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(app.mode, Mode::Detail);
+        let num_actions = app.detail_actions.len();
+
+        // Move down
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        assert_eq!(app.detail_selected, 1);
+
+        // Move up
+        app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
+        assert_eq!(app.detail_selected, 0);
+
+        // Clamp at bottom
+        for _ in 0..num_actions + 2 {
+            app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        }
+        assert_eq!(app.detail_selected, num_actions - 1);
+    }
+
+    #[test]
+    fn detail_mode_back() {
+        let (mut app, _tmp) = make_app(3);
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(app.mode, Mode::Detail);
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(app.mode, Mode::Normal);
+    }
+
+    #[test]
+    fn group_by_source_toggle() {
+        let (mut app, _tmp) = make_app(3);
+        assert!(!app.group_by_source);
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert!(app.group_by_source);
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert!(!app.group_by_source);
+    }
+
+    #[test]
+    fn search_then_sort() {
+        let (mut app, _tmp) = make_app(10);
+        // Enter search mode
+        app.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE));
+        for c in "skill".chars() {
+            app.handle_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        // All 10 should match "skill"
+        assert_eq!(app.filtered_indices.len(), 10);
+
+        // Cycle sort and verify it still has the right count
+        app.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+        assert_eq!(app.sort_mode, SortMode::Source);
+        assert_eq!(app.filtered_indices.len(), 10);
     }
 }

--- a/crates/tome/src/browse/fuzzy.rs
+++ b/crates/tome/src/browse/fuzzy.rs
@@ -48,16 +48,22 @@ mod tests {
                 name: "pdf-extract".into(),
                 source: "claude-plugins".into(),
                 path: "~/.claude/plugins/pdf-extract".into(),
+                managed: false,
+                synced_at: String::new(),
             },
             SkillRow {
                 name: "git-commit".into(),
                 source: "claude-skills".into(),
                 path: "~/.claude/skills/git-commit".into(),
+                managed: false,
+                synced_at: String::new(),
             },
             SkillRow {
                 name: "rust-clippy".into(),
                 source: "agents-skills".into(),
                 path: "~/.agents/skills/rust-clippy".into(),
+                managed: false,
+                synced_at: String::new(),
             },
         ]
     }

--- a/crates/tome/src/browse/mod.rs
+++ b/crates/tome/src/browse/mod.rs
@@ -11,13 +11,23 @@ use crate::discover::DiscoveredSkill;
 use app::{App, SkillRow};
 
 /// Launch the interactive skill browser.
-pub fn browse(skills: Vec<DiscoveredSkill>) -> Result<()> {
+pub fn browse(skills: Vec<DiscoveredSkill>, manifest: &crate::manifest::Manifest) -> Result<()> {
     let rows: Vec<SkillRow> = skills
         .into_iter()
-        .map(|s| SkillRow {
-            name: s.name.to_string(),
-            source: s.source_name,
-            path: s.path.display().to_string(),
+        .map(|s| {
+            let skill_name = s.name.to_string();
+            let synced_at = manifest
+                .get(&skill_name)
+                .map(|e| e.synced_at.clone())
+                .unwrap_or_default();
+            let managed = s.origin.is_managed();
+            SkillRow {
+                name: skill_name,
+                source: s.source_name,
+                path: s.path.display().to_string(),
+                managed,
+                synced_at,
+            }
         })
         .collect();
 

--- a/crates/tome/src/browse/ui.rs
+++ b/crates/tome/src/browse/ui.rs
@@ -2,11 +2,20 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, Wrap};
+use ratatui::widgets::{
+    Block, Borders, Cell, List, ListItem, ListState, Paragraph, Row, Table, Wrap,
+};
 
-use super::app::{App, Mode};
+use super::app::{App, Mode, SortMode};
 
 pub fn render(frame: &mut Frame, app: &mut App) {
+    match app.mode {
+        Mode::Detail => render_detail(frame, app),
+        _ => render_normal(frame, app),
+    }
+}
+
+fn render_normal(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
 
     let chunks = Layout::vertical([
@@ -42,30 +51,10 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     frame.render_widget(separator, chunks[1]);
 
     // -- Left body: skills table --
-    let visible_rows: Vec<Row> = app
-        .filtered_indices
-        .iter()
-        .skip(app.scroll_offset)
-        .take(app.visible_height)
-        .enumerate()
-        .map(|(vis_idx, &row_idx)| {
-            let row = &app.rows[row_idx];
-            let abs_idx = app.scroll_offset + vis_idx;
-            let style = if abs_idx == app.selected {
-                Style::default()
-                    .bg(Color::DarkGray)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default()
-            };
-            Row::new(vec![
-                Cell::from(row.name.as_str()),
-                Cell::from(row.source.as_str()),
-                Cell::from(row.path.as_str()),
-            ])
-            .style(style)
-        })
-        .collect();
+    let show_groups =
+        app.group_by_source && app.sort_mode == SortMode::Source && app.search_input.is_empty();
+
+    let visible_rows = build_visible_rows(app, show_groups);
 
     let body_table = Table::new(visible_rows, widths()).block(Block::default());
     frame.render_widget(body_table, body_chunks[0]);
@@ -81,6 +70,205 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     frame.render_widget(preview, body_chunks[1]);
 
     // -- Status bar --
+    render_status_bar(frame, app, area.width, chunks[3]);
+}
+
+/// Build the visible table rows, optionally inserting group headers when
+/// `show_groups` is true. Group headers are non-selectable visual separators.
+fn build_visible_rows<'a>(app: &'a App, show_groups: bool) -> Vec<Row<'a>> {
+    let mut rows: Vec<Row<'a>> = Vec::new();
+    let mut prev_source: Option<&str> = None;
+
+    for (vis_idx, &row_idx) in app
+        .filtered_indices
+        .iter()
+        .skip(app.scroll_offset)
+        .take(app.visible_height)
+        .enumerate()
+    {
+        let row = &app.rows[row_idx];
+        let abs_idx = app.scroll_offset + vis_idx;
+
+        // Insert group header when source changes
+        if show_groups {
+            let current_source = row.source.as_str();
+            if prev_source != Some(current_source) {
+                // Count skills in this source group
+                let group_count = app
+                    .filtered_indices
+                    .iter()
+                    .filter(|&&idx| app.rows[idx].source == current_source)
+                    .count();
+                let header_text = format!("── {} ({}) ──", current_source, group_count);
+                rows.push(
+                    Row::new(vec![
+                        Cell::from(header_text),
+                        Cell::from(""),
+                        Cell::from(""),
+                    ])
+                    .style(
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                );
+                prev_source = Some(current_source);
+            }
+        }
+
+        let style = if abs_idx == app.selected {
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        rows.push(
+            Row::new(vec![
+                Cell::from(row.name.as_str()),
+                Cell::from(row.source.as_str()),
+                Cell::from(row.path.as_str()),
+            ])
+            .style(style),
+        );
+    }
+
+    rows
+}
+
+fn render_detail(frame: &mut Frame, app: &mut App) {
+    let area = frame.area();
+
+    let chunks = Layout::vertical([
+        Constraint::Min(1),    // body
+        Constraint::Length(1), // status bar
+    ])
+    .split(area);
+
+    let body_chunks = Layout::horizontal([Constraint::Percentage(45), Constraint::Percentage(55)])
+        .split(chunks[0]);
+
+    // -- Left side: metadata + action list --
+    let left_chunks = Layout::vertical([
+        Constraint::Length(2), // title + separator
+        Constraint::Length(6), // metadata
+        Constraint::Min(1),    // actions
+    ])
+    .split(body_chunks[0]);
+
+    // Get the selected row info
+    let (name, source, path, managed, synced_at) =
+        if let Some(&row_idx) = app.filtered_indices.get(app.selected) {
+            let row = &app.rows[row_idx];
+            (
+                row.name.as_str(),
+                row.source.as_str(),
+                row.path.as_str(),
+                row.managed,
+                row.synced_at.as_str(),
+            )
+        } else {
+            ("(none)", "", "", false, "")
+        };
+
+    // Title
+    let title = Paragraph::new(Line::from(vec![
+        Span::styled("< ", Style::default().fg(Color::Cyan)),
+        Span::styled(
+            name,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]));
+    frame.render_widget(title, left_chunks[0]);
+
+    // Metadata
+    let type_label = if managed { "managed" } else { "local" };
+    let synced_display = if synced_at.is_empty() {
+        "(unknown)"
+    } else {
+        synced_at
+    };
+    let metadata = Paragraph::new(vec![
+        Line::from("────────────────────"),
+        Line::from(vec![
+            Span::styled("Source:   ", Style::default().fg(Color::DarkGray)),
+            Span::raw(source),
+        ]),
+        Line::from(vec![
+            Span::styled("Type:     ", Style::default().fg(Color::DarkGray)),
+            Span::raw(type_label),
+        ]),
+        Line::from(vec![
+            Span::styled("Path:     ", Style::default().fg(Color::DarkGray)),
+            Span::raw(path),
+        ]),
+        Line::from(vec![
+            Span::styled("Synced:   ", Style::default().fg(Color::DarkGray)),
+            Span::raw(synced_display),
+        ]),
+    ]);
+    frame.render_widget(metadata, left_chunks[1]);
+
+    // Actions list
+    let items: Vec<ListItem> = app
+        .detail_actions
+        .iter()
+        .enumerate()
+        .map(|(i, action)| {
+            let style = if i == app.detail_selected {
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            let prefix = if i == app.detail_selected { "> " } else { "  " };
+            ListItem::new(format!("{}{}", prefix, action.label())).style(style)
+        })
+        .collect();
+
+    let actions_block = Block::default()
+        .title("Actions")
+        .borders(Borders::TOP)
+        .border_style(Style::default().fg(Color::DarkGray));
+    let actions_list = List::new(items).block(actions_block);
+    let mut list_state = ListState::default().with_selected(Some(app.detail_selected));
+    frame.render_stateful_widget(actions_list, left_chunks[2], &mut list_state);
+
+    // -- Right side: preview --
+    let preview = Paragraph::new(app.preview_content.as_str())
+        .block(
+            Block::default()
+                .title(app.preview_title.as_str())
+                .borders(Borders::LEFT),
+        )
+        .wrap(Wrap { trim: false });
+    frame.render_widget(preview, body_chunks[1]);
+
+    // -- Status bar for Detail mode --
+    let status = Line::from(vec![
+        Span::styled(
+            " Detail ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            " j/k select  \u{23ce} run action  esc back",
+            Style::default().fg(Color::Gray).bg(Color::DarkGray),
+        ),
+        Span::styled(
+            " ".repeat(area.width as usize),
+            Style::default().bg(Color::DarkGray),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(status), chunks[1]);
+}
+
+fn render_status_bar(frame: &mut Frame, app: &App, width: u16, area: ratatui::layout::Rect) {
     let filtered = app.filtered_indices.len();
     let total = app.rows.len();
 
@@ -91,11 +279,15 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     };
 
     let mode_text = match app.mode {
-        Mode::Normal => String::new(),
+        Mode::Normal | Mode::Detail => String::new(),
         Mode::Search => format!("/{}", app.search_input),
     };
 
-    let hints = " │ j/k ↕  / search  q quit";
+    let sort_label = app.sort_mode.label();
+    let hints = format!(
+        " | j/k \u{2195}  / search  s sort:{}  tab group  \u{23ce} detail  q quit",
+        sort_label
+    );
 
     let status = Line::from(vec![
         Span::styled(
@@ -109,18 +301,15 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             format!(" {mode_text}"),
             Style::default().fg(Color::Yellow).bg(Color::DarkGray),
         ),
-        Span::styled(
-            hints.to_string(),
-            Style::default().fg(Color::Gray).bg(Color::DarkGray),
-        ),
+        Span::styled(hints, Style::default().fg(Color::Gray).bg(Color::DarkGray)),
         // Fill the rest
         Span::styled(
-            " ".repeat(area.width as usize),
+            " ".repeat(width as usize),
             Style::default().bg(Color::DarkGray),
         ),
     ]);
 
-    frame.render_widget(Paragraph::new(status), chunks[3]);
+    frame.render_widget(Paragraph::new(status), area);
 }
 
 fn widths() -> [Constraint; 3] {

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -175,7 +175,8 @@ pub fn run(cli: Cli) -> Result<()> {
                 println!("No skills found. Run `tome init` to configure sources.");
                 return Ok(());
             }
-            browse::browse(skills)?;
+            let manifest = manifest::load(paths.tome_home())?;
+            browse::browse(skills, &manifest)?;
         }
         Command::Eject => {
             let plan = eject::plan(&config, &paths)?;


### PR DESCRIPTION
## Summary

Completes the remaining v0.4.1 browse features.

### Sorting & Grouping (#166)
- **Sort modes**: `s` cycles through Name → Source → Recent (by `synced_at`)
- **Group by source**: `Tab` toggles visual group headers when sorted by source
- Sort indicator shown in status bar
- Sort applies within fuzzy-filtered results

### Detail Screen (#169)
- **Enter** opens detail view for selected skill
- Left pane shows metadata (source, type, path, synced_at) + action menu
- Right pane shows SKILL.md preview
- Actions: Open source directory (`open`), Copy path (`pbcopy`), Back
- `j/k` navigates actions, `Enter` executes, `Esc` returns to list

### Prerequisite: SkillRow enrichment
- `SkillRow` now includes `managed` and `synced_at` fields
- `browse()` accepts manifest reference to populate sync metadata
- `collapse_home()` used for path display in detail view

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] 277 unit tests pass (+10 new browse tests)
- [x] 59 integration tests pass

Closes #166, closes #169