### PR TITLE
feat: shell completions and lockfile warning demotion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,6 +1886,7 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "clap",
+ "clap_complete",
  "console 0.16.3",
  "crossterm",
  "dialoguer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/martinP7r/tome"
 [workspace.dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 console = "0.16"
 dialoguer = "0.12"
 indicatif = "0.18"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,7 @@
 ## v0.1.x — Polish & UX
 
 - [x] **Wizard interaction hints**: Show keybinding hints in MultiSelect prompts (space to toggle, enter to confirm) — embedded in prompt text to work around `dialoguer`'s limitation.
-- [ ] **Clarify plugin cache source**: Make it clearer that `~/.claude/plugins/cache` refers to *active* plugins installed from the Claude Code marketplace, not arbitrary cached files. Tracked in v0.4.1.
+- [x] **Clarify plugin cache source**: Clarified in v0.4.1 (#312).
 - [x] **Wizard visual polish**: Color, section dividers, and summary output via `console::style()` — implemented in `wizard.rs`.
 - [x] **Modern TUI with welcome ASCII art**: Evaluate `ratatui` vs `console` + `indicatif` before committing to a framework. → Decision: ratatui + nucleo for interactive commands (`tome browse`), plain text for non-interactive commands. See v0.2.1 and v0.4.1.
 - [x] **Progress spinners for sync** (`indicatif`): Spinners during discover → consolidate → distribute → cleanup steps, implemented in `lib.rs`.
@@ -147,7 +147,7 @@ Auto-install managed plugins and backup the library. Builds on the portable libr
 - [ ] **`tome update` auto-install**: Extend `tome update` to actively run `claude plugin install <name@registry>` for approved managed plugins, upgrading from notification-only to full reconciliation.
 - [ ] **Claude marketplace first** ([#41](https://github.com/MartinP7r/tome/issues/41)): First managed source targeting the Claude plugin marketplace. Version pinning via version string or git commit SHA.
 - [ ] **Git-backed backup & restore** ([#94](https://github.com/MartinP7r/tome/issues/94)): `tome backup` subcommand for snapshots, restore, and diff of library state. Optional automatic pre-sync snapshots (`auto_snapshot = true`). Includes `tome restore <git-url>` for bootstrapping a new machine from a git-backed library.
-- [ ] **Portable config paths**: Wizard should write `~/`-prefixed paths in `tome.toml` instead of absolute paths, so config is portable across machines with different usernames/OS.
+- [x] **Portable config paths**: Wizard writes `~/`-prefixed paths in `tome.toml` for portability across machines.
 - [ ] **Git repo scope for library**: Design decision needed — should the git repo be scoped to just the library, or to a broader "tome home" that also tracks hooks, commands, agents, and other AI tool config? The broader scope is more useful for portable machine setup (backup everything, not just skills), but complicates `tome sync` git operations which currently assume library-only changes. Options: (a) git root = `~/.tome/` (includes skills + config), (b) git root = library only (skills), (c) let the user decide and scope git operations accordingly.
 - [ ] **Remote library sync**: `tome pull` / `tome push` for syncing the git-backed library with a remote. Handle merge conflicts in skill files — detect conflicts after pull, offer `tome doctor` to verify integrity. `tome update` lockfile diffing should account for remote changes to the lockfile.
 - [ ] **Shell completions** ([#208](https://github.com/MartinP7r/tome/issues/208)): `clap_complete` for bash, zsh, fish, PowerShell

--- a/crates/tome/Cargo.toml
+++ b/crates/tome/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 console.workspace = true
 dialoguer.workspace = true
 dirs.workspace = true

--- a/crates/tome/src/cli.rs
+++ b/crates/tome/src/cli.rs
@@ -77,6 +77,13 @@ pub enum Command {
         new_path: PathBuf,
     },
 
+    /// Generate shell completions for bash, zsh, fish, or powershell
+    Completions {
+        /// Shell to generate completions for
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
+    },
+
     /// Print version information
     Version,
 

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -245,6 +245,10 @@ pub fn run(cli: Cli) -> Result<()> {
             relocate::verify(&new_config, &plan.new_library_dir, paths.tome_home())?;
         }
         Command::Version => unreachable!(),
+        Command::Completions { shell } => {
+            let mut cmd = <cli::Cli as clap::CommandFactory>::command();
+            clap_complete::generate(shell, &mut cmd, "tome", &mut std::io::stdout());
+        }
         Command::List { json } => list(&config, cli.quiet, json)?,
         Command::Config { path } => show_config(&config, path)?,
     }
@@ -408,7 +412,9 @@ fn sync(
     // Generate lockfile for reproducibility
     if !dry_run && paths.tome_home().is_dir() {
         let lf = lockfile::generate(&manifest, &skills);
-        lockfile::save(&lf, paths.tome_home())?;
+        if let Err(e) = lockfile::save(&lf, paths.tome_home()) {
+            eprintln!("warning: could not save lockfile: {e}");
+        }
     }
 
     let report = SyncReport {
@@ -609,7 +615,9 @@ fn update_cmd(
         if paths.library_dir().is_dir() {
             library::generate_gitignore(paths.library_dir(), &manifest)?;
         }
-        lockfile::save(&new_lockfile, paths.tome_home())?;
+        if let Err(e) = lockfile::save(&new_lockfile, paths.tome_home()) {
+            eprintln!("warning: could not save lockfile: {e}");
+        }
     }
 
     let report = SyncReport {

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -2436,3 +2436,35 @@ fn eject_nothing_to_eject() {
         .success()
         .stdout(predicate::str::contains("Nothing to eject"));
 }
+
+#[test]
+fn completions_fish_outputs_valid_completions() {
+    tome()
+        .args(["completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("complete -c tome"));
+}
+
+#[test]
+fn completions_bash_outputs_valid_completions() {
+    tome()
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tome"));
+}
+
+#[test]
+fn completions_zsh_outputs_valid_completions() {
+    tome()
+        .args(["completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("#compdef tome"));
+}
+
+#[test]
+fn completions_invalid_shell_fails() {
+    tome().args(["completions", "invalid"]).assert().failure();
+}


### PR DESCRIPTION
Closes #208, closes #224

- **Shell completions**: `tome completions <shell>` generates completions for bash, zsh, fish, powershell via `clap_complete`
- **Lockfile warning**: Lockfile write failures demoted from hard error to warning — sync no longer aborts
- **Roadmap**: Checked off portable config paths and plugin cache wording (already shipped)

4 new integration tests for completions.