### PR TITLE
feat: add tome lint command with frontmatter parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,6 +1582,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,6 +1911,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "tabled",
  "tempfile",
@@ -1996,6 +2010,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tabled = "0.20"
 toml = "1"
 sha2 = "0.10"
 walkdir = "2"
+serde_yaml = "0.9"
 
 # TUI
 ratatui = "0.30"

--- a/crates/tome/Cargo.toml
+++ b/crates/tome/Cargo.toml
@@ -25,6 +25,7 @@ serde_json.workspace = true
 tabled.workspace = true
 toml.workspace = true
 walkdir.workspace = true
+serde_yaml.workspace = true
 
 # TUI (browse command)
 ratatui.workspace = true

--- a/crates/tome/src/cli.rs
+++ b/crates/tome/src/cli.rs
@@ -35,6 +35,12 @@ pub struct Cli {
     pub machine: Option<PathBuf>,
 }
 
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum LintFormat {
+    Text,
+    Json,
+}
+
 #[derive(Subcommand)]
 pub enum Command {
     /// Interactive wizard to configure sources and targets
@@ -62,6 +68,16 @@ pub enum Command {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+    },
+
+    /// Validate skill frontmatter and report issues
+    Lint {
+        /// Specific skill directory to lint (default: entire library)
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
+        /// Output format
+        #[arg(long, value_enum, default_value = "text")]
+        format: LintFormat,
     },
 
     /// Interactively browse discovered skills

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -29,11 +29,13 @@ pub(crate) mod distribute;
 pub(crate) mod doctor;
 pub(crate) mod eject;
 pub(crate) mod library;
+pub(crate) mod lint;
 pub(crate) mod lockfile;
 pub(crate) mod machine;
 pub(crate) mod manifest;
 pub(crate) mod paths;
 pub(crate) mod relocate;
+pub(crate) mod skill;
 pub(crate) mod status;
 pub(crate) mod update;
 pub(crate) mod validation;
@@ -163,6 +165,26 @@ pub fn run(cli: Cli) -> Result<()> {
         )?,
         Command::Status => status::show(&config, &paths)?,
         Command::Doctor => doctor::diagnose(&config, &paths, cli.dry_run)?,
+        Command::Lint { path, format } => {
+            let report = match path {
+                Some(p) => {
+                    let dir_name = p.file_name().and_then(|n| n.to_str()).unwrap_or("unknown");
+                    let issues = lint::lint_skill(dir_name, &p);
+                    lint::LintReport {
+                        results: vec![(dir_name.to_string(), issues)],
+                        skills_checked: 1,
+                    }
+                }
+                None => lint::lint_library(paths.library_dir()),
+            };
+            match format {
+                cli::LintFormat::Text => lint::render_text(&report),
+                cli::LintFormat::Json => lint::render_json(&report),
+            }
+            if report.has_errors() {
+                std::process::exit(1);
+            }
+        }
         Command::Browse => {
             let mut warnings = Vec::new();
             let skills = discover::discover_all(&config, &mut warnings)?;

--- a/crates/tome/src/lint.rs
+++ b/crates/tome/src/lint.rs
@@ -1,0 +1,516 @@
+//! Skill validation and linting.
+//!
+//! Implements tiered validation (error/warning/info) for SKILL.md frontmatter
+//! based on the agentskills.io standard and platform compatibility requirements.
+
+use console::style;
+use std::path::Path;
+
+use crate::skill;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+}
+
+#[derive(Debug, Clone)]
+pub struct LintIssue {
+    pub severity: Severity,
+    pub message: String,
+}
+
+pub struct LintReport {
+    pub results: Vec<(String, Vec<LintIssue>)>, // (skill_name, issues)
+    pub skills_checked: usize,
+}
+
+impl LintReport {
+    pub fn error_count(&self) -> usize {
+        self.results
+            .iter()
+            .flat_map(|(_, issues)| issues)
+            .filter(|i| i.severity == Severity::Error)
+            .count()
+    }
+    pub fn warning_count(&self) -> usize {
+        self.results
+            .iter()
+            .flat_map(|(_, issues)| issues)
+            .filter(|i| i.severity == Severity::Warning)
+            .count()
+    }
+    pub fn info_count(&self) -> usize {
+        self.results
+            .iter()
+            .flat_map(|(_, issues)| issues)
+            .filter(|i| i.severity == Severity::Info)
+            .count()
+    }
+    pub fn has_errors(&self) -> bool {
+        self.error_count() > 0
+    }
+}
+
+/// Lint a single skill directory.
+pub fn lint_skill(dir_name: &str, skill_dir: &Path) -> Vec<LintIssue> {
+    let mut issues = Vec::new();
+    let skill_md = skill_dir.join("SKILL.md");
+
+    let content = match std::fs::read_to_string(&skill_md) {
+        Ok(c) => c,
+        Err(e) => {
+            issues.push(LintIssue {
+                severity: Severity::Error,
+                message: format!("could not read SKILL.md: {e}"),
+            });
+            return issues;
+        }
+    };
+
+    let (fm, body) = match skill::parse(&content) {
+        Ok(result) => result,
+        Err(e) => {
+            issues.push(LintIssue {
+                severity: Severity::Error,
+                message: e,
+            });
+            return issues;
+        }
+    };
+
+    // --- Errors ---
+
+    // name present but doesn't match directory
+    if let Some(ref name) = fm.name {
+        if name != dir_name {
+            issues.push(LintIssue {
+                severity: Severity::Error,
+                message: format!(
+                    "name '{}' does not match directory name '{}'",
+                    name, dir_name
+                ),
+            });
+        }
+        if name.len() > 64 {
+            issues.push(LintIssue {
+                severity: Severity::Error,
+                message: format!("name exceeds 64 characters ({} chars)", name.len()),
+            });
+        }
+        if !name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        {
+            issues.push(LintIssue {
+                severity: Severity::Error,
+                message: format!(
+                    "name '{}' uses invalid characters (expected [a-z0-9-])",
+                    name
+                ),
+            });
+        }
+    }
+
+    // Missing description
+    if fm.description.is_none() {
+        issues.push(LintIssue {
+            severity: Severity::Error,
+            message: "missing required 'description' field".to_string(),
+        });
+    }
+
+    // --- Warnings ---
+
+    // Missing name (not portable)
+    if fm.name.is_none() {
+        issues.push(LintIssue {
+            severity: Severity::Warning,
+            message:
+                "missing 'name' field -- Claude Code infers from directory, but other tools may not"
+                    .to_string(),
+        });
+    }
+
+    // Description length warnings
+    if let Some(ref desc) = fm.description {
+        if desc.is_empty() {
+            issues.push(LintIssue {
+                severity: Severity::Info,
+                message: "description is empty".to_string(),
+            });
+        } else if desc.len() > 1024 {
+            issues.push(LintIssue {
+                severity: Severity::Warning,
+                message: format!("description exceeds 1024 characters ({} chars)", desc.len()),
+            });
+        } else if desc.len() > 500 {
+            issues.push(LintIssue {
+                severity: Severity::Warning,
+                message: format!(
+                    "description exceeds 500 characters ({} chars) -- may be truncated by VS Code Copilot",
+                    desc.len()
+                ),
+            });
+        }
+    }
+
+    // Non-standard fields
+    let known_non_standard = ["version", "category", "tags", "last-updated", "author"];
+    for key in fm.extra.keys() {
+        if known_non_standard.contains(&key.as_str()) {
+            issues.push(LintIssue {
+                severity: Severity::Warning,
+                message: format!(
+                    "non-standard field '{}' -- consider moving to 'metadata' section",
+                    key
+                ),
+            });
+        }
+    }
+
+    // Body length
+    if body.len() > 6000 {
+        issues.push(LintIssue {
+            severity: Severity::Warning,
+            message: format!(
+                "body exceeds 6000 characters ({} chars) -- may be truncated by Windsurf",
+                body.len()
+            ),
+        });
+    }
+
+    // Unicode Tag codepoints (U+E0001-U+E007F) -- security risk
+    if content
+        .chars()
+        .any(|c| ('\u{E0001}'..='\u{E007F}').contains(&c))
+    {
+        issues.push(LintIssue {
+            severity: Severity::Warning,
+            message: "contains hidden Unicode Tag codepoints (U+E0001-U+E007F) -- potential prompt injection risk".to_string(),
+        });
+    }
+
+    // --- Info ---
+
+    if fm.allowed_tools.is_some() {
+        issues.push(LintIssue {
+            severity: Severity::Info,
+            message: "'allowed-tools' field is experimental".to_string(),
+        });
+    }
+
+    issues
+}
+
+/// Lint all skills in a library directory.
+pub fn lint_library(library_dir: &Path) -> LintReport {
+    let mut results = Vec::new();
+    let mut skills_checked = 0;
+
+    if let Ok(entries) = std::fs::read_dir(library_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() && !path.is_symlink() {
+                continue;
+            }
+            // For symlinks (managed skills), resolve to check if directory
+            if path.is_symlink() {
+                match std::fs::metadata(&path) {
+                    Ok(m) if m.is_dir() => {}
+                    _ => continue,
+                }
+            }
+
+            let dir_name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+
+            // Skip non-skill entries (manifest, gitignore, etc.)
+            if dir_name.starts_with('.') {
+                continue;
+            }
+
+            let skill_md = path.join("SKILL.md");
+            if !skill_md.exists() {
+                if let Ok(true) = skill_md.try_exists() {
+                    // exists through symlink, proceed
+                } else {
+                    continue;
+                }
+            }
+
+            let issues = lint_skill(&dir_name, &path);
+            skills_checked += 1;
+            results.push((dir_name, issues));
+        }
+    }
+
+    results.sort_by(|a, b| a.0.cmp(&b.0));
+    LintReport {
+        results,
+        skills_checked,
+    }
+}
+
+/// Render the lint report to stdout.
+pub fn render_text(report: &LintReport) {
+    for (name, issues) in &report.results {
+        if issues.is_empty() {
+            continue; // Skip clean skills in text output
+        }
+        println!("{}:", style(name).bold());
+        for issue in issues {
+            let (icon, styled_msg) = match issue.severity {
+                Severity::Error => (style("x").red(), style(&issue.message).red()),
+                Severity::Warning => (style("!").yellow(), style(&issue.message).yellow()),
+                Severity::Info => (style("i").cyan(), style(&issue.message).cyan()),
+            };
+            println!("  {} {}", icon, styled_msg);
+        }
+        println!();
+    }
+
+    let errors = report.error_count();
+    let warnings = report.warning_count();
+    let info = report.info_count();
+    println!(
+        "Checked {} skill(s): {} error(s), {} warning(s), {} info",
+        report.skills_checked, errors, warnings, info
+    );
+}
+
+/// Render the lint report as JSON.
+pub fn render_json(report: &LintReport) {
+    let issues: Vec<serde_json::Value> = report
+        .results
+        .iter()
+        .flat_map(|(name, issues)| {
+            issues.iter().map(move |issue| {
+                serde_json::json!({
+                    "skill": name,
+                    "severity": match issue.severity {
+                        Severity::Error => "error",
+                        Severity::Warning => "warning",
+                        Severity::Info => "info",
+                    },
+                    "message": issue.message,
+                })
+            })
+        })
+        .collect();
+
+    let output = serde_json::json!({
+        "skills_checked": report.skills_checked,
+        "errors": report.error_count(),
+        "warnings": report.warning_count(),
+        "info": report.info_count(),
+        "issues": issues,
+    });
+
+    println!("{}", serde_json::to_string_pretty(&output).unwrap());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn create_skill_dir(dir: &Path, name: &str, content: &str) {
+        let skill_dir = dir.join(name);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), content).unwrap();
+    }
+
+    #[test]
+    fn lint_missing_frontmatter() {
+        let tmp = TempDir::new().unwrap();
+        create_skill_dir(tmp.path(), "my-skill", "# No frontmatter here");
+        let issues = lint_skill("my-skill", &tmp.path().join("my-skill"));
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.severity == Severity::Error && i.message.contains("no frontmatter"))
+        );
+    }
+
+    #[test]
+    fn lint_invalid_yaml() {
+        let tmp = TempDir::new().unwrap();
+        create_skill_dir(tmp.path(), "my-skill", "---\n: invalid [[\n---\nbody");
+        let issues = lint_skill("my-skill", &tmp.path().join("my-skill"));
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.severity == Severity::Error && i.message.contains("invalid YAML"))
+        );
+    }
+
+    #[test]
+    fn lint_name_mismatch() {
+        let tmp = TempDir::new().unwrap();
+        create_skill_dir(
+            tmp.path(),
+            "my-skill",
+            "---\nname: wrong-name\ndescription: test\n---\nbody",
+        );
+        let issues = lint_skill("my-skill", &tmp.path().join("my-skill"));
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.severity == Severity::Error && i.message.contains("does not match"))
+        );
+    }
+
+    #[test]
+    fn lint_name_too_long() {
+        let tmp = TempDir::new().unwrap();
+        let long_name = "a".repeat(65);
+        let dir_name = long_name.clone();
+        create_skill_dir(
+            tmp.path(),
+            &dir_name,
+            &format!("---\nname: {}\ndescription: test\n---\nbody", long_name),
+        );
+        let issues = lint_skill(&dir_name, &tmp.path().join(&dir_name));
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.severity == Severity::Error && i.message.contains("exceeds 64"))
+        );
+    }
+
+    #[test]
+    fn lint_name_invalid_chars() {
+        let tmp = TempDir::new().unwrap();
+        create_skill_dir(
+            tmp.path(),
+            "My_Skill",
+            "---\nname: My_Skill\ndescription: test\n---\nbody",
+        );
+        let issues = lint_skill("My_Skill", &tmp.path().join("My_Skill"));
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.severity == Severity::Error && i.message.contains("invalid characters"))
+        );
+    }
+
+    #[test]
+    fn lint_missing_description() {
+        let tmp = TempDir::new().unwrap();
+        create_skill_dir(tmp.path(), "my-skill", "---\nname: my-skill\n---\nbody");
+        let issues = lint_skill("my-skill", &tmp.path().join("my-skill"));
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.severity == Severity::Error && i.message.contains("missing required"))
+        );
+    }
+
+    #[test]
+    fn lint_missing_name_warning() {
+        let tmp = TempDir::new().unwrap();
+        create_skill_dir(
+            tmp.path(),
+            "my-skill",
+            "---\ndescription: A test skill\n---\nbody",
+        );
+        let issues = lint_skill("my-skill", &tmp.path().join("my-skill"));
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.severity == Severity::Warning && i.message.contains("missing 'name'"))
+        );
+    }
+
+    #[test]
+    fn lint_description_too_long() {
+        let tmp = TempDir::new().unwrap();
+        let long_desc = "x".repeat(1025);
+        create_skill_dir(
+            tmp.path(),
+            "my-skill",
+            &format!(
+                "---\nname: my-skill\ndescription: \"{}\"\n---\nbody",
+                long_desc
+            ),
+        );
+        let issues = lint_skill("my-skill", &tmp.path().join("my-skill"));
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.severity == Severity::Warning && i.message.contains("exceeds 1024"))
+        );
+    }
+
+    #[test]
+    fn lint_non_standard_fields() {
+        let tmp = TempDir::new().unwrap();
+        create_skill_dir(
+            tmp.path(),
+            "my-skill",
+            "---\nname: my-skill\ndescription: test\nversion: 1.0\n---\nbody",
+        );
+        let issues = lint_skill("my-skill", &tmp.path().join("my-skill"));
+        assert!(
+            issues.iter().any(
+                |i| i.severity == Severity::Warning && i.message.contains("non-standard field")
+            )
+        );
+    }
+
+    #[test]
+    fn lint_clean_skill() {
+        let tmp = TempDir::new().unwrap();
+        create_skill_dir(
+            tmp.path(),
+            "my-skill",
+            "---\nname: my-skill\ndescription: A valid skill\n---\n# Body",
+        );
+        let issues = lint_skill("my-skill", &tmp.path().join("my-skill"));
+        assert!(issues.is_empty(), "expected no issues, got: {:?}", issues);
+    }
+
+    #[test]
+    fn lint_report_counts() {
+        let tmp = TempDir::new().unwrap();
+        // Clean skill
+        create_skill_dir(
+            tmp.path(),
+            "good-skill",
+            "---\nname: good-skill\ndescription: Valid\n---\nbody",
+        );
+        // Skill with errors (missing description + name mismatch)
+        create_skill_dir(tmp.path(), "bad-skill", "---\nname: wrong-name\n---\nbody");
+
+        let report = lint_library(tmp.path());
+        assert_eq!(report.skills_checked, 2);
+        assert!(report.has_errors());
+        assert!(report.error_count() >= 2); // name mismatch + missing description
+    }
+
+    #[test]
+    fn lint_skips_dotfiles() {
+        let tmp = TempDir::new().unwrap();
+        // Create a dotfile directory that should be skipped
+        let dotdir = tmp.path().join(".hidden");
+        std::fs::create_dir_all(&dotdir).unwrap();
+        std::fs::write(dotdir.join("SKILL.md"), "---\nname: hidden\n---\nbody").unwrap();
+
+        let report = lint_library(tmp.path());
+        assert_eq!(report.skills_checked, 0);
+    }
+
+    #[test]
+    fn lint_missing_skill_md_file() {
+        let tmp = TempDir::new().unwrap();
+        // Skill directory without SKILL.md — should not be counted
+        std::fs::create_dir_all(tmp.path().join("empty-skill")).unwrap();
+
+        let report = lint_library(tmp.path());
+        assert_eq!(report.skills_checked, 0);
+    }
+}

--- a/crates/tome/src/skill.rs
+++ b/crates/tome/src/skill.rs
@@ -1,0 +1,124 @@
+//! SKILL.md frontmatter parsing.
+//!
+//! Extracts and parses YAML frontmatter from SKILL.md files.
+
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+/// Parsed SKILL.md frontmatter fields.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+#[allow(dead_code)]
+pub struct SkillFrontmatter {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub license: Option<String>,
+    pub compatibility: Option<String>,
+    pub metadata: Option<BTreeMap<String, serde_yaml::Value>>,
+    pub allowed_tools: Option<String>,
+    // Claude Code extensions
+    pub user_invocable: Option<bool>,
+    pub argument_hint: Option<String>,
+    pub context: Option<String>,
+    pub agent: Option<String>,
+    // Capture unknown/non-standard fields
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_yaml::Value>,
+}
+
+/// Extract frontmatter YAML block from SKILL.md content.
+/// Returns (yaml_content, body) or None if no valid frontmatter delimiters.
+pub fn extract_frontmatter(content: &str) -> Option<(&str, &str)> {
+    let content = content.trim_start();
+    if !content.starts_with("---") {
+        return None;
+    }
+    let after_first = &content[3..];
+    // Skip the newline after opening ---
+    let after_first = after_first.strip_prefix('\n').unwrap_or(after_first);
+
+    // Handle empty frontmatter: closing --- immediately follows opening
+    if let Some(rest) = after_first.strip_prefix("---") {
+        let body = rest.strip_prefix('\n').unwrap_or(rest);
+        return Some(("", body));
+    }
+
+    let end = after_first.find("\n---")?;
+    let yaml = &after_first[..end];
+    let body = &after_first[end + 4..];
+    // Strip optional newline after closing ---
+    let body = body.strip_prefix('\n').unwrap_or(body);
+    Some((yaml.trim(), body))
+}
+
+/// Parse SKILL.md content into frontmatter + body.
+pub fn parse(content: &str) -> Result<(SkillFrontmatter, String), String> {
+    match extract_frontmatter(content) {
+        Some((yaml, body)) => {
+            let fm: SkillFrontmatter =
+                serde_yaml::from_str(yaml).map_err(|e| format!("invalid YAML frontmatter: {e}"))?;
+            Ok((fm, body.to_string()))
+        }
+        None => Err("no frontmatter found (expected --- delimiters)".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_frontmatter() {
+        let content = "---\nname: my-skill\ndescription: A test skill\n---\n# Body";
+        let (fm, body) = parse(content).unwrap();
+        assert_eq!(fm.name.as_deref(), Some("my-skill"));
+        assert_eq!(fm.description.as_deref(), Some("A test skill"));
+        assert_eq!(body, "# Body");
+    }
+
+    #[test]
+    fn parse_with_extra_fields() {
+        let content = "---\nname: test\nversion: 1.0\ncategory: tools\n---\nbody";
+        let (fm, _) = parse(content).unwrap();
+        assert!(fm.extra.contains_key("version"));
+        assert!(fm.extra.contains_key("category"));
+    }
+
+    #[test]
+    fn parse_missing_frontmatter() {
+        let content = "# Just a heading\nNo frontmatter here";
+        assert!(parse(content).is_err());
+    }
+
+    #[test]
+    fn parse_malformed_yaml() {
+        let content = "---\n: invalid yaml [[\n---\nbody";
+        assert!(parse(content).is_err());
+    }
+
+    #[test]
+    fn parse_empty_frontmatter() {
+        let content = "---\n---\nbody";
+        let (fm, body) = parse(content).unwrap();
+        assert!(fm.name.is_none());
+        assert_eq!(body, "body");
+    }
+
+    #[test]
+    fn parse_claude_code_extensions() {
+        let content = "---\nname: test\nuser-invocable: false\ncontext: fork\n---\nbody";
+        let (fm, _) = parse(content).unwrap();
+        assert_eq!(fm.user_invocable, Some(false));
+        assert_eq!(fm.context.as_deref(), Some("fork"));
+    }
+
+    #[test]
+    fn extract_no_frontmatter_returns_none() {
+        assert!(extract_frontmatter("just text").is_none());
+    }
+
+    #[test]
+    fn extract_unclosed_frontmatter_returns_none() {
+        assert!(extract_frontmatter("---\nname: test\n").is_none());
+    }
+}

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -2468,3 +2468,96 @@ fn completions_zsh_outputs_valid_completions() {
 fn completions_invalid_shell_fails() {
     tome().args(["completions", "invalid"]).assert().failure();
 }
+
+// === Lint tests ===
+
+#[test]
+fn lint_clean_library() {
+    let env = TestEnvBuilder::new()
+        .source("local", "directory")
+        .skill_with_content(
+            "good-skill",
+            "local",
+            "---\nname: good-skill\ndescription: A valid skill\n---\n# Good Skill",
+        )
+        .build();
+
+    // First sync to populate the library
+    env.cmd().arg("sync").assert().success();
+
+    env.cmd()
+        .arg("lint")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0 error(s)"));
+}
+
+#[test]
+fn lint_reports_errors() {
+    let env = TestEnvBuilder::new()
+        .source("local", "directory")
+        .skill_with_content("my-skill", "local", "---\nname: wrong-name\n---\n# Wrong")
+        .build();
+
+    // Sync to populate library
+    env.cmd().arg("sync").assert().success();
+
+    env.cmd()
+        .arg("lint")
+        .assert()
+        .failure() // exit code 1 because of errors
+        .stdout(predicate::str::contains("does not match directory"));
+}
+
+#[test]
+fn lint_json_output() {
+    let env = TestEnvBuilder::new()
+        .source("local", "directory")
+        .skill_with_content(
+            "test-skill",
+            "local",
+            "---\nname: test-skill\ndescription: Valid skill\n---\n# Test",
+        )
+        .build();
+
+    // Sync to populate library
+    env.cmd().arg("sync").assert().success();
+
+    env.cmd()
+        .args(["lint", "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"skills_checked\": 1"));
+}
+
+#[test]
+fn lint_single_skill_path() {
+    let tmp = TempDir::new().unwrap();
+    let skill = tmp.path().join("my-skill");
+    std::fs::create_dir_all(&skill).unwrap();
+    std::fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: my-skill\ndescription: Test\n---\n# Test",
+    )
+    .unwrap();
+
+    tome()
+        .args(["lint", &skill.to_string_lossy()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0 error(s)"));
+}
+
+#[test]
+fn lint_single_skill_path_with_errors() {
+    let tmp = TempDir::new().unwrap();
+    let skill = tmp.path().join("bad-skill");
+    std::fs::create_dir_all(&skill).unwrap();
+    std::fs::write(skill.join("SKILL.md"), "# No frontmatter").unwrap();
+
+    tome()
+        .args(["lint", &skill.to_string_lossy()])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("no frontmatter"));
+}


### PR DESCRIPTION
Closes #47
Closes #176

## Summary

- Add `skill.rs` module for SKILL.md frontmatter extraction and YAML parsing (serde_yaml)
- Add `lint.rs` module with tiered validation rules (error/warning/info):
  - **Errors**: missing frontmatter, invalid YAML, name/directory mismatch, name too long, invalid name characters, missing description
  - **Warnings**: missing name, long description (>500/1024 chars), non-standard fields, body >6000 chars, hidden Unicode tag codepoints (prompt injection risk)
  - **Info**: experimental allowed-tools field, empty description
- Add `tome lint` CLI command with `--format text|json` and optional `PATH` argument for single-skill linting
- Exit code 1 when errors are found (CI-friendly)
- 20 unit tests across skill.rs and lint.rs, 5 integration tests in cli.rs

## Test plan

- [x] `make ci` passes
- [x] All 298 unit tests pass
- [x] All 68 integration tests pass (including 5 new lint tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean