### PR TITLE
feat: tome backup — git-backed snapshot, restore, diff, and list (#94)

### DIFF
--- a/crates/tome/src/backup.rs
+++ b/crates/tome/src/backup.rs
@@ -1,0 +1,337 @@
+//! Git-backed backup and restore for the skill library.
+//!
+//! Provides snapshot, restore, list, and diff operations using git as the
+//! underlying version control system. All git operations use `std::process::Command`.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+/// Run a git command in the given directory, returning its raw output.
+fn git(library_dir: &Path, args: &[&str]) -> Result<std::process::Output> {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(library_dir)
+        .output()
+        .with_context(|| format!("failed to run git {}", args.join(" ")))?;
+    Ok(output)
+}
+
+/// Run a git command and bail if it fails.
+fn git_success(library_dir: &Path, args: &[&str]) -> Result<()> {
+    let output = git(library_dir, args)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git {} failed: {}", args.join(" "), stderr.trim());
+    }
+    Ok(())
+}
+
+/// Run a git command and return its stdout as a trimmed string.
+fn git_stdout(library_dir: &Path, args: &[&str]) -> Result<String> {
+    let output = git(library_dir, args)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git {} failed: {}", args.join(" "), stderr.trim());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Check whether the library directory contains a git repository.
+pub(crate) fn has_repo(library_dir: &Path) -> bool {
+    library_dir.join(".git").exists()
+}
+
+/// Initialize a git repository in the library directory.
+pub(crate) fn init(library_dir: &Path, dry_run: bool) -> Result<()> {
+    if has_repo(library_dir) {
+        println!("Git repo already exists in {}", library_dir.display());
+        return Ok(());
+    }
+    if dry_run {
+        println!("Would initialize git repo in {}", library_dir.display());
+        return Ok(());
+    }
+    std::fs::create_dir_all(library_dir)?;
+    git_success(library_dir, &["init"])?;
+    // Initial commit
+    git_success(library_dir, &["add", "-A"])?;
+    let output = git(library_dir, &["status", "--porcelain"])?;
+    let status = String::from_utf8_lossy(&output.stdout);
+    if !status.trim().is_empty() {
+        git_success(library_dir, &["commit", "-m", "Initial tome backup"])?;
+    }
+    println!("{} Initialized backup repo", console::style("✓").green());
+    Ok(())
+}
+
+/// Create a snapshot (git commit) of the current library state.
+///
+/// Returns `true` if a commit was created, `false` if there was nothing to commit.
+pub(crate) fn snapshot(library_dir: &Path, message: Option<&str>, dry_run: bool) -> Result<bool> {
+    if !has_repo(library_dir) {
+        anyhow::bail!("no git repo in library — run `tome backup init` first");
+    }
+    // Stage all changes (gitignore handles managed skill exclusion)
+    git_success(library_dir, &["add", "-A"])?;
+    // Check if there's anything to commit
+    let output = git(library_dir, &["status", "--porcelain"])?;
+    let status = String::from_utf8_lossy(&output.stdout);
+    if status.trim().is_empty() {
+        if !dry_run {
+            println!("Nothing to snapshot — library is clean");
+        }
+        return Ok(false);
+    }
+    if dry_run {
+        println!("Would snapshot {} changed file(s)", status.lines().count());
+        return Ok(true);
+    }
+    let msg = message.unwrap_or("tome backup snapshot");
+    git_success(library_dir, &["commit", "-m", msg])?;
+    println!("{} Snapshot created: {}", console::style("✓").green(), msg);
+    Ok(true)
+}
+
+/// A single entry in the backup history.
+pub(crate) struct BackupEntry {
+    pub hash: String,
+    pub date: String,
+    pub message: String,
+}
+
+/// List the most recent backup entries.
+pub(crate) fn list(library_dir: &Path, count: usize) -> Result<Vec<BackupEntry>> {
+    if !has_repo(library_dir) {
+        anyhow::bail!("no git repo in library — run `tome backup init` first");
+    }
+    let format = "--format=%h\t%ci\t%s";
+    let count_arg = format!("-{}", count);
+    let stdout = git_stdout(library_dir, &["log", &count_arg, format])?;
+    let entries = stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|line| {
+            let parts: Vec<&str> = line.splitn(3, '\t').collect();
+            BackupEntry {
+                hash: parts.first().unwrap_or(&"").to_string(),
+                date: parts.get(1).unwrap_or(&"").to_string(),
+                message: parts.get(2).unwrap_or(&"").to_string(),
+            }
+        })
+        .collect();
+    Ok(entries)
+}
+
+/// Restore the library to a previous snapshot.
+///
+/// Automatically creates a pre-restore snapshot of the current state before
+/// checking out files from the target ref.
+pub(crate) fn restore(library_dir: &Path, target: &str, dry_run: bool) -> Result<()> {
+    if !has_repo(library_dir) {
+        anyhow::bail!("no git repo in library — run `tome backup init` first");
+    }
+    if dry_run {
+        println!("Would restore library to {}", target);
+        return Ok(());
+    }
+    // Auto-snapshot current state before restoring
+    let _ = snapshot(library_dir, Some("pre-restore auto-snapshot"), false);
+    // Restore files from target ref
+    git_success(library_dir, &["checkout", target, "--", "."])?;
+    println!(
+        "{} Restored to {}. Run {} to re-distribute.",
+        console::style("✓").green(),
+        target,
+        console::style("tome sync").cyan(),
+    );
+    Ok(())
+}
+
+/// Show a diff stat of the working tree against a target ref.
+pub(crate) fn diff(library_dir: &Path, target: &str) -> Result<String> {
+    if !has_repo(library_dir) {
+        anyhow::bail!("no git repo in library — run `tome backup init` first");
+    }
+    // Show diff of working tree against target
+    let stdout = git_stdout(library_dir, &["diff", target, "--stat"])?;
+    Ok(stdout)
+}
+
+/// Render backup entries to stdout.
+pub(crate) fn render_list(entries: &[BackupEntry]) {
+    if entries.is_empty() {
+        println!("No backups found");
+        return;
+    }
+    for entry in entries {
+        println!(
+            "{} {} {}",
+            console::style(&entry.hash).yellow(),
+            console::style(&entry.date).dim(),
+            entry.message,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn setup_git_config(dir: &Path) {
+        let _ = std::process::Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(dir)
+            .output();
+        let _ = std::process::Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(dir)
+            .output();
+    }
+
+    fn init_test_repo(dir: &Path) {
+        git_success(dir, &["init"]).unwrap();
+        setup_git_config(dir);
+        // Create an initial file so we can make the initial commit
+        std::fs::write(dir.join(".gitkeep"), "").unwrap();
+        git_success(dir, &["add", "-A"]).unwrap();
+        git_success(dir, &["commit", "-m", "initial"]).unwrap();
+    }
+
+    #[test]
+    fn init_creates_git_repo() {
+        let tmp = TempDir::new().unwrap();
+        let lib_dir = tmp.path().join("library");
+        std::fs::create_dir_all(&lib_dir).unwrap();
+        // Set git config globally for the test process scope via env
+        init(&lib_dir, false).unwrap();
+        setup_git_config(&lib_dir);
+        assert!(lib_dir.join(".git").exists());
+    }
+
+    #[test]
+    fn init_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let lib_dir = tmp.path().join("library");
+        std::fs::create_dir_all(&lib_dir).unwrap();
+        init(&lib_dir, false).unwrap();
+        setup_git_config(&lib_dir);
+        // Second call should not error
+        init(&lib_dir, false).unwrap();
+    }
+
+    #[test]
+    fn snapshot_creates_commit() {
+        let tmp = TempDir::new().unwrap();
+        let lib_dir = tmp.path().join("library");
+        std::fs::create_dir_all(&lib_dir).unwrap();
+        init_test_repo(&lib_dir);
+
+        // Add a file and snapshot
+        std::fs::write(lib_dir.join("test-skill.md"), "# Test").unwrap();
+        let created = snapshot(&lib_dir, Some("added test skill"), false).unwrap();
+        assert!(created);
+
+        // Verify git log has the entry
+        let stdout = git_stdout(&lib_dir, &["log", "--oneline"]).unwrap();
+        assert!(stdout.contains("added test skill"));
+    }
+
+    #[test]
+    fn snapshot_nothing_to_commit() {
+        let tmp = TempDir::new().unwrap();
+        let lib_dir = tmp.path().join("library");
+        std::fs::create_dir_all(&lib_dir).unwrap();
+        init_test_repo(&lib_dir);
+
+        let created = snapshot(&lib_dir, None, false).unwrap();
+        assert!(!created);
+    }
+
+    #[test]
+    fn list_returns_entries() {
+        let tmp = TempDir::new().unwrap();
+        let lib_dir = tmp.path().join("library");
+        std::fs::create_dir_all(&lib_dir).unwrap();
+        init_test_repo(&lib_dir);
+
+        // Create 3 snapshots
+        for i in 1..=3 {
+            std::fs::write(lib_dir.join(format!("file{i}.txt")), format!("content {i}")).unwrap();
+            snapshot(&lib_dir, Some(&format!("snapshot {i}")), false).unwrap();
+        }
+
+        let entries = list(&lib_dir, 10).unwrap();
+        // initial commit + 3 snapshots = 4
+        assert_eq!(entries.len(), 4);
+        // Most recent first
+        assert_eq!(entries[0].message, "snapshot 3");
+        assert_eq!(entries[1].message, "snapshot 2");
+        assert_eq!(entries[2].message, "snapshot 1");
+        // Check that hash and date are populated
+        assert!(!entries[0].hash.is_empty());
+        assert!(!entries[0].date.is_empty());
+    }
+
+    #[test]
+    fn restore_reverts_changes() {
+        let tmp = TempDir::new().unwrap();
+        let lib_dir = tmp.path().join("library");
+        std::fs::create_dir_all(&lib_dir).unwrap();
+        init_test_repo(&lib_dir);
+
+        // Create a file and snapshot
+        std::fs::write(lib_dir.join("skill.md"), "original").unwrap();
+        snapshot(&lib_dir, Some("original state"), false).unwrap();
+
+        // Modify the file and snapshot again
+        std::fs::write(lib_dir.join("skill.md"), "modified").unwrap();
+        snapshot(&lib_dir, Some("modified state"), false).unwrap();
+
+        // Restore to HEAD~1 (the "original state" commit)
+        restore(&lib_dir, "HEAD~1", false).unwrap();
+
+        // File should be back to original content
+        let content = std::fs::read_to_string(lib_dir.join("skill.md")).unwrap();
+        assert_eq!(content, "original");
+    }
+
+    #[test]
+    fn diff_shows_changes() {
+        let tmp = TempDir::new().unwrap();
+        let lib_dir = tmp.path().join("library");
+        std::fs::create_dir_all(&lib_dir).unwrap();
+        init_test_repo(&lib_dir);
+
+        // Create a file and snapshot
+        std::fs::write(lib_dir.join("skill.md"), "original").unwrap();
+        snapshot(&lib_dir, Some("baseline"), false).unwrap();
+
+        // Modify the file (unstaged)
+        std::fs::write(lib_dir.join("skill.md"), "changed content here").unwrap();
+
+        let output = diff(&lib_dir, "HEAD").unwrap();
+        assert!(output.contains("skill.md"), "diff output: {output}");
+    }
+
+    #[test]
+    fn dry_run_snapshot_no_commit() {
+        let tmp = TempDir::new().unwrap();
+        let lib_dir = tmp.path().join("library");
+        std::fs::create_dir_all(&lib_dir).unwrap();
+        init_test_repo(&lib_dir);
+
+        // Add a file
+        std::fs::write(lib_dir.join("new-file.md"), "content").unwrap();
+
+        // Dry run should say it would snapshot but not actually commit
+        let result = snapshot(&lib_dir, Some("dry run test"), true).unwrap();
+        assert!(result); // There are changes to snapshot
+
+        // Count commits — should still be just the initial one
+        let log = git_stdout(&lib_dir, &["log", "--oneline"]).unwrap();
+        let commit_count = log.lines().count();
+        assert_eq!(commit_count, 1, "dry run should not create a commit");
+    }
+}

--- a/crates/tome/src/cli.rs
+++ b/crates/tome/src/cli.rs
@@ -109,4 +109,43 @@ pub enum Command {
         #[arg(long)]
         path: bool,
     },
+
+    /// Git-backed backup and restore for the skill library
+    Backup {
+        #[command(subcommand)]
+        sub: BackupCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum BackupCommand {
+    /// Initialize git repo in the library for backup tracking
+    Init,
+    /// Create a snapshot of the current library state
+    Snapshot {
+        /// Custom commit message
+        #[arg(short, long)]
+        message: Option<String>,
+    },
+    /// Show backup history
+    List {
+        /// Number of entries to show
+        #[arg(short = 'n', long, default_value = "10")]
+        count: usize,
+    },
+    /// Restore library to a previous snapshot
+    Restore {
+        /// Git ref to restore to (commit hash, HEAD~1, etc.)
+        #[arg(default_value = "HEAD~1")]
+        target: String,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        force: bool,
+    },
+    /// Show changes since last backup
+    Diff {
+        /// Compare against specific ref (default: last commit)
+        #[arg(default_value = "HEAD")]
+        target: String,
+    },
 }

--- a/crates/tome/src/config.rs
+++ b/crates/tome/src/config.rs
@@ -83,6 +83,23 @@ impl<'de> serde::Deserialize<'de> for TargetName {
     }
 }
 
+/// Backup configuration — controls git-backed snapshots of the skill library.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BackupConfig {
+    pub(crate) enabled: bool,
+    pub(crate) auto_snapshot: bool,
+}
+
+impl Default for BackupConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            auto_snapshot: false,
+        }
+    }
+}
+
 /// Top-level configuration for tome.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -101,6 +118,10 @@ pub struct Config {
     /// Distribution targets — keyed by tool name (e.g. "claude", "antigravity")
     #[serde(default, deserialize_with = "deserialize_targets")]
     pub(crate) targets: BTreeMap<TargetName, TargetConfig>,
+
+    /// Backup settings
+    #[serde(default)]
+    pub(crate) backup: BackupConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -348,6 +369,7 @@ impl Default for Config {
             exclude: BTreeSet::new(),
             sources: Vec::new(),
             targets: BTreeMap::new(),
+            backup: BackupConfig::default(),
         }
     }
 }
@@ -452,6 +474,7 @@ mod tests {
                 source_type: SourceType::Directory,
             }],
             targets: BTreeMap::new(),
+            ..Default::default()
         };
         let toml_str = toml::to_string_pretty(&config).unwrap();
         let parsed: Config = toml::from_str(&toml_str).unwrap();
@@ -488,6 +511,7 @@ mod tests {
                     },
                 },
             )]),
+            ..Default::default()
         };
         config.validate().unwrap();
     }
@@ -649,6 +673,7 @@ skills_dir = "~/.gemini/antigravity/skills"
                     },
                 },
             )]),
+            ..Default::default()
         };
         let toml_str = toml::to_string_pretty(&config).unwrap();
         let parsed: Config = toml::from_str(&toml_str).unwrap();

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -20,6 +20,7 @@
 //! - [`TomePaths`] — bundled home/library paths
 //! - [`SyncReport`] — sync operation results
 
+pub(crate) mod backup;
 pub(crate) mod browse;
 pub(crate) mod cleanup;
 pub mod cli;
@@ -273,6 +274,48 @@ pub fn run(cli: Cli) -> Result<()> {
         }
         Command::List { json } => list(&config, cli.quiet, json)?,
         Command::Config { path } => show_config(&config, path)?,
+        Command::Backup { sub } => match sub {
+            cli::BackupCommand::Init => {
+                backup::init(paths.library_dir(), cli.dry_run)?;
+            }
+            cli::BackupCommand::Snapshot { message } => {
+                backup::snapshot(paths.library_dir(), message.as_deref(), cli.dry_run)?;
+            }
+            cli::BackupCommand::List { count } => {
+                let entries = backup::list(paths.library_dir(), count)?;
+                backup::render_list(&entries);
+            }
+            cli::BackupCommand::Restore { target, force } => {
+                if !force {
+                    if std::io::stdin().is_terminal() {
+                        let confirmed = dialoguer::Confirm::new()
+                            .with_prompt(format!(
+                                "Restore library to {}? This will overwrite current state",
+                                target
+                            ))
+                            .default(false)
+                            .interact()?;
+                        if !confirmed {
+                            println!("Aborted.");
+                            return Ok(());
+                        }
+                    } else {
+                        anyhow::bail!(
+                            "tome backup restore requires confirmation — use --force in non-interactive mode"
+                        );
+                    }
+                }
+                backup::restore(paths.library_dir(), &target, cli.dry_run)?;
+            }
+            cli::BackupCommand::Diff { target } => {
+                let diff = backup::diff(paths.library_dir(), &target)?;
+                if diff.is_empty() {
+                    println!("No changes since {}", target);
+                } else {
+                    println!("{}", diff);
+                }
+            }
+        },
     }
 
     Ok(())
@@ -309,6 +352,23 @@ fn sync(
     }
 
     let show_progress = !quiet && !verbose;
+
+    // Pre-sync auto-snapshot if configured
+    if !dry_run
+        && config.backup.enabled
+        && config.backup.auto_snapshot
+        && backup::has_repo(paths.library_dir())
+    {
+        match backup::snapshot(paths.library_dir(), Some("pre-sync auto-snapshot"), false) {
+            Ok(true) => {
+                if !quiet {
+                    eprintln!("info: pre-sync snapshot created");
+                }
+            }
+            Ok(false) => {} // nothing to snapshot
+            Err(e) => eprintln!("warning: auto-snapshot failed: {e}"),
+        }
+    }
 
     // 1. Discover
     let sp = show_progress.then(|| spinner("Discovering skills..."));

--- a/crates/tome/src/relocate.rs
+++ b/crates/tome/src/relocate.rs
@@ -490,6 +490,7 @@ mod tests {
             exclude: Default::default(),
             sources: Vec::new(),
             targets,
+            ..Default::default()
         }
     }
 

--- a/crates/tome/src/wizard.rs
+++ b/crates/tome/src/wizard.rs
@@ -75,6 +75,7 @@ pub fn run(dry_run: bool) -> Result<Config> {
         exclude,
         sources,
         targets,
+        ..Default::default()
     };
 
     // Summary

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -2561,3 +2561,115 @@ fn lint_single_skill_path_with_errors() {
         .failure()
         .stdout(predicate::str::contains("no frontmatter"));
 }
+
+// === Backup tests ===
+
+fn setup_git_config(dir: &Path) {
+    let _ = StdCommand::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir)
+        .output();
+    let _ = StdCommand::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir)
+        .output();
+}
+
+#[test]
+fn backup_init_and_snapshot() {
+    let env = TestEnvBuilder::new()
+        .source("local", "directory")
+        .skill("my-skill", "local")
+        .build();
+
+    // Sync first to populate the library
+    tome()
+        .args(["--config", &env.config_path.to_string_lossy(), "sync"])
+        .assert()
+        .success();
+
+    // Init backup (commits existing library content)
+    tome()
+        .args([
+            "--config",
+            &env.config_path.to_string_lossy(),
+            "backup",
+            "init",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Initialized backup repo"));
+
+    setup_git_config(&env.library_dir);
+
+    // Add a new file to the library so there's something to snapshot
+    std::fs::write(env.library_dir.join("extra.txt"), "new content").unwrap();
+
+    // Snapshot
+    tome()
+        .args([
+            "--config",
+            &env.config_path.to_string_lossy(),
+            "backup",
+            "snapshot",
+            "-m",
+            "test snapshot",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Snapshot created"));
+}
+
+#[test]
+fn backup_list_shows_history() {
+    let env = TestEnvBuilder::new()
+        .source("local", "directory")
+        .skill("skill-a", "local")
+        .build();
+
+    // Sync to populate library
+    tome()
+        .args(["--config", &env.config_path.to_string_lossy(), "sync"])
+        .assert()
+        .success();
+
+    // Init backup
+    tome()
+        .args([
+            "--config",
+            &env.config_path.to_string_lossy(),
+            "backup",
+            "init",
+        ])
+        .assert()
+        .success();
+
+    setup_git_config(&env.library_dir);
+
+    // Add a file and create a snapshot
+    std::fs::write(env.library_dir.join("extra.txt"), "new content").unwrap();
+    tome()
+        .args([
+            "--config",
+            &env.config_path.to_string_lossy(),
+            "backup",
+            "snapshot",
+            "-m",
+            "first snapshot",
+        ])
+        .assert()
+        .success();
+
+    // List should show both the initial backup and the snapshot
+    tome()
+        .args([
+            "--config",
+            &env.config_path.to_string_lossy(),
+            "backup",
+            "list",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("first snapshot"))
+        .stdout(predicate::str::contains("Initial tome backup"));
+}


### PR DESCRIPTION
## Summary

Git-backed safety net for the skill library. Provides snapshot, restore, diff, and list commands, with optional auto-snapshots before each sync.

### Commands

- **`tome backup init`** — Initialize git repo in library (or adopt existing)
- **`tome backup snapshot [-m "message"]`** — Commit current state
- **`tome backup list [-n 10]`** — Show backup history
- **`tome backup restore [<ref>] [--force]`** — Restore to previous snapshot (auto-snapshots current state first, confirms interactively)
- **`tome backup diff [<ref>]`** — Show changes since last backup

### Configuration

```toml
[backup]
enabled = true         # default
auto_snapshot = false   # set true for pre-sync snapshots
```

When `auto_snapshot = true`, `tome sync` automatically creates a snapshot before making changes — always a restore point available.

### Design choices

- `.gitignore` already excludes managed skill symlinks, so `git add -A` is safe
- Restore auto-snapshots current state before overwriting (safety net for the safety net)
- Non-interactive restore requires `--force` flag
- All git failures are graceful (warnings, never hard errors in auto-snapshot path)

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] 306 unit tests pass (+8 new backup tests)
- [x] 70 integration tests pass (+2 new backup tests)

Closes #94