### PR TITLE
feat: integrate remote sync into tome sync flow

### DIFF
--- a/crates/tome/src/backup.rs
+++ b/crates/tome/src/backup.rs
@@ -215,16 +215,14 @@ pub(crate) fn pull(repo_dir: &Path) -> Result<bool> {
 }
 
 /// Push the current branch to origin.
-///
-/// Returns `Ok(true)` if commits were pushed, `Ok(false)` if already up-to-date.
-pub(crate) fn push(repo_dir: &Path) -> Result<bool> {
+pub(crate) fn push(repo_dir: &Path) -> Result<()> {
     let branch = git_stdout(repo_dir, &["rev-parse", "--abbrev-ref", "HEAD"])?;
     let output = git(repo_dir, &["push", "origin", &branch])?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         anyhow::bail!("git push failed: {}", stderr.trim());
     }
-    Ok(true)
+    Ok(())
 }
 
 /// Add a remote named "origin" to the repo.
@@ -233,9 +231,13 @@ pub(crate) fn add_remote(repo_dir: &Path, url: &str) -> Result<()> {
 }
 
 /// Verify the remote is reachable.
+///
+/// Accepts exit code 0 (refs found) and 2 (connected but empty repo).
 pub(crate) fn verify_remote(repo_dir: &Path) -> Result<()> {
     let output = git(repo_dir, &["ls-remote", "--exit-code", "origin"])?;
-    if !output.status.success() {
+    let code = output.status.code().unwrap_or(-1);
+    // 0 = success, 2 = connected but no matching refs (empty repo)
+    if code != 0 && code != 2 {
         anyhow::bail!("could not connect to remote — check the URL and your credentials");
     }
     Ok(())
@@ -249,17 +251,22 @@ pub(crate) fn push_initial(repo_dir: &Path) -> Result<()> {
 
 /// Detect the remote branch to merge from.
 ///
-/// Tries `origin/main`, then `origin/master`, then the current branch on origin.
+/// Tries `origin/main`, then `origin/master`, then `origin/<current-branch>`.
+/// Bails if none of the candidates exist on the remote.
 fn detect_remote_branch(repo_dir: &Path) -> Result<String> {
-    for candidate in &["origin/main", "origin/master"] {
+    let branch = git_stdout(repo_dir, &["rev-parse", "--abbrev-ref", "HEAD"])?;
+    let candidates = [
+        "origin/main".to_string(),
+        "origin/master".to_string(),
+        format!("origin/{branch}"),
+    ];
+    for candidate in &candidates {
         let output = git(repo_dir, &["rev-parse", "--verify", candidate])?;
         if output.status.success() {
-            return Ok(candidate.to_string());
+            return Ok(candidate.clone());
         }
     }
-    // Fall back to origin/<current-branch>
-    let branch = git_stdout(repo_dir, &["rev-parse", "--abbrev-ref", "HEAD"])?;
-    Ok(format!("origin/{branch}"))
+    anyhow::bail!("no remote branch found — tried {}", candidates.join(", "));
 }
 
 /// Render backup entries to stdout.

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -370,8 +370,12 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
 
     let show_progress = !quiet && !verbose;
 
+    // Cache git state to avoid repeated subprocess calls
+    let has_backup_repo = backup::has_repo(paths.tome_home());
+    let has_remote = has_backup_repo && backup::has_remote(paths.tome_home());
+
     // Pull from remote before anything else (if configured)
-    if !dry_run && backup::has_repo(paths.tome_home()) && backup::has_remote(paths.tome_home()) {
+    if !dry_run && has_remote {
         match backup::pull(paths.tome_home()) {
             Ok(true) => {
                 if !quiet {
@@ -387,11 +391,7 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
     }
 
     // Pre-sync auto-snapshot if configured
-    if !dry_run
-        && config.backup.enabled
-        && config.backup.auto_snapshot
-        && backup::has_repo(paths.tome_home())
-    {
+    if !dry_run && config.backup.enabled && config.backup.auto_snapshot && has_backup_repo {
         match backup::snapshot(paths.tome_home(), Some("pre-sync auto-snapshot"), false) {
             Ok(true) => {
                 if !quiet {
@@ -583,19 +583,21 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
     }
 
     // Offer git commit if tome home is a git repo with changes
-    if !dry_run && !quiet {
+    let committed = if !dry_run && !quiet {
         offer_git_commit(
             paths.tome_home(),
             report.consolidate.created,
             report.consolidate.updated,
             report.cleanup.removed_from_library,
-        )?;
-    }
+        )?
+    } else {
+        false
+    };
 
-    // Push to remote after commit (if configured)
-    if !dry_run && backup::has_repo(paths.tome_home()) && backup::has_remote(paths.tome_home()) {
+    // Push to remote after commit (only if something was committed)
+    if committed && has_remote {
         match backup::push(paths.tome_home()) {
-            Ok(_) => {
+            Ok(()) => {
                 if !quiet {
                     println!("  {} Pushed to remote", console::style("↑").cyan());
                 }
@@ -831,14 +833,16 @@ fn generate_tome_home_gitignore(tome_home: &Path) -> Result<()> {
 }
 
 /// If tome home is a git repo with uncommitted changes, prompt the user to commit.
+///
+/// Returns `true` if a commit was created, `false` otherwise.
 fn offer_git_commit(
     tome_home: &Path,
     created: usize,
     updated: usize,
     removed: usize,
-) -> Result<()> {
+) -> Result<bool> {
     if !tome_home.join(".git").exists() || !std::io::stdin().is_terminal() {
-        return Ok(());
+        return Ok(false);
     }
 
     let output = match GitCommand::new("git")
@@ -849,7 +853,7 @@ fn offer_git_commit(
         Ok(o) => o,
         Err(e) => {
             eprintln!("warning: could not run git status: {e}");
-            return Ok(());
+            return Ok(false);
         }
     };
 
@@ -858,10 +862,10 @@ fn offer_git_commit(
             "warning: git status returned non-zero exit code {:?}",
             output.status.code()
         );
-        return Ok(());
+        return Ok(false);
     }
     if output.stdout.is_empty() {
-        return Ok(());
+        return Ok(false);
     }
 
     let msg = sync_commit_message(created, updated, removed);
@@ -872,7 +876,7 @@ fn offer_git_commit(
         .interact_opt()?;
 
     if confirm != Some(true) {
-        return Ok(());
+        return Ok(false);
     }
 
     // Stage all tracked files — .gitignore handles exclusions.
@@ -890,7 +894,7 @@ fn offer_git_commit(
         if !stderr.trim().is_empty() {
             eprintln!("  git said: {}", stderr.trim());
         }
-        return Ok(());
+        return Ok(false);
     }
 
     let commit_output = GitCommand::new("git")
@@ -906,10 +910,10 @@ fn offer_git_commit(
         if !stderr.trim().is_empty() {
             eprintln!("  git said: {}", stderr.trim());
         }
-        return Ok(());
+        return Ok(false);
     }
 
-    Ok(())
+    Ok(true)
 }
 
 /// Build a commit message summarizing sync changes.


### PR DESCRIPTION
Closes #349

## Summary

Integrates remote git sync into the `tome sync` flow. When `~/.tome/` has a git remote configured:

- **Pull before sync**: `git fetch` + `--ff-only` merge at the start
- **Push after commit**: `git push` at the end
- Both are soft failures (warnings only, sync continues)

New `backup.rs` functions:
- `has_remote()` — checks if origin is configured
- `pull()` — fetch + ff-only merge (bails on diverged histories)
- `push()` — pushes current branch to origin
- `add_remote()`, `verify_remote()`, `push_initial()` — for setup wizard

Enhanced `tome backup init`:
- Interactive prompt to add a remote URL after git init
- Verifies connectivity via `git ls-remote`
- Pushes initial commit to establish tracking

## Test plan

- [x] `make ci` passes (fmt, clippy, 71+71 tests)
- [x] `has_remote_false_without_remote` — fresh repo returns false
- [x] `has_remote_true_with_remote` — repo with origin returns true
- [x] `push_and_pull_roundtrip` — full push→pull cycle between two repos