### PR TITLE
fix: default library_dir derives from TOME_HOME

### DIFF
--- a/crates/tome/src/config.rs
+++ b/crates/tome/src/config.rs
@@ -433,9 +433,13 @@ mod defaults {
     pub fn library_dir() -> PathBuf {
         // Best-effort default for serde; expand_tildes() and validate() will
         // surface a proper error if home is unavailable.
-        dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("~"))
-            .join(".tome")
+        // Uses TOME_HOME if set, otherwise ~/.tome/
+        super::default_tome_home()
+            .unwrap_or_else(|_| {
+                dirs::home_dir()
+                    .unwrap_or_else(|| PathBuf::from("~"))
+                    .join(".tome")
+            })
             .join("skills")
     }
 }


### PR DESCRIPTION
## Summary

The default `library_dir` was hardcoded to `~/.tome/skills` regardless of `TOME_HOME`. Now it uses `default_tome_home()` so `library_dir` naturally follows `TOME_HOME/skills`.

This means `library_dir` can be omitted from `tome.toml` when the default is correct — less config to maintain.

## Before
```toml
# Required in tome.toml when TOME_HOME != ~/.tome/
library_dir = "~/dev/coding-agent-files/skills"
```

## After
```toml
# library_dir defaults to TOME_HOME/skills — can be omitted
```

## Test plan
- [x] 387 tests pass (309 unit + 78 integration)
- [x] `tome status` shows correct library path with custom TOME_HOME
- [x] Default `~/.tome/` case unchanged

Refs #369