### PR TITLE
feat: v0.5.3 UX & CLI polish (9 issues)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,22 @@ For repository workflow guidance, see [docs/src/development-workflow.md](docs/sr
 
 ## Commands
 
-| Command       | Description                                              |
-| ------------- | -------------------------------------------------------- |
-| `tome init`   | Interactive wizard to configure sources and targets      |
-| `tome sync`   | Discover, consolidate, triage changes, and distribute    |
-| `tome status` | Show library, sources, targets, and health               |
-| `tome list`   | List all discovered skills with sources                  |
-| `tome doctor` | Diagnose and repair broken symlinks or config issues     |
-| `tome config` | Show current configuration                               |
+| Command            | Description                                              |
+| ------------------ | -------------------------------------------------------- |
+| `tome init`        | Interactive wizard to configure sources and targets      |
+| `tome sync`        | Discover, consolidate, triage changes, and distribute    |
+| `tome status`      | Show library, sources, targets, and health               |
+| `tome list`        | List all discovered skills with sources                  |
+| `tome browse`      | Interactively browse discovered skills (fuzzy search)    |
+| `tome doctor`      | Diagnose and repair broken symlinks or config issues     |
+| `tome lint`        | Validate skill frontmatter and report issues             |
+| `tome config`      | Show current configuration                               |
+| `tome backup`      | Git-backed backup and restore for the skill library      |
+| `tome eject`       | Remove tome's symlinks from all targets (reversible)     |
+| `tome relocate`    | Move the skill library to a new location                 |
+| `tome completions` | Install shell completions (bash, zsh, fish, powershell)  |
 
-All commands support `--dry-run`, `--verbose`, `--quiet`, `--config <path>`, and `--machine <path>`.
+All commands support `--dry-run`, `--verbose`, `--quiet`, `--no-input`, `--config <path>`, and `--machine <path>`.
 
 ## How It Works
 

--- a/crates/tome/src/cleanup.rs
+++ b/crates/tome/src/cleanup.rs
@@ -45,28 +45,68 @@ pub fn cleanup_library(
         .cloned()
         .collect();
 
-    for name in stale {
-        let entry_path = library_dir.join(name.as_str());
+    // Group stale skills by their previous source for better messaging
+    let mut stale_by_source: std::collections::BTreeMap<String, Vec<SkillName>> =
+        std::collections::BTreeMap::new();
+    for name in &stale {
+        let source = manifest
+            .get(name.as_str())
+            .map(|e| e.source_name.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+        stale_by_source
+            .entry(source)
+            .or_default()
+            .push(name.clone());
+    }
 
-        if interactive {
-            let prompt = format!(
-                "Skill '{}' was removed from sources. Delete from library?",
-                name
+    // In interactive mode, show grouped summary and batch-confirm
+    let skills_to_remove: Vec<SkillName> = if interactive && !stale.is_empty() {
+        println!(
+            "{}",
+            console::style(format!(
+                "{} skill(s) from sources no longer configured:",
+                stale.len()
+            ))
+            .yellow()
+            .bold()
+        );
+        for (source, names) in &stale_by_source {
+            println!(
+                "  {} (from '{}'):",
+                console::style(format!("{} skill(s)", names.len())).dim(),
+                source
             );
-            let confirmed = dialoguer::Confirm::new()
-                .with_prompt(prompt)
-                .default(false)
-                .interact_opt()?;
-
-            if confirmed != Some(true) {
-                continue;
+            for name in names {
+                println!("    {}", name);
             }
-        } else {
-            eprintln!(
-                "warning: skill '{}' no longer in any source, removing from library",
-                name
-            );
         }
+        println!();
+        let confirmed = dialoguer::Confirm::new()
+            .with_prompt("Delete these skills from library?")
+            .default(false)
+            .interact_opt()?;
+        if confirmed == Some(true) {
+            stale.clone()
+        } else {
+            Vec::new()
+        }
+    } else if !stale.is_empty() {
+        // Non-interactive: warn and auto-remove
+        for (source, names) in &stale_by_source {
+            for name in names {
+                eprintln!(
+                    "warning: skill '{}' (from '{}') no longer in any source, removing from library",
+                    name, source
+                );
+            }
+        }
+        stale.clone()
+    } else {
+        Vec::new()
+    };
+
+    for name in skills_to_remove {
+        let entry_path = library_dir.join(name.as_str());
 
         if !dry_run {
             if entry_path.is_symlink() {

--- a/crates/tome/src/cleanup.rs
+++ b/crates/tome/src/cleanup.rs
@@ -28,6 +28,7 @@ pub fn cleanup_library(
     manifest: &mut Manifest,
     dry_run: bool,
     quiet: bool,
+    no_input: bool,
 ) -> Result<CleanupResult> {
     let mut result = CleanupResult::default();
 
@@ -35,7 +36,7 @@ pub fn cleanup_library(
         return Ok(result);
     }
 
-    let interactive = std::io::stdin().is_terminal() && !quiet;
+    let interactive = !no_input && std::io::stdin().is_terminal() && !quiet;
 
     // Find manifest entries not in discovered_names
     let stale: Vec<SkillName> = manifest
@@ -193,8 +194,15 @@ mod tests {
 
         // "old-skill" is NOT in discovered names — should be removed (non-interactive)
         let discovered: HashSet<String> = HashSet::new();
-        let result =
-            cleanup_library(library.path(), &discovered, &mut manifest, false, false).unwrap();
+        let result = cleanup_library(
+            library.path(),
+            &discovered,
+            &mut manifest,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
 
         assert_eq!(result.removed_from_library, 1);
         assert!(!library.path().join("old-skill").exists());
@@ -221,8 +229,15 @@ mod tests {
         );
 
         let discovered: HashSet<String> = ["keep-me".to_string()].into();
-        let result =
-            cleanup_library(library.path(), &discovered, &mut manifest, false, false).unwrap();
+        let result = cleanup_library(
+            library.path(),
+            &discovered,
+            &mut manifest,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
 
         assert_eq!(result.removed_from_library, 0);
         assert!(library.path().join("keep-me").exists());
@@ -248,8 +263,15 @@ mod tests {
         );
 
         let discovered: HashSet<String> = HashSet::new();
-        let result =
-            cleanup_library(library.path(), &discovered, &mut manifest, true, false).unwrap();
+        let result = cleanup_library(
+            library.path(),
+            &discovered,
+            &mut manifest,
+            true,
+            false,
+            true,
+        )
+        .unwrap();
 
         assert_eq!(result.removed_from_library, 1);
         // Should still exist in dry run
@@ -267,8 +289,15 @@ mod tests {
 
         let mut manifest = Manifest::default();
         let discovered: HashSet<String> = HashSet::new();
-        let result =
-            cleanup_library(library.path(), &discovered, &mut manifest, false, false).unwrap();
+        let result = cleanup_library(
+            library.path(),
+            &discovered,
+            &mut manifest,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
 
         assert_eq!(result.removed_from_library, 1);
         assert!(!library.path().join("broken").exists());
@@ -333,8 +362,15 @@ mod tests {
         let mut manifest = Manifest::default();
         let discovered: HashSet<String> = HashSet::new();
 
-        let result =
-            cleanup_library(library.path(), &discovered, &mut manifest, true, false).unwrap();
+        let result = cleanup_library(
+            library.path(),
+            &discovered,
+            &mut manifest,
+            true,
+            false,
+            true,
+        )
+        .unwrap();
 
         // Dry-run should report it would clean up but not actually remove
         assert!(
@@ -372,8 +408,15 @@ mod tests {
 
         // Skill not in discovered names — should be removed
         let discovered: HashSet<String> = HashSet::new();
-        let result =
-            cleanup_library(library.path(), &discovered, &mut manifest, false, false).unwrap();
+        let result = cleanup_library(
+            library.path(),
+            &discovered,
+            &mut manifest,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
 
         assert_eq!(result.removed_from_library, 1);
         assert!(

--- a/crates/tome/src/cli.rs
+++ b/crates/tome/src/cli.rs
@@ -37,6 +37,10 @@ pub struct Cli {
     /// Path to machine preferences file (default: ~/.config/tome/machine.toml)
     #[arg(long, global = true)]
     pub machine: Option<PathBuf>,
+
+    /// Disable all interactive prompts (implies --no-triage for sync)
+    #[arg(long, global = true)]
+    pub no_input: bool,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]

--- a/crates/tome/src/cli.rs
+++ b/crates/tome/src/cli.rs
@@ -52,9 +52,13 @@ pub enum LintFormat {
 #[derive(Subcommand)]
 pub enum Command {
     /// Interactive wizard to configure sources and targets
+    #[command(after_help = "Examples:\n  tome init")]
     Init,
 
     /// Discover, consolidate, and distribute skills
+    #[command(
+        after_help = "Examples:\n  tome sync\n  tome sync --dry-run\n  tome sync --force\n  tome sync --no-triage\n  tome sync --no-input"
+    )]
     Sync {
         /// Recreate all symlinks even if they appear up-to-date
         #[arg(short, long)]
@@ -65,13 +69,18 @@ pub enum Command {
     },
 
     /// Show library, sources, targets, and health summary
+    #[command(after_help = "Examples:\n  tome status")]
     Status,
 
     /// Diagnose and repair broken symlinks or config issues
+    #[command(after_help = "Examples:\n  tome doctor\n  tome doctor --dry-run")]
     Doctor,
 
     /// List all discovered skills with their sources
-    #[command(alias = "ls")]
+    #[command(
+        alias = "ls",
+        after_help = "Examples:\n  tome list\n  tome list --json"
+    )]
     List {
         /// Output as JSON
         #[arg(long)]
@@ -79,6 +88,9 @@ pub enum Command {
     },
 
     /// Validate skill frontmatter and report issues
+    #[command(
+        after_help = "Examples:\n  tome lint\n  tome lint path/to/skill\n  tome lint --format json"
+    )]
     Lint {
         /// Specific skill directory to lint (default: entire library)
         #[arg(value_name = "PATH")]
@@ -89,12 +101,15 @@ pub enum Command {
     },
 
     /// Interactively browse discovered skills
+    #[command(after_help = "Examples:\n  tome browse")]
     Browse,
 
     /// Remove tome's symlinks from all target tool directories (reversible via `tome sync`)
+    #[command(after_help = "Examples:\n  tome eject\n  tome eject --dry-run")]
     Eject,
 
     /// Move the skill library to a new location safely
+    #[command(after_help = "Examples:\n  tome relocate ~/new-library")]
     Relocate {
         /// New library directory path
         #[arg(value_name = "NEW_PATH")]
@@ -102,6 +117,7 @@ pub enum Command {
     },
 
     /// Install shell completions for bash, zsh, fish, or powershell
+    #[command(after_help = "Examples:\n  tome completions fish\n  tome completions zsh --print")]
     Completions {
         /// Shell to install completions for
         #[arg(value_enum)]
@@ -115,6 +131,7 @@ pub enum Command {
     Version,
 
     /// Show configuration
+    #[command(after_help = "Examples:\n  tome config\n  tome config --path")]
     Config {
         /// Print config file path only
         #[arg(long)]
@@ -122,6 +139,9 @@ pub enum Command {
     },
 
     /// Git-backed backup and restore for the skill library
+    #[command(
+        after_help = "Examples:\n  tome backup init\n  tome backup snapshot -m 'before update'\n  tome backup list\n  tome backup diff"
+    )]
     Backup {
         #[command(subcommand)]
         sub: BackupCommand,

--- a/crates/tome/src/distribute.rs
+++ b/crates/tome/src/distribute.rs
@@ -18,6 +18,8 @@ pub struct DistributeResult {
     pub skipped: usize,
     /// Skills skipped because they are disabled in machine preferences.
     pub disabled: usize,
+    /// Managed skills skipped because they originate from the same tool as the target.
+    pub skipped_managed: usize,
     pub target_name: TargetName,
 }
 
@@ -41,6 +43,7 @@ pub fn distribute_to_target(
             unchanged: 0,
             skipped: 0,
             disabled: 0,
+            skipped_managed: 0,
         });
     }
 
@@ -118,6 +121,7 @@ fn distribute_symlinks(
         unchanged: 0,
         skipped: 0,
         disabled: 0,
+        skipped_managed: 0,
     };
 
     // Library may not exist yet on a first dry-run (consolidate skips creating it).
@@ -175,7 +179,11 @@ fn distribute_symlinks(
                 if !dry_run && target_link.is_symlink() {
                     let _ = std::fs::remove_file(&target_link);
                 }
-                result.unchanged += 1;
+                if manifest_entry.managed {
+                    result.skipped_managed += 1;
+                } else {
+                    result.unchanged += 1;
+                }
                 continue;
             }
         }
@@ -691,8 +699,9 @@ mod tests {
         )
         .unwrap();
 
-        // Should be skipped (counted as unchanged), not distributed
-        assert_eq!(result.unchanged, 1);
+        // Should be skipped as managed, not distributed
+        assert_eq!(result.skipped_managed, 1);
+        assert_eq!(result.unchanged, 0);
         assert_eq!(result.changed, 0);
         assert!(
             !target_dir.join("my-skill").exists(),
@@ -713,7 +722,7 @@ mod tests {
             false,
         )
         .unwrap();
-        assert_eq!(result2.unchanged, 1);
+        assert_eq!(result2.skipped_managed, 1);
         assert!(
             !target_dir.join("my-skill").exists(),
             "legacy symlink should be removed on re-sync"

--- a/crates/tome/src/distribute.rs
+++ b/crates/tome/src/distribute.rs
@@ -176,8 +176,15 @@ fn distribute_symlinks(
             if skip {
                 // Remove any existing symlink from a previous sync that
                 // didn't have this check (cleans up legacy duplicates).
-                if !dry_run && target_link.is_symlink() {
-                    let _ = std::fs::remove_file(&target_link);
+                if !dry_run
+                    && target_link.is_symlink()
+                    && let Err(e) = std::fs::remove_file(&target_link)
+                {
+                    eprintln!(
+                        "warning: failed to remove legacy symlink {}: {}",
+                        target_link.display(),
+                        e
+                    );
                 }
                 if manifest_entry.managed {
                     result.skipped_managed += 1;

--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -89,7 +89,7 @@ pub fn check(config: &Config, paths: &TomePaths) -> Result<DoctorReport> {
 // -- Rendering + control flow --
 
 /// Diagnose and optionally repair issues.
-pub fn diagnose(config: &Config, paths: &TomePaths, dry_run: bool) -> Result<()> {
+pub fn diagnose(config: &Config, paths: &TomePaths, dry_run: bool, no_input: bool) -> Result<()> {
     let report = check(config, paths)?;
 
     if !report.configured {
@@ -128,7 +128,7 @@ pub fn diagnose(config: &Config, paths: &TomePaths, dry_run: bool) -> Result<()>
         );
 
         if !dry_run {
-            let confirmed = if std::io::stdin().is_terminal() {
+            let confirmed = if !no_input && std::io::stdin().is_terminal() {
                 Confirm::new()
                     .with_prompt("Repair these issues?")
                     .default(true)
@@ -691,6 +691,7 @@ mod tests {
         let result = diagnose(
             &config,
             &TomePaths::new(tmp.path().to_path_buf(), config.library_dir.clone()).unwrap(),
+            true,
             true,
         );
         assert!(result.is_ok());

--- a/crates/tome/src/install.rs
+++ b/crates/tome/src/install.rs
@@ -81,6 +81,7 @@ pub(crate) fn reconcile(
     installed_plugins_path: &Path,
     dry_run: bool,
     quiet: bool,
+    no_input: bool,
 ) -> Result<usize> {
     let missing = find_missing(lockfile, installed_plugins_path)?;
     if missing.is_empty() {
@@ -125,8 +126,8 @@ pub(crate) fn reconcile(
         return Ok(unique.len());
     }
 
-    // Prompt for confirmation (TTY only)
-    if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+    // Prompt for confirmation (TTY only, unless --no-input)
+    if !no_input && std::io::IsTerminal::is_terminal(&std::io::stdin()) {
         let confirm = dialoguer::Confirm::new()
             .with_prompt(format!("Install {} plugin(s)?", unique.len()))
             .default(true)
@@ -295,7 +296,7 @@ mod tests {
             skills: std::collections::BTreeMap::new(),
         };
 
-        let count = reconcile(&lockfile, &json, true, true).unwrap();
+        let count = reconcile(&lockfile, &json, true, true, false).unwrap();
         assert_eq!(count, 0);
     }
 }

--- a/crates/tome/src/install.rs
+++ b/crates/tome/src/install.rs
@@ -135,8 +135,17 @@ pub(crate) fn reconcile(
         if !confirm {
             return Ok(0);
         }
+    } else if no_input {
+        if !quiet {
+            eprintln!(
+                "info: {} missing plugin(s) detected — skipped due to --no-input. \
+                 Run `tome sync` without --no-input to install interactively.",
+                unique.len()
+            );
+        }
+        return Ok(0);
     } else {
-        // Non-interactive: skip installation
+        // Genuine non-TTY
         if !quiet {
             eprintln!(
                 "info: {} missing plugin(s) detected — run `tome sync` interactively to install",

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -157,6 +157,9 @@ pub fn run(cli: Cli) -> Result<()> {
     let effective_config = resolve_config_path(cli.tome_home.as_deref(), cli.config.as_deref())?;
 
     if matches!(cli.command, Command::Init) {
+        if cli.no_input {
+            anyhow::bail!("tome init requires interactive input — cannot use --no-input");
+        }
         if let Err(e) = Config::load_or_default(effective_config.as_deref()) {
             eprintln!(
                 "warning: existing config is malformed ({}), the wizard will create a new one",
@@ -206,7 +209,7 @@ pub fn run(cli: Cli) -> Result<()> {
             },
         )?,
         Command::Status => status::show(&config, &paths)?,
-        Command::Doctor => doctor::diagnose(&config, &paths, cli.dry_run)?,
+        Command::Doctor => doctor::diagnose(&config, &paths, cli.dry_run, cli.no_input)?,
         Command::Lint { path, format } => {
             let report = match path {
                 Some(p) => {

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -456,8 +456,9 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
     // Load existing lockfile for diffing and auto-install
     let old_lockfile = lockfile::load(paths.config_dir())?;
 
-    // Auto-install missing managed plugins (before discovery so they're found)
-    if !dry_run && !no_triage {
+    // Auto-install missing managed plugins (before discovery so they're found).
+    // Run even with --no-input so users get the info message about missing plugins.
+    if !dry_run {
         reconcile_managed_plugins(&old_lockfile, config, quiet, no_input)?;
     }
 

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -729,12 +729,13 @@ fn render_sync_report(report: &SyncReport) {
 
     for dr in &report.distributions {
         println!(
-            "  {}: {} linked, {} unchanged{}{}",
+            "  {}: {} linked, {} unchanged{}{}{}",
             style(&dr.target_name).bold(),
             style(dr.changed).cyan(),
             dr.unchanged,
             skipped_note(dr.skipped),
-            disabled_note(dr.disabled)
+            disabled_note(dr.disabled),
+            managed_note(dr.skipped_managed)
         );
     }
 
@@ -853,6 +854,14 @@ fn disabled_note(count: usize) -> String {
         String::new()
     } else {
         format!(", {} disabled (machine prefs)", style(count).dim())
+    }
+}
+
+fn managed_note(count: usize) -> String {
+    if count == 0 {
+        String::new()
+    } else {
+        format!(", {} skipped (managed)", style(count).dim())
     }
 }
 

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -175,6 +175,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     dry_run: cli.dry_run,
                     force: false,
                     no_triage: true, // skip on initial sync after init
+                    no_input: cli.no_input,
                     verbose: cli.verbose,
                     quiet: cli.quiet,
                     machine_override: cli.machine.as_deref(),
@@ -197,7 +198,8 @@ pub fn run(cli: Cli) -> Result<()> {
             SyncOptions {
                 dry_run: cli.dry_run,
                 force,
-                no_triage,
+                no_triage: no_triage || cli.no_input,
+                no_input: cli.no_input,
                 verbose: cli.verbose,
                 quiet: cli.quiet,
                 machine_override: cli.machine.as_deref(),
@@ -385,6 +387,7 @@ struct SyncOptions<'a> {
     dry_run: bool,
     force: bool,
     no_triage: bool,
+    no_input: bool,
     verbose: bool,
     quiet: bool,
     machine_override: Option<&'a Path>,
@@ -396,6 +399,7 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
         dry_run,
         force,
         no_triage,
+        no_input,
         verbose,
         quiet,
         machine_override,
@@ -451,7 +455,7 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
 
     // Auto-install missing managed plugins (before discovery so they're found)
     if !dry_run && !no_triage {
-        reconcile_managed_plugins(&old_lockfile, config, quiet)?;
+        reconcile_managed_plugins(&old_lockfile, config, quiet, no_input)?;
     }
 
     // 1. Discover
@@ -539,6 +543,7 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
         &mut manifest,
         dry_run,
         quiet,
+        no_input,
     )?;
 
     // Regenerate lockfile after cleanup so it reflects removals
@@ -1051,6 +1056,7 @@ fn reconcile_managed_plugins(
     old_lockfile: &Option<lockfile::Lockfile>,
     config: &config::Config,
     quiet: bool,
+    no_input: bool,
 ) -> Result<()> {
     let Some(lf) = old_lockfile else {
         return Ok(());
@@ -1058,7 +1064,7 @@ fn reconcile_managed_plugins(
     let Some(json_path) = install::find_installed_plugins_json(config) else {
         return Ok(());
     };
-    match install::reconcile(lf, &json_path, false, quiet) {
+    match install::reconcile(lf, &json_path, false, quiet, no_input) {
         Ok(n) if n > 0 && !quiet => {
             println!(
                 "  {} Installed {n} managed plugin(s)",

--- a/crates/tome/src/update.rs
+++ b/crates/tome/src/update.rs
@@ -79,41 +79,65 @@ pub fn present_changes(
 
     let mut added_names: Vec<SkillName> = Vec::new();
 
+    // Group changes by source for cleaner output
+    let mut by_source: BTreeMap<String, Vec<(&SkillName, &SkillChange)>> = BTreeMap::new();
     for (name, change) in &diff.changes {
-        match change {
-            SkillChange::Added(entry) => {
-                let msg = if entry.registry_id.is_some() {
-                    format!(
-                        "New managed skill '{}' from source '{}' is now available.",
-                        name, entry.source_name
-                    )
-                } else {
-                    format!(
-                        "New skill '{}' from source '{}' is now available.",
-                        name, entry.source_name
-                    )
-                };
-                if interactive {
-                    println!("  {}", msg);
-                } else if !quiet {
-                    eprintln!("info: {}", msg);
+        let source = match change {
+            SkillChange::Added(e) => &e.source_name,
+            SkillChange::Changed { new, .. } => &new.source_name,
+            SkillChange::Removed(e) => &e.source_name,
+        };
+        by_source
+            .entry(source.clone())
+            .or_default()
+            .push((name, change));
+    }
+
+    for (source, changes) in &by_source {
+        if interactive {
+            println!(
+                "{}",
+                console::style(format!(
+                    "  {} ({} change{}):",
+                    source,
+                    changes.len(),
+                    if changes.len() == 1 { "" } else { "s" }
+                ))
+                .bold()
+            );
+        }
+
+        for (name, change) in changes {
+            match change {
+                SkillChange::Added(entry) => {
+                    let kind = if entry.registry_id.is_some() {
+                        "new managed"
+                    } else {
+                        "new"
+                    };
+                    if interactive {
+                        println!("    {} {}", console::style("+").green(), name);
+                    } else if !quiet {
+                        eprintln!(
+                            "info: {} skill '{}' from '{}' is now available.",
+                            kind, name, source
+                        );
+                    }
+                    added_names.push((*name).clone());
                 }
-                added_names.push(name.clone());
-            }
-            SkillChange::Changed { .. } => {
-                let msg = format!("Skill '{}' was updated (hash changed).", name);
-                if interactive {
-                    println!("  {}", msg);
-                } else if !quiet {
-                    eprintln!("info: {}", msg);
+                SkillChange::Changed { .. } => {
+                    if interactive {
+                        println!("    {} {} (updated)", console::style("~").yellow(), name);
+                    } else if !quiet {
+                        eprintln!("info: Skill '{}' was updated (hash changed).", name);
+                    }
                 }
-            }
-            SkillChange::Removed(_) => {
-                let msg = format!("Skill '{}' was removed from the library.", name);
-                if interactive {
-                    println!("  {}", msg);
-                } else if !quiet {
-                    eprintln!("info: {}", msg);
+                SkillChange::Removed(_) => {
+                    if interactive {
+                        println!("    {} {} (removed)", console::style("-").red(), name);
+                    } else if !quiet {
+                        eprintln!("info: Skill '{}' was removed from the library.", name);
+                    }
                 }
             }
         }

--- a/crates/tome/src/update.rs
+++ b/crates/tome/src/update.rs
@@ -126,7 +126,7 @@ pub fn present_changes(
         println!();
         let display_names: Vec<&str> = added_names.iter().map(|n| n.as_str()).collect();
         let selections = dialoguer::MultiSelect::new()
-            .with_prompt("Disable any of these new skills on this machine?")
+            .with_prompt("Disable any of these new skills on this machine?\n  (space to toggle, enter to confirm)")
             .items(&display_names)
             .interact_opt()?;
 

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -2967,3 +2967,74 @@ fn backup_list_shows_history() {
         .stdout(predicate::str::contains("first snapshot"))
         .stdout(predicate::str::contains("Initial tome backup"));
 }
+
+#[test]
+fn exit_code_2_for_invalid_args() {
+    // Clap returns exit code 2 for usage errors (invalid flags)
+    tome().arg("--nonexistent-flag").assert().code(2);
+}
+
+#[test]
+fn exit_code_1_for_runtime_errors() {
+    // Runtime errors (missing config) return exit code 1
+    tome()
+        .args(["--config", "/nonexistent/path.toml", "status"])
+        .assert()
+        .code(1);
+}
+
+#[test]
+fn no_input_flag_skips_all_prompts() {
+    let env = TestEnvBuilder::new()
+        .source("local", "directory")
+        .target("test-tool")
+        .skill("skill-a", "local")
+        .build();
+
+    // Sync with --no-input should succeed without hanging on prompts
+    tome()
+        .args([
+            "--config",
+            &env.config_path.to_string_lossy(),
+            "--no-input",
+            "sync",
+        ])
+        .assert()
+        .success();
+
+    // Verify skill was distributed to default target
+    let target_dir = &env.target_dirs[0].1;
+    assert!(target_dir.join("skill-a").is_symlink());
+}
+
+#[test]
+fn no_color_env_suppresses_ansi_escapes() {
+    let env = TestEnvBuilder::new()
+        .source("local", "directory")
+        .skill("skill-a", "local")
+        .build();
+
+    // Sync first to populate library
+    tome()
+        .args(["--config", &env.config_path.to_string_lossy(), "sync"])
+        .assert()
+        .success();
+
+    // Run status with NO_COLOR=1 — output must not contain ANSI escape sequences
+    let output = tome()
+        .args(["--config", &env.config_path.to_string_lossy(), "status"])
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run tome status");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stdout.contains("\x1b["),
+        "stdout should not contain ANSI escapes with NO_COLOR=1, got: {stdout}"
+    );
+    assert!(
+        !stderr.contains("\x1b["),
+        "stderr should not contain ANSI escapes with NO_COLOR=1, got: {stderr}"
+    );
+}

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -3008,6 +3008,34 @@ fn no_input_flag_skips_all_prompts() {
 }
 
 #[test]
+fn init_with_no_input_fails() {
+    tome()
+        .args(["--no-input", "init"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot use --no-input"));
+}
+
+#[test]
+fn doctor_with_no_input_skips_repair() {
+    let env = TestEnvBuilder::new()
+        .source("local", "directory")
+        .skill("skill-a", "local")
+        .build();
+
+    // Doctor with --no-input should not hang on prompts
+    tome()
+        .args([
+            "--config",
+            &env.config_path.to_string_lossy(),
+            "--no-input",
+            "doctor",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
 fn no_color_env_suppresses_ansi_escapes() {
     let env = TestEnvBuilder::new()
         .source("local", "directory")

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -6,16 +6,25 @@
 | `tome sync` | Discover, consolidate, triage changes, and distribute skills |
 | `tome status` | Show library, sources, targets, and health summary |
 | `tome list` (alias: `ls`) | List all discovered skills with sources (supports `--json`) |
+| `tome browse` | Interactively browse discovered skills with fuzzy search |
 | `tome doctor` | Diagnose and repair broken symlinks or config issues |
+| `tome lint` | Validate skill frontmatter and report issues |
 | `tome config` | Show current configuration |
+| `tome backup` | Git-backed backup and restore for the skill library |
+| `tome eject` | Remove tome's symlinks from all targets (reversible via `tome sync`) |
+| `tome relocate <path>` | Move the skill library to a new location |
+| `tome completions <shell>` | Install shell completions (bash, zsh, fish, powershell) |
+| `tome version` | Print version information |
 
 ## Global Flags
 
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--config <path>` | | Path to config file (default: `~/.tome/tome.toml`) |
+| `--tome-home <path>` | | Override tome home directory (default: `~/.tome/`, or `TOME_HOME` env var) |
 | `--machine <path>` | | Path to machine preferences file (default: `~/.config/tome/machine.toml`) |
 | `--dry-run` | | Preview changes without modifying filesystem |
+| `--no-input` | | Disable all interactive prompts (implies `--no-triage` for sync) |
 | `--verbose` | `-v` | Detailed output |
 | `--quiet` | `-q` | Suppress non-error output (conflicts with `--verbose`) |
 
@@ -36,8 +45,48 @@ Runs the full pipeline: discover skills from sources, consolidate into the libra
 |------|-------------|
 | `--json` | Output as JSON |
 
+### `tome browse`
+
+Full-screen interactive skill browser using fuzzy search. Supports sorting, grouping by source, and per-skill actions (view source, copy path, disable/enable).
+
+### `tome lint`
+
+| Flag | Description |
+|------|-------------|
+| `PATH` | Specific skill directory to lint (default: entire library) |
+| `--format text\|json` | Output format (default: `text`) |
+
+Validates SKILL.md frontmatter: missing/mismatched names, description length, non-standard fields, Unicode tag codepoints. Exits with code 1 on errors (CI-friendly).
+
 ### `tome config`
 
 | Flag | Description |
 |------|-------------|
 | `--path` | Print config file path only |
+
+### `tome backup`
+
+Git-backed backup and restore. Subcommands:
+
+| Subcommand | Description |
+|------------|-------------|
+| `tome backup init` | Initialize git repo in the library for backup tracking |
+| `tome backup snapshot [-m MSG]` | Create a snapshot of the current library state |
+| `tome backup list [-n COUNT]` | Show backup history (default: 10 entries) |
+| `tome backup restore [REF]` | Restore library to a previous snapshot (default: `HEAD~1`) |
+| `tome backup diff [REF]` | Show changes since last backup (default: `HEAD`) |
+
+### `tome eject`
+
+Removes all of tome's symlinks from target tool directories. Reversible — run `tome sync` to recreate them.
+
+### `tome relocate`
+
+Moves the skill library to a new path, updating symlinks in all targets.
+
+### `tome completions`
+
+| Flag | Description |
+|------|-------------|
+| `SHELL` | Shell to install for: `bash`, `zsh`, `fish`, `powershell` |
+| `--print` | Print completions to stdout instead of installing |


### PR DESCRIPTION
## Summary

9 issues across 3 waves — UX improvements, CLI standards compliance, and docs.

### Wave 1 — Foundations
- **#371** NO_COLOR: `console` crate already handles it; added integration test
- **#375** Semantic exit codes: clap → 2 for bad args, runtime → 1; added tests
- **#376** `--no-input` global flag: suppresses all interactive prompts (cleanup, triage, install)

### Wave 2 — UX improvements
- **#381** Keybinding hints: "(space to toggle, enter to confirm)" on triage MultiSelect
- **#389** Sync output: `skipped_managed` counter — shows "216 skipped (managed)" per target
- **#380** Group triage by source: changes grouped under source headers with +/~/- indicators
- **#382** Stale messaging: batch prompt showing all stale skills grouped by previous source

### Wave 3 — Help & Docs
- **#378** Usage examples in every subcommand `--help`
- **#368** README and commands.md updated with all commands and new flags

## Test plan
- [x] 406 tests pass (322 unit + 84 integration)
- [x] `cargo clippy` clean
- [x] `NO_COLOR=1 tome status` — no ANSI escapes
- [x] `tome --bad-flag` → exit 2
- [x] `tome sync --no-input` — no prompts
- [x] `tome sync --help` shows examples

Closes #371, closes #375, closes #376, closes #381, closes #389, closes #380, closes #382, closes #378, closes #368