### PR TITLE
feat: v0.5.4 infrastructure (7 issues)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +424,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.2",
+ "windows-sys",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +563,18 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -989,7 +1021,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -1043,6 +1075,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1105,6 +1149,21 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -1849,7 +1908,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float",
@@ -1954,6 +2013,7 @@ dependencies = [
  "clap_complete",
  "console",
  "crossterm",
+ "ctrlc",
  "dialoguer",
  "dirs",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 console = "0.16"
+ctrlc = "3"
 dialoguer = "0.12"
 indicatif = "0.18"
 dirs = "6"

--- a/crates/tome/Cargo.toml
+++ b/crates/tome/Cargo.toml
@@ -16,6 +16,7 @@ anyhow.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 console.workspace = true
+ctrlc.workspace = true
 dialoguer.workspace = true
 dirs.workspace = true
 indicatif.workspace = true

--- a/crates/tome/src/cli.rs
+++ b/crates/tome/src/cli.rs
@@ -69,12 +69,22 @@ pub enum Command {
     },
 
     /// Show library, sources, targets, and health summary
-    #[command(after_help = "Examples:\n  tome status")]
-    Status,
+    #[command(after_help = "Examples:\n  tome status\n  tome status --json")]
+    Status {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 
     /// Diagnose and repair broken symlinks or config issues
-    #[command(after_help = "Examples:\n  tome doctor\n  tome doctor --dry-run")]
-    Doctor,
+    #[command(
+        after_help = "Examples:\n  tome doctor\n  tome doctor --dry-run\n  tome doctor --json"
+    )]
+    Doctor {
+        /// Output as JSON (skips repair)
+        #[arg(long)]
+        json: bool,
+    },
 
     /// List all discovered skills with their sources
     #[command(

--- a/crates/tome/src/config.rs
+++ b/crates/tome/src/config.rs
@@ -389,8 +389,10 @@ pub fn expand_tilde(path: &Path) -> Result<PathBuf> {
 ///
 /// Resolution order:
 /// 1. `TOME_HOME` environment variable (if set and non-empty)
-/// 2. `~/.tome/`
+/// 2. `~/.config/tome/config.toml` → `tome_home` field
+/// 3. `~/.tome/`
 pub fn default_tome_home() -> Result<PathBuf> {
+    // 1. TOME_HOME env var
     match std::env::var("TOME_HOME") {
         Ok(val) if !val.is_empty() => return expand_tilde(Path::new(&val)),
         Ok(_) => {}                               // empty string, fall through
@@ -399,9 +401,37 @@ pub fn default_tome_home() -> Result<PathBuf> {
             anyhow::bail!("TOME_HOME environment variable contains invalid Unicode");
         }
     }
+    // 2. ~/.config/tome/config.toml
+    if let Some(path) = read_config_tome_home()? {
+        return Ok(path);
+    }
+    // 3. Default
     Ok(dirs::home_dir()
         .context("could not determine home directory")?
         .join(".tome"))
+}
+
+/// Read `tome_home` from the machine-level config at `~/.config/tome/config.toml`.
+fn read_config_tome_home() -> Result<Option<PathBuf>> {
+    let config_path = dirs::home_dir()
+        .context("could not determine home directory")?
+        .join(".config/tome/config.toml");
+    if !config_path.is_file() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+    let table: toml::Table = content
+        .parse()
+        .with_context(|| format!("invalid TOML in {}", config_path.display()))?;
+    match table.get("tome_home") {
+        Some(toml::Value::String(val)) => {
+            let expanded = expand_tilde(Path::new(val))?;
+            Ok(Some(expanded))
+        }
+        Some(_) => anyhow::bail!("tome_home in {} must be a string", config_path.display()),
+        None => Ok(None),
+    }
 }
 
 /// Resolve the config directory for a given tome home.

--- a/crates/tome/src/discover.rs
+++ b/crates/tome/src/discover.rs
@@ -149,6 +149,9 @@ pub struct DiscoveredSkill {
     pub source_name: String,
     /// How this skill was sourced (managed vs local), with optional provenance metadata.
     pub origin: SkillOrigin,
+    /// Parsed frontmatter from SKILL.md (None if parsing failed).
+    #[allow(dead_code)]
+    pub frontmatter: Option<crate::skill::SkillFrontmatter>,
 }
 
 /// Discover all skills from configured sources.
@@ -414,11 +417,18 @@ fn scan_for_skills(
                         },
                         None => SkillOrigin::Local,
                     };
+                    // Parse frontmatter if SKILL.md exists and is readable
+                    let frontmatter = std::fs::read_to_string(skill_dir.join("SKILL.md"))
+                        .ok()
+                        .and_then(|content| crate::skill::parse(&content).ok())
+                        .map(|(fm, _body)| fm);
+
                     skills.push(DiscoveredSkill {
                         name,
                         path: skill_dir.to_path_buf(),
                         source_name: source_name.to_string(),
                         origin,
+                        frontmatter,
                     });
                 }
                 Err(e) => {

--- a/crates/tome/src/discover.rs
+++ b/crates/tome/src/discover.rs
@@ -418,10 +418,20 @@ fn scan_for_skills(
                         None => SkillOrigin::Local,
                     };
                     // Parse frontmatter if SKILL.md exists and is readable
-                    let frontmatter = std::fs::read_to_string(skill_dir.join("SKILL.md"))
-                        .ok()
-                        .and_then(|content| crate::skill::parse(&content).ok())
-                        .map(|(fm, _body)| fm);
+                    let frontmatter = match std::fs::read_to_string(skill_dir.join("SKILL.md")) {
+                        Ok(content) => match crate::skill::parse(&content) {
+                            Ok((fm, _body)) => Some(fm),
+                            Err(e) => {
+                                warnings.push(format!(
+                                    "could not parse frontmatter in {}/SKILL.md: {}",
+                                    skill_dir.display(),
+                                    e
+                                ));
+                                None
+                            }
+                        },
+                        Err(_) => None, // File not readable — already validated by scan
+                    };
 
                     skills.push(DiscoveredSkill {
                         name,

--- a/crates/tome/src/distribute.rs
+++ b/crates/tome/src/distribute.rs
@@ -184,7 +184,9 @@ fn distribute_symlinks(
                     || (manifest_entry.managed
                         && shares_tool_root(&source, &target, source_paths))
                 }
-                _ => false,
+                // If canonicalization fails for a managed skill, skip to be safe —
+                // creating circular symlinks is worse than missing a distribution.
+                _ => manifest_entry.managed,
             };
             if skip {
                 // Remove any existing symlink from a previous sync that

--- a/crates/tome/src/distribute.rs
+++ b/crates/tome/src/distribute.rs
@@ -66,7 +66,8 @@ pub fn distribute_to_target(
 /// Check if a managed skill's source and a target belong to the same tool.
 ///
 /// For each configured source, checks if the skill's source_path is under that
-/// source AND the configured source and target share a direct parent directory.
+/// source AND the configured source and target are siblings (share the same
+/// direct parent directory).
 ///
 /// Example: configured source `~/.claude/plugins` and target `~/.claude/skills`
 /// → both are children of `~/.claude/`, so they're the same tool. A managed skill
@@ -74,29 +75,36 @@ pub fn distribute_to_target(
 ///
 /// Counter-example: `~/.claude/plugins` and `~/.gemini/antigravity/skills`
 /// → parents are `~/.claude/` and `~/.gemini/antigravity/`, no match.
+///
+/// Uses already-expanded paths from config (tilde-expanded at load time).
+/// Falls back to canonicalization only when needed for symlink resolution.
 fn shares_tool_root(source: &Path, target: &Path, source_paths: &[PathBuf]) -> bool {
     for configured_source in source_paths {
-        let Ok(configured) = configured_source.canonicalize() else {
-            continue;
-        };
+        // Try canonicalize for symlink resolution, fall back to raw path
+        let configured = configured_source
+            .canonicalize()
+            .unwrap_or_else(|_| configured_source.clone());
 
         // Check if the skill's source_path is under this configured source
         if !source.starts_with(&configured) {
             continue;
         }
 
-        // Check if the configured source is under the target's parent, or vice versa.
-        // This catches: ~/.claude/plugins (source) under ~/.claude/ (target parent)
-        // and also: ~/.claude/skills (target) under ~/.claude/ (source parent)
-        if let Some(configured_parent) = configured.parent()
-            && target.starts_with(configured_parent)
-        {
-            return true;
-        }
-        if let Some(target_parent) = target.parent()
-            && configured.starts_with(target_parent)
-        {
-            return true;
+        // Check if the target is under the configured source's parent directory.
+        // e.g., configured = ~/.claude/plugins, parent = ~/.claude/
+        // target = ~/.claude/skills → starts_with(~/.claude/) → same tool.
+        //
+        // Guard: the parent must be deeper than the home directory to avoid
+        // matching ~/source and ~/.claude/skills as "same tool" just because
+        // both are under ~.
+        if let Some(configured_parent) = configured.parent() {
+            let home = dirs::home_dir();
+            let is_home_or_shallower = home.as_ref().is_some_and(|h| {
+                configured_parent == h.as_path() || h.starts_with(configured_parent)
+            });
+            if !is_home_or_shallower && target.starts_with(configured_parent) {
+                return true;
+            }
         }
     }
     false

--- a/crates/tome/src/distribute.rs
+++ b/crates/tome/src/distribute.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{Context, Result};
 use std::os::unix::fs as unix_fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::config::{TargetConfig, TargetMethod, TargetName};
 use crate::machine::MachinePrefs;
@@ -27,12 +27,14 @@ pub struct DistributeResult {
 /// When `force` is true, all symlinks are recreated even if they already point to the correct target.
 /// The `manifest` is used to check whether a skill's source originated from the target dir
 /// (to prevent circular symlinks when a directory is both a source and target).
+#[allow(clippy::too_many_arguments)]
 pub fn distribute_to_target(
     library_dir: &Path,
     target_name: &str,
     target: &TargetConfig,
     manifest: &Manifest,
     machine_prefs: &MachinePrefs,
+    source_paths: &[PathBuf],
     dry_run: bool,
     force: bool,
 ) -> Result<DistributeResult> {
@@ -54,59 +56,61 @@ pub fn distribute_to_target(
             skills_dir,
             manifest,
             machine_prefs,
+            source_paths,
             dry_run,
             force,
         ),
     }
 }
 
-/// Check if two paths share a tool root directory (e.g., both under `~/.claude/`).
+/// Check if a managed skill's source and a target belong to the same tool.
 ///
-/// Finds the first "tool-like" dotfile directory in each path (directories
-/// starting with `.` that match known AI tool patterns) and checks if they're
-/// the same. This detects that `~/.claude/plugins/cache/foo` and `~/.claude/skills`
-/// belong to the same tool.
-fn shares_tool_root(source: &Path, target: &Path) -> bool {
-    find_tool_dir(source) == find_tool_dir(target) && find_tool_dir(source).is_some()
-}
-
-/// Find the tool directory component in a path.
+/// For each configured source, checks if the skill's source_path is under that
+/// source AND the configured source and target share a direct parent directory.
 ///
-/// Looks for known tool directory names (`.claude`, `.gemini`, `.agents`, `.codex`,
-/// `.cursor`, `.copilot`, etc.) in the path components.
-fn find_tool_dir(path: &Path) -> Option<String> {
-    use std::path::Component;
+/// Example: configured source `~/.claude/plugins` and target `~/.claude/skills`
+/// → both are children of `~/.claude/`, so they're the same tool. A managed skill
+/// from `~/.claude/plugins/cache/...` is under that source, so it's skipped.
+///
+/// Counter-example: `~/.claude/plugins` and `~/.gemini/antigravity/skills`
+/// → parents are `~/.claude/` and `~/.gemini/antigravity/`, no match.
+fn shares_tool_root(source: &Path, target: &Path, source_paths: &[PathBuf]) -> bool {
+    for configured_source in source_paths {
+        let Ok(configured) = configured_source.canonicalize() else {
+            continue;
+        };
 
-    const TOOL_DIRS: &[&str] = &[
-        ".claude",
-        ".gemini",
-        ".agents",
-        ".codex",
-        ".cursor",
-        ".copilot",
-        ".openclaw",
-        ".windsurf",
-        ".amp",
-    ];
+        // Check if the skill's source_path is under this configured source
+        if !source.starts_with(&configured) {
+            continue;
+        }
 
-    for component in path.components() {
-        if let Component::Normal(name) = component
-            && let Some(name_str) = name.to_str()
-            && TOOL_DIRS.contains(&name_str)
+        // Check if the configured source is under the target's parent, or vice versa.
+        // This catches: ~/.claude/plugins (source) under ~/.claude/ (target parent)
+        // and also: ~/.claude/skills (target) under ~/.claude/ (source parent)
+        if let Some(configured_parent) = configured.parent()
+            && target.starts_with(configured_parent)
         {
-            return Some(name_str.to_string());
+            return true;
+        }
+        if let Some(target_parent) = target.parent()
+            && configured.starts_with(target_parent)
+        {
+            return true;
         }
     }
-    None
+    false
 }
 
 /// Distribute via directory-level symlinks.
+#[allow(clippy::too_many_arguments)]
 fn distribute_symlinks(
     library_dir: &Path,
     target_name: &str,
     skills_dir: &Path,
     manifest: &Manifest,
     machine_prefs: &MachinePrefs,
+    source_paths: &[PathBuf],
     dry_run: bool,
     force: bool,
 ) -> Result<DistributeResult> {
@@ -169,7 +173,8 @@ fn distribute_symlinks(
                     source.starts_with(&target)
                     // Same tool: managed skill whose source shares a tool root
                     // with the target (e.g. both under ~/.claude/)
-                    || (manifest_entry.managed && shares_tool_root(&source, &target))
+                    || (manifest_entry.managed
+                        && shares_tool_root(&source, &target, source_paths))
                 }
                 _ => false,
             };
@@ -270,6 +275,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &[],
             false,
             false,
         )
@@ -299,6 +305,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &[],
             false,
             false,
         )
@@ -309,6 +316,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &[],
             false,
             false,
         )
@@ -337,6 +345,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &[],
             false,
             false,
         )
@@ -347,6 +356,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &[],
             false,
             true,
         )
@@ -389,6 +399,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &[],
             false,
             false,
         )
@@ -421,6 +432,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &[],
             false,
             false,
         )
@@ -439,6 +451,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &[],
             false,
             false,
         )
@@ -468,6 +481,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &[],
             false,
             false,
         )
@@ -495,6 +509,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &[],
             true,
             false,
         )
@@ -524,6 +539,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &[],
             true,
             false,
         )
@@ -554,6 +570,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &[],
             false,
             false,
         )
@@ -587,6 +604,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &[],
             false,
             false,
         )
@@ -645,6 +663,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &[],
             false,
             false,
         )
@@ -695,12 +714,16 @@ mod tests {
             },
         };
 
+        // Source paths from config — the plugin cache is under .claude/
+        let source_paths = vec![home.join(".claude/plugins")];
+
         let result = distribute_to_target(
             &library,
             "claude",
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &source_paths,
             false,
             false,
         )
@@ -725,6 +748,7 @@ mod tests {
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &source_paths,
             false,
             false,
         )
@@ -772,12 +796,16 @@ mod tests {
             },
         };
 
+        // Source paths: claude plugins is under .claude/, target is under .gemini/
+        let source_paths = vec![home.join(".claude/plugins")];
+
         let result = distribute_to_target(
             &library,
             "antigravity",
             &target,
             &manifest,
             &MachinePrefs::default(),
+            &source_paths,
             false,
             false,
         )
@@ -813,6 +841,7 @@ mod tests {
             &target,
             &manifest,
             &prefs,
+            &[],
             false,
             false,
         )

--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -15,7 +15,7 @@ use crate::paths::{TomePaths, resolve_symlink_target};
 // -- Data structs --
 
 /// Severity of a diagnostic issue.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub enum IssueSeverity {
     /// Critical problem (e.g., missing directory, broken symlink).
     Error,
@@ -24,14 +24,14 @@ pub enum IssueSeverity {
 }
 
 /// A single diagnostic issue found during a health check.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct DiagnosticIssue {
     pub severity: IssueSeverity,
     pub message: String,
 }
 
 /// Complete diagnostic report for the tome system.
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub struct DoctorReport {
     pub configured: bool,
     pub library_issues: Vec<DiagnosticIssue>,
@@ -89,8 +89,19 @@ pub fn check(config: &Config, paths: &TomePaths) -> Result<DoctorReport> {
 // -- Rendering + control flow --
 
 /// Diagnose and optionally repair issues.
-pub fn diagnose(config: &Config, paths: &TomePaths, dry_run: bool, no_input: bool) -> Result<()> {
+pub fn diagnose(
+    config: &Config,
+    paths: &TomePaths,
+    dry_run: bool,
+    no_input: bool,
+    json: bool,
+) -> Result<()> {
     let report = check(config, paths)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
 
     if !report.configured {
         println!("Not configured yet. Run `tome init` to get started.");
@@ -693,6 +704,7 @@ mod tests {
             &TomePaths::new(tmp.path().to_path_buf(), config.library_dir.clone()).unwrap(),
             true,
             true,
+            false,
         );
         assert!(result.is_ok());
     }

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -612,7 +612,7 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
     if !dry_run && paths.config_dir().is_dir() {
         generate_tome_home_gitignore(paths.config_dir())?;
         lockfile::save(&new_lockfile, paths.config_dir())
-            .context("failed to save lockfile — library state may be out of sync")?;
+            .context("failed to save lockfile — sync completed but lockfile is stale; re-run `tome sync` to retry")?;
     }
 
     let report = SyncReport {

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -47,7 +47,7 @@ pub(crate) mod wizard;
 
 use std::collections::HashSet;
 use std::io::IsTerminal;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command as GitCommand;
 
 use anyhow::{Context, Result};
@@ -554,6 +554,7 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
     let new_lockfile = lockfile::generate(&manifest, &skills);
 
     // 5. Distribute to targets
+    let source_paths: Vec<PathBuf> = config.sources.iter().map(|s| s.path.clone()).collect();
     let mut distribute_results = Vec::new();
     for (name, target) in config.targets.iter() {
         if machine_prefs.is_target_disabled(name.as_str()) {
@@ -579,6 +580,7 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
             target,
             &manifest,
             &machine_prefs,
+            &source_paths,
             dry_run,
             force,
         )?;
@@ -607,9 +609,8 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
     }
     if !dry_run && paths.config_dir().is_dir() {
         generate_tome_home_gitignore(paths.config_dir())?;
-        if let Err(e) = lockfile::save(&new_lockfile, paths.config_dir()) {
-            eprintln!("warning: could not save lockfile: {e}");
-        }
+        lockfile::save(&new_lockfile, paths.config_dir())
+            .context("failed to save lockfile — library state may be out of sync")?;
     }
 
     let report = SyncReport {

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -208,8 +208,10 @@ pub fn run(cli: Cli) -> Result<()> {
                 machine_override: cli.machine.as_deref(),
             },
         )?,
-        Command::Status => status::show(&config, &paths)?,
-        Command::Doctor => doctor::diagnose(&config, &paths, cli.dry_run, cli.no_input)?,
+        Command::Status { json } => status::show(&config, &paths, json)?,
+        Command::Doctor { json } => {
+            doctor::diagnose(&config, &paths, cli.dry_run, cli.no_input, json)?;
+        }
         Command::Lint { path, format } => {
             let report = match path {
                 Some(p) => {

--- a/crates/tome/src/library.rs
+++ b/crates/tome/src/library.rs
@@ -406,6 +406,7 @@ mod tests {
             path: skill_dir,
             source_name: "test".into(),
             origin,
+            frontmatter: None,
         }
     }
 
@@ -636,6 +637,7 @@ mod tests {
             path: skill2_dir,
             source_name: "test2".into(),
             origin: crate::discover::SkillOrigin::Local,
+            frontmatter: None,
         };
 
         let (result, _manifest) = consolidate(
@@ -717,6 +719,7 @@ mod tests {
             path: skill_dir,
             source_name: "test".into(),
             origin: crate::discover::SkillOrigin::Local,
+            frontmatter: None,
         };
 
         let (result, _) = consolidate(
@@ -1318,6 +1321,7 @@ mod tests {
             path: source_skill.clone(),
             source_name: "plugins".into(),
             origin: crate::discover::SkillOrigin::Managed { provenance: None },
+            frontmatter: None,
         };
 
         // Call consolidate_managed directly

--- a/crates/tome/src/lockfile.rs
+++ b/crates/tome/src/lockfile.rs
@@ -162,6 +162,7 @@ mod tests {
             path: PathBuf::from(format!("/tmp/{name}")),
             source_name: source.to_string(),
             origin,
+            frontmatter: None,
         }
     }
 

--- a/crates/tome/src/main.rs
+++ b/crates/tome/src/main.rs
@@ -9,7 +9,6 @@ fn main() -> ExitCode {
     // Tome's sync pipeline is crash-safe (atomic writes, idempotent manifest),
     // so no cleanup is needed — just exit cleanly.
     if let Err(e) = ctrlc::set_handler(|| {
-        // Second Ctrl-C: force quit immediately (default behavior restored)
         eprintln!("\ninterrupted — run `tome sync` to resume");
         std::process::exit(130); // 128 + SIGINT(2)
     }) {

--- a/crates/tome/src/main.rs
+++ b/crates/tome/src/main.rs
@@ -5,6 +5,17 @@ use std::process::ExitCode;
 use clap::Parser;
 
 fn main() -> ExitCode {
+    // Handle Ctrl-C gracefully: print a clean message and exit.
+    // Tome's sync pipeline is crash-safe (atomic writes, idempotent manifest),
+    // so no cleanup is needed — just exit cleanly.
+    if let Err(e) = ctrlc::set_handler(|| {
+        // Second Ctrl-C: force quit immediately (default behavior restored)
+        eprintln!("\ninterrupted — run `tome sync` to resume");
+        std::process::exit(130); // 128 + SIGINT(2)
+    }) {
+        eprintln!("warning: could not set signal handler: {e}");
+    }
+
     let cli = tome::cli::Cli::parse();
 
     match tome::run(cli) {

--- a/crates/tome/src/status.rs
+++ b/crates/tome/src/status.rs
@@ -12,6 +12,29 @@ use crate::paths::TomePaths;
 
 // -- Data structs --
 
+/// A count that may have failed with an error message.
+#[derive(serde::Serialize)]
+pub struct CountOrError {
+    pub count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl From<Result<usize, String>> for CountOrError {
+    fn from(result: Result<usize, String>) -> Self {
+        match result {
+            Ok(n) => Self {
+                count: Some(n),
+                error: None,
+            },
+            Err(e) => Self {
+                count: None,
+                error: Some(e),
+            },
+        }
+    }
+}
+
 /// Status of a single configured source.
 #[derive(serde::Serialize)]
 pub struct SourceStatus {
@@ -19,7 +42,7 @@ pub struct SourceStatus {
     pub source_type: String,
     pub path: String,
     /// Number of skills discovered, or an error message if discovery failed.
-    pub skill_count: Result<usize, String>,
+    pub skill_count: CountOrError,
     /// Warnings emitted during discovery.
     pub warnings: Vec<String>,
 }
@@ -38,11 +61,11 @@ pub struct StatusReport {
     pub configured: bool,
     pub library_dir: PathBuf,
     /// Number of skills consolidated in the library, or an error message.
-    pub library_count: Result<usize, String>,
+    pub library_count: CountOrError,
     pub sources: Vec<SourceStatus>,
     pub targets: Vec<TargetStatus>,
     /// Number of health issues, or an error message.
-    pub health: Result<usize, String>,
+    pub health: CountOrError,
 }
 
 // -- Data gathering (pure computation, no I/O) --
@@ -69,7 +92,7 @@ pub fn gather(config: &Config, paths: &TomePaths) -> Result<StatusReport> {
                 name: source.name.clone(),
                 source_type: source.source_type.to_string(),
                 path: source.path.display().to_string(),
-                skill_count,
+                skill_count: skill_count.into(),
                 warnings,
             }
         })
@@ -99,10 +122,10 @@ pub fn gather(config: &Config, paths: &TomePaths) -> Result<StatusReport> {
     Ok(StatusReport {
         configured,
         library_dir: paths.library_dir().to_path_buf(),
-        library_count,
+        library_count: library_count.into(),
         sources,
         targets,
-        health,
+        health: health.into(),
     })
 }
 
@@ -131,13 +154,15 @@ fn render_status(report: &StatusReport) {
         style("Library:").bold(),
         crate::paths::collapse_home(&report.library_dir)
     );
-    let (lib_count, lib_indicator) = match &report.library_count {
-        Ok(n) => (format!("{}", n), style("✓").green()),
-        Err(e) => {
-            eprintln!("warning: could not read library: {}", e);
-            ("?".to_string(), style("✗").red())
-        }
-    };
+    let (lib_count, lib_indicator) =
+        match (&report.library_count.count, &report.library_count.error) {
+            (Some(n), _) => (format!("{}", n), style("✓").green()),
+            (None, Some(e)) => {
+                eprintln!("warning: could not read library: {}", e);
+                ("?".to_string(), style("✗").red())
+            }
+            (None, None) => ("0".to_string(), style("✓").green()),
+        };
     println!(
         "  {} {} skills consolidated",
         lib_indicator,
@@ -158,15 +183,16 @@ fn render_status(report: &StatusReport) {
             "SKILLS".to_string(),
         ]);
         for source in &report.sources {
-            let count = match &source.skill_count {
-                Ok(n) => format!("✓ {}", n),
-                Err(e) => {
+            let count = match (&source.skill_count.count, &source.skill_count.error) {
+                (Some(n), _) => format!("✓ {}", n),
+                (None, Some(e)) => {
                     eprintln!(
                         "warning: could not discover skills from '{}': {}",
                         source.name, e
                     );
                     "✗ ?".to_string()
                 }
+                (None, None) => "✓ 0".to_string(),
             };
             rows.push([
                 source.name.clone(),
@@ -224,17 +250,18 @@ fn render_status(report: &StatusReport) {
     println!();
 
     // Health
-    let health = match &report.health {
-        Ok(0) => format!("{} {}", style("✓").green(), style("All good").green()),
-        Ok(n) => format!(
+    let health = match (&report.health.count, &report.health.error) {
+        (Some(0), _) => format!("{} {}", style("✓").green(), style("All good").green()),
+        (Some(n), _) => format!(
             "{} {}",
             style("⚠").yellow(),
             style(format!("{} issue(s) — run `tome doctor` for details", n)).yellow()
         ),
-        Err(e) => {
+        (None, Some(e)) => {
             eprintln!("warning: could not check library health: {}", e);
             format!("{} {}", style("✗").red(), style("unknown").red())
         }
+        (None, None) => format!("{} {}", style("✓").green(), style("All good").green()),
     };
     println!("{} {}", style("Health:").bold(), health);
 }
@@ -338,7 +365,7 @@ mod tests {
         assert_eq!(report.sources.len(), 1);
         assert_eq!(report.sources[0].name, "test");
         // Source path doesn't exist — discover_source returns Ok(empty) with a warning
-        assert_eq!(report.sources[0].skill_count.as_ref().copied().unwrap(), 0);
+        assert_eq!(report.sources[0].skill_count.count, Some(0));
     }
 
     #[test]
@@ -358,7 +385,7 @@ mod tests {
         )
         .unwrap();
         assert!(report.configured);
-        assert_eq!(report.library_count.unwrap(), 2);
+        assert_eq!(report.library_count.count, Some(2));
     }
 
     #[test]
@@ -409,7 +436,7 @@ mod tests {
             &TomePaths::new(config.library_dir.clone(), config.library_dir.clone()).unwrap(),
         )
         .unwrap();
-        assert_eq!(report.health.unwrap(), 1);
+        assert_eq!(report.health.count, Some(1));
     }
 
     // -- Legacy tests (now calling show(), which delegates to gather() + render) --

--- a/crates/tome/src/status.rs
+++ b/crates/tome/src/status.rs
@@ -13,6 +13,7 @@ use crate::paths::TomePaths;
 // -- Data structs --
 
 /// Status of a single configured source.
+#[derive(serde::Serialize)]
 pub struct SourceStatus {
     pub name: String,
     pub source_type: String,
@@ -24,6 +25,7 @@ pub struct SourceStatus {
 }
 
 /// Status of a single configured target.
+#[derive(serde::Serialize)]
 pub struct TargetStatus {
     pub name: String,
     pub enabled: bool,
@@ -31,6 +33,7 @@ pub struct TargetStatus {
 }
 
 /// Complete status report for the tome system.
+#[derive(serde::Serialize)]
 pub struct StatusReport {
     pub configured: bool,
     pub library_dir: PathBuf,
@@ -106,9 +109,13 @@ pub fn gather(config: &Config, paths: &TomePaths) -> Result<StatusReport> {
 // -- Rendering --
 
 /// Display the current status of the tome system.
-pub fn show(config: &Config, paths: &TomePaths) -> Result<()> {
+pub fn show(config: &Config, paths: &TomePaths, json: bool) -> Result<()> {
     let report = gather(config, paths)?;
-    render_status(&report);
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        render_status(&report);
+    }
     Ok(())
 }
 

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -3036,6 +3036,59 @@ fn doctor_with_no_input_skips_repair() {
 }
 
 #[test]
+fn status_json_output() {
+    let env = TestEnvBuilder::new()
+        .source("local", "directory")
+        .target("test-tool")
+        .skill("skill-a", "local")
+        .build();
+
+    tome()
+        .args(["--config", &env.config_path.to_string_lossy(), "sync"])
+        .assert()
+        .success();
+
+    let output = tome()
+        .args([
+            "--config",
+            &env.config_path.to_string_lossy(),
+            "status",
+            "--json",
+        ])
+        .output()
+        .expect("failed to run");
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("status --json should produce valid JSON");
+    assert_eq!(json["configured"], true);
+    assert!(json["sources"].is_array());
+    assert!(json["targets"].is_array());
+}
+
+#[test]
+fn doctor_json_output() {
+    let env = TestEnvBuilder::new()
+        .source("local", "directory")
+        .skill("skill-a", "local")
+        .build();
+
+    let output = tome()
+        .args([
+            "--config",
+            &env.config_path.to_string_lossy(),
+            "doctor",
+            "--json",
+        ])
+        .output()
+        .expect("failed to run");
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("doctor --json should produce valid JSON");
+    assert_eq!(json["configured"], true);
+    assert!(json["library_issues"].is_array());
+}
+
+#[test]
 fn no_color_env_suppresses_ansi_escapes() {
     let env = TestEnvBuilder::new()
         .source("local", "directory")

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -3089,6 +3089,29 @@ fn doctor_json_output() {
 }
 
 #[test]
+fn config_toml_tome_home_override() {
+    // This test verifies that --tome-home takes precedence,
+    // which exercises the resolution order without needing to write
+    // to ~/.config/tome/config.toml.
+    let env = TestEnvBuilder::new()
+        .source("local", "directory")
+        .skill("skill-a", "local")
+        .build();
+
+    // Sync using --tome-home to set a custom tome home
+    tome()
+        .args([
+            "--config",
+            &env.config_path.to_string_lossy(),
+            "--tome-home",
+            &env.library_dir.parent().unwrap().to_string_lossy(),
+            "status",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
 fn no_color_env_suppresses_ansi_escapes() {
     let env = TestEnvBuilder::new()
         .source("local", "directory")


### PR DESCRIPTION
## Summary

Infrastructure improvements preparing for v0.6 unified directory model.

### Implemented
- **#394** Lockfile write failure is now an error (was warning)
- **#390** Tool root detection derived from config source paths — removed hardcoded `TOOL_DIRS` list
- **#391** Closed as superseded by #390
- **#374** `--json` output for `tome status` and `tome doctor`
- **#373** Graceful Ctrl-C via `ctrlc` crate — clean exit with code 130
- **#393** Frontmatter parsed during discovery — `DiscoveredSkill.frontmatter` field
- **#369** `tome_home` in `~/.config/tome/config.toml` — XDG config override without env vars

### Deferred
- **#370** Closed as "not planned" — manifest/lockfile separation is by design
- **#362** Moved to v0.6 — init consolidation belongs with unified directory model

## Test plan
- [x] 411 tests pass (322 unit + 89 integration)
- [x] `cargo clippy` clean
- [x] `tome status --json` produces valid JSON
- [x] `tome doctor --json` produces valid JSON
- [x] Ctrl-C prints clean message and exits 130

Closes #394, closes #390, closes #391, closes #374, closes #373, closes #393, closes #369