### PR TITLE
chore: remove beads/bd references, point agent docs at GSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,2 @@
 /target
 /docs/book/
-
-# Dolt database files (added by bd init)
-.dolt/
-*.db
-*.bak
-
-# Beads / Dolt files (added by bd init)
-.beads-credential-key

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -51,7 +51,6 @@
 ├── openspec/                            # OpenSpec tracking
 │   ├── changes/                         # Change proposals
 │   └── specs/                           # Detailed specifications
-├── .beads/                              # Beads issue tracking
 ├── .claude/                             # Claude-specific config
 ├── .planning/                           # GSD planning directory
 │   └── codebase/                        # GSD codebase docs (ARCHITECTURE.md, STRUCTURE.md, etc.)
@@ -211,11 +210,6 @@
 - Purpose: Cargo build artifacts
 - Generated: Yes (cargo build output)
 - Committed: No (.gitignore'd)
-
-**.beads/:**
-- Purpose: Beads issue database (git-backed)
-- Generated: No (manually tracked)
-- Committed: Yes
 
 **.planning/codebase/:**
 - Purpose: GSD analysis documents

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,9 +47,9 @@ cp -rf source dest          # NOT: cp -r source dest
 - Tasks and roadmap tracked via **GitHub Issues** with milestones (v0.4.1, v0.4.2, v0.5, etc.)
 - Project board: **"tome Execution Board"** on GitHub Projects
 - Labels: `bug`, `enhancement`, `architecture`, `testing`, `documentation`, `dependencies`
-- Default workflow for substantial changes: GitHub issue/idea → OpenSpec change → Beads execution tasks → implementation → archive/close
+- Default workflow for substantial changes: GitHub issue/idea → OpenSpec change → GSD phase/plans → implementation → archive/close
 - Reference doc: `docs/src/development-workflow.md`
-- Small fixes (typos, tiny bugs, narrowly scoped cleanups) do **not** need full OpenSpec + Beads overhead
+- Small fixes (typos, tiny bugs, narrowly scoped cleanups) do **not** need full OpenSpec + GSD overhead
 
 ## Tech Stack
 
@@ -81,20 +81,26 @@ openspec archive <change-id>
 For meaningful changes, link the layers when they exist:
 - GitHub issue: `#123`
 - OpenSpec change: `<change-id>`
-- Beads task: `tome-xyz` / `tome-xyz.1`
+- GSD phase: `.planning/phases/<NN>-<name>/`
+- Requirement IDs: as defined in `.planning/REQUIREMENTS.md`
 - Commit / PR: implementation evidence
 
-Suggested commit body or PR footer:
+Commit-body / PR-footer shapes used in recent PRs (pick one — don't invent a new shape):
 ```text
 Refs #123
 OpenSpec: <change-id>
-Beads: <task-id>[, <task-id>...]
+```
+or, for PRs that close a phase:
+```text
+## Traceability
+- Requirements: WHARD-04, WHARD-05, WHARD-06
+- Phase artifacts: .planning/phases/05-wizard-test-coverage/
 ```
 
 This repo uses:
 - **GitHub Issues** for backlog / roadmap intent
 - **OpenSpec** for requirements + design + checklist
-- **Beads** for execution state
+- **GSD** (`.planning/` + `/gsd:*` commands) for phase/plan execution state
 - **git / PRs** for shipped evidence
 
 ## Build & Development Commands
@@ -189,7 +195,7 @@ This project uses **GitHub Issues** for backlog and roadmap intent, and **GSD** 
 
 1. **File follow-up issues** — Open GitHub issues (or add `/gsd:add-backlog` entries) for anything discovered that won't ship in this session.
 2. **Run quality gates** — `make ci` (fmt-check, clippy -D warnings, tests) if code changed.
-3. **Update planning artifacts** — Mark completed plans/phases in `.planning/` (GSD's `phase complete` CLI does this automatically after `/gsd:execute-phase`).
+3. **Update planning artifacts** — Mark completed plans/phases in `.planning/`. `/gsd:execute-phase` handles this automatically on success; otherwise update STATE.md and ROADMAP.md manually.
 4. **PUSH TO REMOTE** — This is MANDATORY:
    ```bash
    git push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,128 +172,38 @@ Releases are managed by [cargo-dist](https://opensource.axo.dev/cargo-dist/). Th
 
 **Important:** When bumping `cargo-dist-version` in `Cargo.toml`, always run `cargo dist init` afterwards to regenerate `release.yml`. We use `allow-dirty = ["ci"]` to tolerate Dependabot action bumps, but cargo-dist upgrades may require real workflow changes that won't be applied automatically.
 
-<!-- BEGIN BEADS INTEGRATION v:1 profile:full hash:f65d5d33 -->
-## Issue Tracking with bd (beads)
+## Issue Tracking
 
-**IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
+This project uses **GitHub Issues** for backlog and roadmap intent, and **GSD** (`.planning/` + `/gsd:*` commands) for phase-level execution state. Do NOT create markdown TODOs or parallel task trackers — they fall out of sync.
 
-### Why bd?
-
-- Dependency-aware: Track blockers and relationships between issues
-- Git-friendly: Dolt-powered version control with native sync
-- Agent-optimized: JSON output, ready work detection, discovered-from links
-- Prevents duplicate tracking systems and confusion
-
-### Quick Start
-
-**Check for ready work:**
-
-```bash
-bd ready --json
-```
-
-**Create new issues:**
-
-```bash
-bd create "Issue title" --description="Detailed context" -t bug|feature|task -p 0-4 --json
-bd create "Issue title" --description="What this issue is about" -p 1 --deps discovered-from:bd-123 --json
-```
-
-**Claim and update:**
-
-```bash
-bd update <id> --claim --json
-bd update bd-42 --priority 1 --json
-```
-
-**Complete work:**
-
-```bash
-bd close bd-42 --reason "Completed" --json
-```
-
-### Issue Types
-
-- `bug` - Something broken
-- `feature` - New functionality
-- `task` - Work item (tests, docs, refactoring)
-- `epic` - Large feature with subtasks
-- `chore` - Maintenance (dependencies, tooling)
-
-### Priorities
-
-- `0` - Critical (security, data loss, broken builds)
-- `1` - High (major features, important bugs)
-- `2` - Medium (default, nice-to-have)
-- `3` - Low (polish, optimization)
-- `4` - Backlog (future ideas)
-
-### Workflow for AI Agents
-
-1. **Check ready work**: `bd ready` shows unblocked issues
-2. **Claim your task atomically**: `bd update <id> --claim`
-3. **Work on it**: Implement, test, document
-4. **Discover new work?** Create linked issue:
-   - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
-5. **Complete**: `bd close <id> --reason "Done"`
-
-### Quality
-- Use `--acceptance` and `--design` fields when creating issues
-- Use `--validate` to check description completeness
-
-### Lifecycle
-- `bd defer <id>` / `bd supersede <id>` for issue management
-- `bd stale` / `bd orphans` / `bd lint` for hygiene
-- `bd human <id>` to flag for human decisions
-- `bd formula list` / `bd mol pour <name>` for structured workflows
-
-### Auto-Sync
-
-bd automatically syncs via Dolt:
-
-- Each write auto-commits to Dolt history
-- Use `bd dolt push`/`bd dolt pull` for remote sync
-- No manual export/import needed!
-
-### Important Rules
-
-- ✅ Use bd for ALL task tracking
-- ✅ Always use `--json` flag for programmatic use
-- ✅ Link discovered work with `discovered-from` dependencies
-- ✅ Check `bd ready` before asking "what should I work on?"
-- ❌ Do NOT create markdown TODO lists
-- ❌ Do NOT use external issue trackers
-- ❌ Do NOT duplicate tracking systems
-
-For more details, see README.md and docs/QUICKSTART.md.
+- **Backlog / product intent**: GitHub Issues + Milestones (`gh issue create`, project board "tome Execution Board")
+- **Milestone/phase execution**: GSD planning artifacts under `.planning/` (ROADMAP.md, PROJECT.md, STATE.md, REQUIREMENTS.md) and the `/gsd:*` commands (`/gsd:progress`, `/gsd:plan-phase`, `/gsd:execute-phase`, `/gsd:verify-work`)
+- **Substantial changes** also flow through OpenSpec — see `docs/src/development-workflow.md`
+- **Small fixes** (typos, tiny bugs, narrowly scoped cleanups) do NOT need full OpenSpec + GSD overhead — issue → code → PR is fine
 
 ## Session Completion
 
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+**When ending a work session**, work is NOT complete until `git push` succeeds.
 
 **MANDATORY WORKFLOW:**
 
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
-2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
+1. **File follow-up issues** — Open GitHub issues (or add `/gsd:add-backlog` entries) for anything discovered that won't ship in this session.
+2. **Run quality gates** — `make ci` (fmt-check, clippy -D warnings, tests) if code changed.
+3. **Update planning artifacts** — Mark completed plans/phases in `.planning/` (GSD's `phase complete` CLI does this automatically after `/gsd:execute-phase`).
+4. **PUSH TO REMOTE** — This is MANDATORY:
    ```bash
-   git pull --rebase
-   bd dolt push
    git push
    git status  # MUST show "up to date with origin"
    ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
+5. **Clean up** — Clear stashes, prune remote branches.
+6. **Verify** — All changes committed AND pushed.
+7. **Hand off** — Provide context for the next session.
 
 **CRITICAL RULES:**
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing - that leaves work stranded locally
-- NEVER say "ready to push when you are" - YOU must push
-- If push fails, resolve and retry until it succeeds
-
-<!-- END BEADS INTEGRATION -->
+- Work is NOT complete until `git push` succeeds.
+- NEVER stop before pushing — that leaves work stranded locally.
+- NEVER say "ready to push when you are" — YOU must push.
+- If push fails, resolve and retry until it succeeds.
 
 <!-- GSD:project-start source:PROJECT.md -->
 ## Project

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ tome status
 
 ## Development
 
-For repository workflow guidance, see [docs/src/development-workflow.md](docs/src/development-workflow.md). It explains when `tome` uses GitHub Issues vs OpenSpec vs Beads, and how to link them cleanly in commits and PRs.
+For repository workflow guidance, see [docs/src/development-workflow.md](docs/src/development-workflow.md). It explains when `tome` uses GitHub Issues vs OpenSpec vs GSD, and how to link them cleanly in commits and PRs.
 
 ## Commands
 

--- a/docs/src/development-workflow.md
+++ b/docs/src/development-workflow.md
@@ -4,14 +4,14 @@
 
 - **GitHub Issues** track product intent, roadmap placement, and user-visible scope.
 - **OpenSpec** tracks the change proposal, requirements, design notes, and implementation checklist.
-- **Beads** tracks live execution state: what is ready, what is claimed, what is blocked, and what is done.
+- **GSD** (`.planning/` + `/gsd:*` commands) tracks phase and plan execution state — what's been researched, discussed, planned, executed, and verified.
 - **Git commits / PRs** are the implementation evidence.
 
 This is meant to improve traceability, not create process theater. If the workflow becomes bureaucratic sludge, scale it back.
 
 ## When to Use This Workflow
 
-Use the full OpenSpec + Beads flow for:
+Use the full OpenSpec + GSD flow for:
 
 - new features
 - significant refactors
@@ -26,11 +26,11 @@ You do **not** need the full workflow for:
 - narrowly scoped internal cleanups
 - mechanical edits with no design impact
 
-For small fixes, issue → code → PR is fine.
+For small fixes, issue → code → PR is fine. `/gsd:quick` or `/gsd:fast` can be used for small-but-structured work without the full planning overhead.
 
 ## Role of Each Layer
 
-## GitHub Issues
+### GitHub Issues
 
 Use GitHub Issues for:
 
@@ -41,7 +41,7 @@ Use GitHub Issues for:
 
 GitHub Issues answer: **why does this work exist at all?**
 
-## OpenSpec
+### OpenSpec
 
 Use OpenSpec for:
 
@@ -62,7 +62,7 @@ openspec/changes/<change-id>/
 └── specs/<capability>/spec.md
 ```
 
-### Core OpenSpec flow
+#### Core OpenSpec flow
 
 ```bash
 # create a new change scaffold
@@ -80,34 +80,52 @@ openspec validate <change-id>
 openspec archive <change-id>
 ```
 
-## Beads
+### GSD
 
-Use Beads for:
+Use GSD for:
 
-- turning an OpenSpec task checklist into live executable tasks
-- claiming work
-- tracking dependencies / blocking relationships
-- recording closure notes tied to implementation
+- turning a milestone into phases, and phases into executable plans
+- tracking which plans are ready, in progress, and done
+- recording verification outcomes tied to implementation
+- advancing STATE.md across phase transitions
 
-Beads answers: **what should be worked on next, who owns it, and what already landed?**
+GSD answers: **what should be worked on next, who's working on it, and what already landed?**
+
+Core artifacts live under `.planning/`:
+
+```text
+.planning/
+├── PROJECT.md         # core value, constraints, decisions, requirements
+├── ROADMAP.md         # milestones, phases, status
+├── REQUIREMENTS.md    # requirement IDs and traceability
+├── STATE.md           # current focus, current phase/plan
+└── phases/<NN>-<name>/
+    ├── <NN>-CONTEXT.md
+    ├── <NN>-<MM>-<slug>-PLAN.md
+    ├── <NN>-<MM>-<slug>-SUMMARY.md   (created when the plan completes)
+    └── <NN>-VERIFICATION.md          (created by the verifier when the phase completes)
+```
 
 Minimal command flow used in `tome`:
 
 ```bash
-# see unblocked work
-bd ready
+# see current state and next actions
+/gsd:progress
 
-# inspect a task
-bd show <task-id>
+# gather phase context, then plan, then execute
+/gsd:discuss-phase <N>
+/gsd:plan-phase <N>
+/gsd:execute-phase <N>
 
-# claim work
-bd update <task-id> --claim
+# verify manually when needed
+/gsd:verify-work <N>
 
-# close work with an implementation note
-bd close <task-id> "Done in commit <sha>"
+# capture follow-up ideas without leaving flow
+/gsd:add-backlog "<idea>"
+/gsd:note "<short note>"
 ```
 
-When creating Beads tasks from an OpenSpec change, set `spec_id` to the OpenSpec change id.
+When creating a GSD phase that implements an OpenSpec change, reference the OpenSpec change id in the phase CONTEXT.md and in commit/PR footers.
 
 ## Default Flow for Significant Changes
 
@@ -118,8 +136,8 @@ When creating Beads tasks from an OpenSpec change, set `spec_id` to the OpenSpec
    - `design.md`
    - `tasks.md`
    - any relevant spec delta files
-4. Create **Beads** tasks for the executable work items.
-5. Use `bd ready` / `bd update --claim` / `bd close` during implementation.
+4. Bring the work into **GSD** by adding a phase to `.planning/ROADMAP.md` (or creating a new milestone with `/gsd:new-milestone`).
+5. Use `/gsd:plan-phase` and `/gsd:execute-phase` to drive implementation. Each plan's `SUMMARY.md` becomes the per-plan closure note; the phase's `VERIFICATION.md` is the phase-level sign-off.
 6. Land code in normal git commits / PRs.
 7. Archive the OpenSpec change when the work is complete.
 
@@ -127,20 +145,14 @@ When creating Beads tasks from an OpenSpec change, set `spec_id` to the OpenSpec
 
 For meaningful changes, link the layers explicitly.
 
-### In Beads
-
-- set `spec_id` to the OpenSpec change id
-- use task descriptions that reference the actual repo artifact being changed
-- close tasks with a note that includes the commit hash when possible
-
 ### In commits or PR descriptions
 
 Include the IDs when they exist:
 
 ```text
 Refs #123
-OpenSpec: document-openspec-beads-workflow
-Beads: tome-8vs.1
+OpenSpec: <change-id>
+Phase: <N>-<phase-name>
 ```
 
 Recommended PR footer shape:
@@ -148,7 +160,8 @@ Recommended PR footer shape:
 ```text
 Closes #123
 OpenSpec: <change-id>
-Beads: <task-id>[, <task-id>...]
+Phase: .planning/phases/<NN>-<phase-name>/
+Requirements: <ID>, <ID>, ...
 ```
 
 This gives a practical audit trail across backlog, planning, execution, and code history.
@@ -157,7 +170,7 @@ This gives a practical audit trail across backlog, planning, execution, and code
 
 - **GitHub Issue** = backlog / business reason
 - **OpenSpec** = requirements + design + checklist
-- **Beads** = execution state
+- **GSD** = execution state (phases, plans, verification)
 - **git / PR** = shipped evidence
 
-Don’t stack ceremony for its own sake. Use the minimum structure needed to stop future-you from asking, “What the hell were we doing here?”
+Don't stack ceremony for its own sake. Use the minimum structure needed to stop future-you from asking, "What the hell were we doing here?"

--- a/docs/src/development-workflow.md
+++ b/docs/src/development-workflow.md
@@ -91,19 +91,22 @@ Use GSD for:
 
 GSD answers: **what should be worked on next, who's working on it, and what already landed?**
 
-Core artifacts live under `.planning/`:
+Selected artifacts under `.planning/` (list is non-exhaustive — GSD adds files as new workflows are used):
 
 ```text
 .planning/
-├── PROJECT.md         # core value, constraints, decisions, requirements
-├── ROADMAP.md         # milestones, phases, status
-├── REQUIREMENTS.md    # requirement IDs and traceability
-├── STATE.md           # current focus, current phase/plan
+├── PROJECT.md                          # core value, constraints, decisions, requirements
+├── ROADMAP.md                          # milestones, phases, status
+├── REQUIREMENTS.md                     # requirement IDs and traceability
+├── STATE.md                            # current focus, current phase/plan
 └── phases/<NN>-<name>/
-    ├── <NN>-CONTEXT.md
-    ├── <NN>-<MM>-<slug>-PLAN.md
-    ├── <NN>-<MM>-<slug>-SUMMARY.md   (created when the plan completes)
-    └── <NN>-VERIFICATION.md          (created by the verifier when the phase completes)
+    ├── <NN>-CONTEXT.md                 # context gathered before planning
+    ├── <NN>-RESEARCH.md                # technical approach research (when created)
+    ├── <NN>-DISCUSSION-LOG.md          # /gsd:discuss-phase transcript (when created)
+    ├── <NN>-UI-SPEC.md                 # UI/UX design contract for frontend phases (when created)
+    ├── <NN>-<MM>-<slug>-PLAN.md        # executable plan per wave/task
+    ├── <NN>-<MM>-<slug>-SUMMARY.md     # created when each plan completes
+    └── <NN>-VERIFICATION.md            # created by the verifier when the phase completes
 ```
 
 Minimal command flow used in `tome`:
@@ -143,25 +146,23 @@ When creating a GSD phase that implements an OpenSpec change, reference the Open
 
 ## Traceability Convention
 
-For meaningful changes, link the layers explicitly.
+For meaningful changes, link the layers explicitly. Don't invent a new footer shape per PR — use one of the two forms used in recent merged PRs:
 
-### In commits or PR descriptions
-
-Include the IDs when they exist:
+**Small / incremental PRs** — a one-liner in the commit body is enough:
 
 ```text
 Refs #123
 OpenSpec: <change-id>
-Phase: <N>-<phase-name>
 ```
 
-Recommended PR footer shape:
+**Phase-closing PRs** — add a `## Traceability` section in the PR body:
 
 ```text
-Closes #123
-OpenSpec: <change-id>
-Phase: .planning/phases/<NN>-<phase-name>/
-Requirements: <ID>, <ID>, ...
+## Traceability
+
+- Requirements: WHARD-04, WHARD-05, WHARD-06
+- Phase artifacts: .planning/phases/05-wizard-test-coverage/
+- OpenSpec: <change-id>   (if an OpenSpec change exists)
 ```
 
 This gives a practical audit trail across backlog, planning, execution, and code history.

--- a/openspec/specs/development-workflow/spec.md
+++ b/openspec/specs/development-workflow/spec.md
@@ -1,7 +1,8 @@
 # development-workflow Specification
 
 ## Purpose
-TBD - created by archiving change document-openspec-beads-workflow. Update Purpose after archive.
+Document the layered workflow tome uses for substantial changes so contributors and coding agents know when to use GitHub Issues, OpenSpec, and GSD — and how those layers connect to commits and PRs. The full workflow is opt-in for non-trivial work; small fixes follow a lightweight issue → code → PR path.
+
 ## Requirements
 ### Requirement: Significant development changes are documented with a workflow artifact
 The repository SHALL define a documented workflow for significant development changes that require planning before implementation.
@@ -11,12 +12,12 @@ The repository SHALL define a documented workflow for significant development ch
 - **THEN** the repository provides guidance describing how to plan and track that work
 
 ### Requirement: The workflow distinguishes planning from execution tracking
-The repository SHALL explain the distinct roles of OpenSpec and Beads so contributors know which system to update.
+The repository SHALL explain the distinct roles of OpenSpec and GSD so contributors know which system to update.
 
 #### Scenario: Contributor needs to know where to record work
 - **WHEN** a contributor is deciding how to track a significant change
 - **THEN** the documentation explains that OpenSpec is used for requirements, design, and task checklists
-- **AND** the documentation explains that Beads is used for execution state, dependencies, and task completion tracking
+- **AND** the documentation explains that GSD (`.planning/` artifacts and `/gsd:*` commands) is used for phase/plan execution state and verification tracking
 
 ### Requirement: Coding agents are instructed to follow the repository workflow
 The repository SHALL provide agent-facing instructions for using the documented workflow during significant changes.
@@ -24,12 +25,12 @@ The repository SHALL provide agent-facing instructions for using the documented 
 #### Scenario: Agent starts a substantial change
 - **WHEN** a coding agent begins a substantial change in the repository
 - **THEN** the repository instructions describe when to create or update an OpenSpec change
-- **AND** the repository instructions describe how to use Beads for task execution tracking
+- **AND** the repository instructions describe how to use GSD phases and plans for execution tracking (`/gsd:plan-phase`, `/gsd:execute-phase`, `/gsd:verify-work`)
 
 ### Requirement: Small fixes can bypass the heavier workflow
 The repository SHALL preserve a lightweight path for minor changes that do not justify full planning overhead.
 
 #### Scenario: Contributor fixes a trivial issue
 - **WHEN** a contributor makes a typo fix, tiny bug fix, or narrowly scoped non-architectural change
-- **THEN** the documentation states that the full OpenSpec + Beads workflow is optional
-
+- **THEN** the documentation states that the full OpenSpec + GSD workflow is optional
+- **AND** the documentation mentions `/gsd:quick` or `/gsd:fast` as a lightweight structured path when some tracking is still desirable


### PR DESCRIPTION
Closes #

## Summary

The project's agent docs and development workflow spec referenced **bd (beads)** as the execution-tracking layer, but bd was never actually adopted here — there's no `.beads/` directory in the repo and `bd list` reports no database. Meanwhile, **GSD** (`.planning/` artifacts + `/gsd:*` commands) is the execution layer we actually use. This PR aligns the docs with reality.

### Changes

1. **`AGENTS.md`** (`CLAUDE.md` is a symlink to this file) — delete the 121-line \`BEGIN/END BEADS INTEGRATION\` block (auto-generated bd onboarding, bd quick-start, issue types, auto-sync instructions, and `bd dolt push` in Session Completion). Replace it with a short "Issue Tracking" section pointing at GitHub Issues (backlog) and GSD (phase execution), plus a trimmed Session Completion section that keeps the "push to remote and verify" discipline but drops the `bd dolt push` step.
2. **`docs/src/development-workflow.md`** — replace the "Beads" layer section with an equivalent "GSD" section describing `.planning/` artifact layout and the `/gsd:plan-phase` / `/gsd:execute-phase` / `/gsd:verify-work` command flow. Update the Default Flow and the Traceability Convention footer shape (drop `Beads: <task-id>`, add `Phase: .planning/phases/<NN>-...` and `Requirements: <ID>, ...`). Keep GitHub Issues and OpenSpec sections unchanged.
3. **`openspec/specs/development-workflow/spec.md`** — the live spec still said Beads in its Purpose (auto-generated TBD) and in three requirement scenarios. Fill in the Purpose paragraph and rewrite the scenarios to pair OpenSpec with GSD. Mention `/gsd:quick` / `/gsd:fast` as the lightweight path for small fixes.

### What this does NOT touch

- **`openspec/changes/archive/2026-03-19-document-openspec-beads-workflow/`** — archived change left intact as a historical record of a decision that shipped then got reverted.
- **No task migration needed** — no active bd tasks existed to migrate.
- **No tool/runtime behavior changes** — docs-only PR.

## Test plan

- [x] `rg "\bbeads\b|\bbd[- ]|bd (create|ready|update|close|dolt)" --glob '!openspec/changes/archive/**'` returns no hits
- [x] `make ci` still passes (no code touched, but verified)
- [ ] Review that the Session Completion discipline still makes sense without the `bd dolt push` step