### PR TITLE
chore(v0.7): archive Wizard Hardening milestone + Phase 6 UAT

### DIFF
--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,5 +1,21 @@
 # Milestones
 
+## v0.7 Wizard Hardening (Shipped: 2026-04-22)
+
+**Phases completed:** 3 phases, 9 plans, 8 tasks
+
+**Key accomplishments:**
+
+- All four Config::validate() bail! bodies rewritten to the D-10 Conflict+Why+Suggestion template with DirectoryRole::description() used for every role mention
+- Config::validate() now rejects every path relation where library_dir overlaps a distribution directory — equality, nesting either direction — using lexical, tilde-aware, trailing-separator-normalized comparison
+- Config::save_checked enforces expand → validate → TOML round-trip → write; wizard save + dry-run now share the same pipeline so invalid configs never reach disk
+- Two `assert_cmd` integration tests drive `tome init --dry-run --no-input` end-to-end against empty and seeded TempDir HOMEs, proving the generated Config validates and round-trips through TOML byte-equal.
+- In-scope correctness fix to `Config::validate()`.
+- Migrated `wizard::show_directory_summary` from manual `println!` column formatting to `tabled::Table` with `Style::rounded()` borders, `PriorityMax::right()` truncation, and an 80-column non-TTY fallback.
+- Closed the v0.7 doc half of WHARD-08: PROJECT.md now explicitly marks WIZ-01–05 as shipped-in-v0.6 and hardened-in-v0.7 (Phases 4+5), stale "Known Gaps (deferred from v0.6)" subsection removed, footer dated 2026-04-21, CHANGELOG cites WHARD-07 + WHARD-08 under [Unreleased].
+
+---
+
 ## v0.6 Unified Directory Model (Shipped: 2026-04-16)
 
 **Phases completed:** 3 phases, 11 plans, 19 tasks

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -35,8 +35,8 @@ Every AI coding tool on a developer's machine shares the same skill library with
 
 ### Active
 
-- [ ] Migrate `show_directory_summary()` from manual println to `tabled`
 - [ ] Expand `KNOWN_DIRECTORIES` registry (Cursor, Windsurf, Aider — if they have skill paths)
+- [ ] Cut `v0.7.0` release via `make release VERSION=0.7.0` (Homebrew formula bump picks up wizard hardening)
 
 ### Validated in v0.7
 
@@ -66,16 +66,11 @@ The wizard-surface work below shipped in v0.6 (as WIZ-01–05) but lacked valida
 
 *v0.7 hardening deliverables:* (a) `Config::validate()` path-overlap checks (Phase 4), (b) `Config::save_checked` with TOML round-trip (Phase 4), (c) `--no-input` plumbing (Phase 5), (d) unit + integration test coverage for pure wizard helpers (Phase 5), (e) 12-combo validation matrix (Phase 5), (f) `tabled` summary migration (Phase 6).
 
-## Current Milestone: v0.7 Wizard Hardening
+## Current State
 
-**Goal:** Close the correctness gaps found between shipped wizard code and the original WIZ-01–05 intent: validation, circular path detection, test coverage, and polish.
+**v0.7 Wizard Hardening shipped 2026-04-22** — all 8 requirements (WHARD-01 through WHARD-08) delivered across Phases 4–6 (9 plans). The wizard now refuses invalid configs at save time, has unit + integration + combo-matrix test coverage, and renders its summary via `tabled` with rounded borders. See [`milestones/v0.7-ROADMAP.md`](milestones/v0.7-ROADMAP.md) for the archived milestone.
 
-**Target features:**
-- Config validation before save (catch invalid type/role combos the wizard struct-building path bypassed)
-- Circular path detection (library_dir inside a synced/target directory)
-- Test coverage for wizard's non-interactive paths (registry lookup, auto-discovery, config assembly)
-- `tabled` migration for summary display
-- Registry expansion for tools missing in KNOWN_DIRECTORIES
+**Next:** `v0.7.0` release cut via `make release`, then `/gsd:new-milestone` to scope v0.8.
 
 ### Out of Scope
 
@@ -87,11 +82,11 @@ The wizard-surface work below shipped in v0.6 (as WIZ-01–05) but lacked valida
 
 ## Context
 
-tome is at v0.6.1 with ~20k lines of Rust across 20+ source modules in a single crate. The unified directory model eliminated the source/target config split. Git-backed skill repos are supported with shallow clones and ref pinning.
+tome is at Cargo.toml `0.6.2` pending the v0.7.0 release cut. Codebase: ~21.8k lines of Rust across 20+ source modules in a single crate. v0.6 introduced the unified directory model; v0.7 hardened the wizard surface around it.
 
-The Rust codebase uses `anyhow` for errors, `serde`/`toml` for config, `clap` for CLI, `ratatui` for the TUI browser, and `nucleo-matcher` for fuzzy search. Tests use `assert_cmd` + `tempfile` + `insta` snapshots. CI runs on Ubuntu and macOS.
+The Rust codebase uses `anyhow` for errors, `serde`/`toml` for config, `clap` for CLI, `ratatui` for the TUI browser, and `nucleo-matcher` for fuzzy search. Tests use `assert_cmd` + `tempfile` + `insta` snapshots. CI runs on Ubuntu and macOS. 525 tests total (417 unit + 108 integration).
 
-Config is `directories: BTreeMap<DirectoryName, DirectoryConfig>` where each entry has a `role` (managed/synced/source/target) and `type` (claude-plugins/directory/git).
+Config is `directories: BTreeMap<DirectoryName, DirectoryConfig>` where each entry has a `role` (managed/synced/source/target) and `type` (claude-plugins/directory/git). `Config::save_checked` enforces expand → `validate()` → TOML round-trip → write; no invalid config can reach disk.
 
 ## Constraints
 
@@ -113,11 +108,15 @@ Config is `directories: BTreeMap<DirectoryName, DirectoryConfig>` where each ent
 | Plan/render/execute pattern for destructive commands | Separation of planning from execution | ✓ Good — reused for remove, reassign, fork |
 | Manifest-based circular prevention | Replaces `shares_tool_root()` path heuristic | ✓ Good — more reliable |
 | Git env clearing pattern | Every `Command::new("git")` clears GIT_DIR etc. | ✓ Good — prevents nesting bugs |
-| Defer wizard rewrite (WIZ-01–05) | Old wizard still works; low priority | ⚠️ Revisit — tech debt |
+| Defer wizard rewrite (WIZ-01–05) | Old wizard still works; low priority | ✓ Resolved v0.7 — kept existing wizard code, hardened in-place (validation + tests + tabled polish) instead of rewriting |
+| D-10 Conflict+Why+Suggestion error template (v0.7 Phase 4) | Validation errors should name what conflicts, explain why, and suggest a fix | ✓ Good — applied to all 4 `Config::validate()` bail sites |
+| TOML round-trip byte-equality over `PartialEq` (v0.7 Phase 4) | Avoids deriving PartialEq cascade across all config types; compares emitted strings | ✓ Good — `Config::save_checked` enforces in ~20 lines |
+| `--no-input` flag over separate non-interactive binary (v0.7 Phase 5) | One wizard, two modes — integration tests drive the same code path users run | ✓ Good — 12-combo matrix test possible because of this |
+| `tabled` `Style::rounded()` for wizard summary, `Style::blank()` stays for `tome status` (v0.7 Phase 6) | Ceremonial one-shot summary deserves visual weight; repeated inspection wants lightweight | ✓ Good — matching pattern not required |
 
 ## Evolution
 
 This document evolves at phase transitions and milestone boundaries.
 
 ---
-*Last updated: 2026-04-21 — Phase 6 (Display Polish & Docs) complete — wizard summary migrated to `tabled` (WHARD-07); WIZ-01–05 marked validated as hardened in v0.7 (WHARD-08)*
+*Last updated: 2026-04-22 — v0.7 Wizard Hardening milestone shipped (Phases 4-6, WHARD-01..08). Ready for `make release VERSION=0.7.0`.*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -3,7 +3,8 @@
 ## Milestones
 
 - ✅ **v0.6 Unified Directory Model** — Phases 1-3 (shipped 2026-04-16) — [archive](milestones/v0.6-ROADMAP.md)
-- 🚧 **v0.7 Wizard Hardening** — Phases 4-6 (active since 2026-04-18)
+- ✅ **v0.7 Wizard Hardening** — Phases 4-6 (shipped 2026-04-22) — [archive](milestones/v0.7-ROADMAP.md)
+- 📋 **v0.8** — TBD (run `/gsd:new-milestone` to plan)
 
 ## Phases
 
@@ -14,59 +15,24 @@
 - [x] Phase 2: Git Sources & Selection (4/4 plans) — git clone/update, per-dir filtering, tome remove
 - [x] Phase 3: Import, Reassignment & Browse Polish (2/2 plans) — tome add/reassign/fork, browse TUI polish
 
-**Known gaps:** WIZ-01 through WIZ-05 (wizard rewrite) deferred — old wizard code still functional.
+**Known gaps:** WIZ-01 through WIZ-05 (wizard rewrite) deferred — closed as "hardened" in v0.7.
 
 </details>
 
-### v0.7 Wizard Hardening
+<details>
+<summary>✅ v0.7 Wizard Hardening (Phases 4-6) — SHIPPED 2026-04-22</summary>
 
-- [x] **Phase 4: Wizard Correctness** — Wizard rejects invalid configs and circular library paths before save (completed 2026-04-19)
-- [x] **Phase 5: Wizard Test Coverage** — Pure helpers and config assembly have unit + integration test coverage (completed 2026-04-20)
-- [ ] **Phase 6: Display Polish & Docs** — Summary table uses `tabled`; PROJECT.md validates WIZ-01–05 shipped/hardened
+- [x] Phase 4: Wizard Correctness (3/3 plans) — `Config::validate()` Conflict+Why+Suggestion errors, library↔distribution overlap detection (Cases A/B/C), `Config::save_checked` expand→validate→round-trip→write pipeline (WHARD-01/02/03)
+- [x] Phase 5: Wizard Test Coverage (4/4 plans) — `--no-input` plumbing + `assemble_config` helper extraction, pure-helper unit tests, `tome init --dry-run --no-input` integration tests, 12-combo `(DirectoryType, DirectoryRole)` matrix (WHARD-04/05/06)
+- [x] Phase 6: Display Polish & Docs (2/2 plans) — wizard summary migrated to `tabled::Table` with `Style::rounded()` + `PriorityMax::right()` truncation, PROJECT.md "Hardened in v0.7" subsection, CHANGELOG WHARD-07/08 entries (WHARD-07/08)
 
-## Phase Details
+**Closed WIZ-01..05:** v0.6's known wizard gaps are now shipped AND hardened.
 
-### Phase 4: Wizard Correctness
-**Goal**: Wizard cannot save a config that would fail at sync time
-**Depends on**: Phase 3 (v0.6 unified directory model shipped)
-**Requirements**: WHARD-01, WHARD-02, WHARD-03
-**Success Criteria** (what must be TRUE):
-  1. User running `tome init` with an invalid type/role combo (e.g., Git + Target) sees a clear validation error and the config is not written to disk
-  2. User who picks a `library_dir` that overlaps a Synced/Target directory sees an error suggesting a non-overlapping location and the config is not written
-  3. User who picks a `library_dir` that is a subdirectory of a synced directory sees a circular-symlink validation error before save
-  4. A successful `tome init` still round-trips: the written config passes `Config::validate()` and reloads without changes
-**Plans**: 3 plans
-- [x] 04-01-validate-error-template-PLAN.md — Upgrade existing `Config::validate()` errors to the D-10 Conflict+Why+Suggestion template
-- [x] 04-02-library-overlap-validation-PLAN.md — Add Cases A/B/C overlap detection between `library_dir` and distribution dirs (WHARD-02/03)
-- [x] 04-03-wizard-save-hardening-PLAN.md — Wizard save path calls `Config::save_checked` (expand → validate → round-trip → write); dry-run branch validates too (WHARD-01)
+</details>
 
-### Phase 5: Wizard Test Coverage
-**Goal**: Wizard logic is testable without a TTY and has enforced coverage of valid/invalid combinations
-**Depends on**: Phase 4
-**Requirements**: WHARD-04, WHARD-05, WHARD-06
-**Success Criteria** (what must be TRUE):
-  1. `cargo test` exercises unit tests for `find_known_directories_in`, `KNOWN_DIRECTORIES` registry lookup, `DirectoryType::default_role`, and pure config-assembly helpers
-  2. An integration test runs `tome init --dry-run --no-input` and asserts the generated config passes validation and round-trips through TOML unchanged
-  3. Every `(DirectoryType, DirectoryRole)` combination the wizard can produce has a test: valid combos save successfully; invalid combos are rejected by the Phase 4 validation path
-  4. CI (ubuntu + macos) passes with the new tests as non-optional gates
-**Plans**: 4 plans
-- [x] 05-01-no-input-plumbing-and-assemble-config-PLAN.md — Plumb `--no-input` through `wizard::run`; extract `pub(crate) fn assemble_config`; remove `lib.rs:164-165` bail (WHARD-04/05 prerequisite)
-- [x] 05-02-pure-helper-unit-tests-PLAN.md — Unit tests for `find_known_directories_in`, `KNOWN_DIRECTORIES` registry invariants, and `assemble_config` (WHARD-04)
-- [x] 05-03-init-integration-test-PLAN.md — Integration tests for `tome init --dry-run --no-input` on empty + seeded HOME (WHARD-05)
-- [x] 05-04-combo-matrix-test-PLAN.md — Table-driven `(DirectoryType, DirectoryRole)` cross-product — 12 combos derived from `valid_roles()` (WHARD-06)
+### 📋 v0.8 (Not yet planned)
 
-### Phase 6: Display Polish & Docs
-**Goal**: Wizard summary renders cleanly on any terminal width and v0.7 scope is marked complete in project docs
-**Depends on**: Phase 5
-**Requirements**: WHARD-07, WHARD-08
-**Success Criteria** (what must be TRUE):
-  1. User running `tome init` sees the directory summary rendered via `tabled` with `Style::rounded()`, matching the visual language of `tome status`
-  2. Long paths (e.g., git repo clones under `~/.tome/repos/<sha>/`) render without breaking column alignment — either truncated or wrapped, never overflowing
-  3. `PROJECT.md` lists WIZ-01 through WIZ-05 as validated with a note that they shipped in v0.6 and were hardened in v0.7
-**Plans**: 2 plans
-- [x] 06-01-wizard-summary-tabled-PLAN.md — Migrate `wizard::show_directory_summary` to `tabled` with `Style::rounded()` and terminal-width-aware truncation; add `terminal_size` crate dep (WHARD-07)
-- [x] 06-02-project-md-wiz-closure-PLAN.md — Mark WIZ-01–05 as validated/hardened in `.planning/PROJECT.md`, remove stale "Known Gaps" bullet, update footer, add CHANGELOG entry (WHARD-08)
-**UI hint**: yes
+Run `/gsd:new-milestone` to scope the next milestone. Candidate themes tracked in `.planning/PROJECT.md` (Active Requirements section).
 
 ## Progress
 
@@ -75,6 +41,6 @@
 | 1. Unified Directory Foundation | v0.6 | 3/5 | Complete | 2026-04-14 |
 | 2. Git Sources & Selection | v0.6 | 4/4 | Complete | 2026-04-15 |
 | 3. Import, Reassignment & Browse Polish | v0.6 | 2/2 | Complete | 2026-04-16 |
-| 4. Wizard Correctness | v0.7 | 3/3 | Complete   | 2026-04-19 |
-| 5. Wizard Test Coverage | v0.7 | 0/4 | Not started | — |
-| 6. Display Polish & Docs | v0.7 | 0/2 | Not started | — |
+| 4. Wizard Correctness | v0.7 | 3/3 | Complete | 2026-04-19 |
+| 5. Wizard Test Coverage | v0.7 | 4/4 | Complete | 2026-04-20 |
+| 6. Display Polish & Docs | v0.7 | 2/2 | Complete | 2026-04-22 |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,16 +1,16 @@
 ---
 gsd_state_version: 1.0
-milestone: v0.7
-milestone_name: Wizard Hardening
-status: verifying
-stopped_at: Completed 06-01-wizard-summary-tabled-PLAN.md
-last_updated: "2026-04-21T13:36:24.752Z"
-last_activity: 2026-04-21
+milestone: null
+milestone_name: null
+status: between_milestones
+stopped_at: v0.7 Wizard Hardening milestone shipped 2026-04-22
+last_updated: "2026-04-22T13:30:00Z"
+last_activity: 2026-04-22
 progress:
-  total_phases: 3
-  completed_phases: 3
-  total_plans: 9
-  completed_plans: 9
+  total_phases: 0
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
   percent: 0
 ---
 
@@ -18,48 +18,33 @@ progress:
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-04-18)
+See: .planning/PROJECT.md (updated 2026-04-22)
 
 **Core value:** Every AI coding tool on a developer's machine shares the same skill library without manual copying or per-tool configuration.
-**Current focus:** Phase 06 — display-polish-docs
+**Current focus:** Awaiting v0.8 scope — run `/gsd:new-milestone` to plan the next milestone.
 
 ## Current Position
 
-Phase: 06
-Plan: Not started
-Status: Phase complete — ready for verification
-Last activity: 2026-04-21
+Milestone: — (between milestones)
+Phase: —
+Plan: —
+Status: v0.7 Wizard Hardening shipped 2026-04-22 (Phases 4-6, WHARD-01..08). Cargo.toml at 0.6.2 pending `make release VERSION=0.7.0`.
 
-Progress: [░░░░░░░░░░] 0% (0/3 phases complete)
-
-## Performance Metrics
-
-- Requirements defined: 8 (v1)
-- Requirements mapped: 8/8 (100% coverage)
-- Phases planned: 3 (Correctness → Test Coverage → Polish & Docs)
-- Granularity: coarse (3 phases fits small 8-requirement milestone)
+Progress: [██████████] 100% — v0.7 milestone complete (9/9 plans across 3 phases)
 
 ## Accumulated Context
 
 ### Decisions
 
-Decisions are logged in PROJECT.md Key Decisions table.
-
-Roadmap-specific:
-
-- Split v0.7 into three phases instead of two (research-suggested Correctness + Polish) to give test-coverage work its own verifiable boundary. Tests depend on Phase 4's pure-function extraction and must pass before polish lands.
-- Phase 6 absorbs both display polish (WHARD-07) and the doc housekeeping (WHARD-08) since they are small and share a "milestone-close" character.
-- [Phase 04]: D-10 Conflict+Why+Suggestion error template applied to all four Config::validate() bail! sites; D-11 role parentheticals routed through DirectoryRole::description()
-- [Phase 04-wizard-correctness]: [Phase 04-02]: Lexical path-overlap detection (no canonicalize) in Config::validate; path_contains helper private to config module; Source-role nesting intentionally allowed (D-05)
-- [Phase 04-wizard-correctness]: [Phase 04]: D-03 TOML round-trip check in Config::save_checked compares emitted strings for byte equality rather than deriving PartialEq on Config (avoids cascade)
-- [Phase 04-wizard-correctness]: [Phase 04]: save_checked operates on a clone; caller's tilde-shaped Config paths are preserved
-- [Phase 06-display-polish-docs]: Plan 06-02: '### Hardened in v0.7' subsection added to PROJECT.md (after '### Previously Validated', before '## Current Milestone'); WIZ-01-05 bullets carry 'Shipped v0.6, hardened v0.7 (Phases 4+5)' provenance + per-bullet (Phase N / WHARD-XX) suffix; stale '### Known Gaps (deferred from v0.6)' subsection removed entirely; footer dated 2026-04-21 Phase 6 completion; CHANGELOG '### Changed — v0.7 Wizard Hardening' added under [Unreleased] with WHARD-07 + WHARD-08 bullets (no version bump)
-- [Phase 06-display-polish-docs]: [Phase 06-01] Style::rounded chosen over Style::blank (D-01) as intentional divergence from status.rs — ceremonial vs repeated inspection
-- [Phase 06-display-polish-docs]: [Phase 06-01] Width::truncate(cols).priority(PriorityMax::right()) with 80-col fallback via terminal_size 0.4 (D-04, D-05) — shrinks widest column first; deterministic under pipes/CI
+Historical decisions are archived in:
+- `.planning/PROJECT.md` — rolling Key Decisions table (v0.6 + v0.7)
+- `.planning/milestones/v0.7-ROADMAP.md` — per-phase decisions for v0.7
+- `.planning/milestones/v0.6-ROADMAP.md` — per-phase decisions for v0.6
 
 ### Pending Todos
 
-- `/gsd:plan-phase 4` to decompose Wizard Correctness into executable plans
+- `make release VERSION=0.7.0` — cut the v0.7.0 release (user-triggered; Cargo.toml bump + changelog cut + git tag + push + Homebrew formula refresh)
+- `/gsd:new-milestone` — scope v0.8 (questioning → research → requirements → roadmap)
 
 ### Blockers/Concerns
 
@@ -67,6 +52,6 @@ None.
 
 ## Session Continuity
 
-Last session: 2026-04-21T13:29:10.561Z
-Stopped at: Completed 06-01-wizard-summary-tabled-PLAN.md
+Last session: 2026-04-22T13:30:00Z
+Stopped at: v0.7 Wizard Hardening milestone shipped
 Resume file: None

--- a/.planning/milestones/v0.7-REQUIREMENTS.md
+++ b/.planning/milestones/v0.7-REQUIREMENTS.md
@@ -1,3 +1,12 @@
+# Requirements Archive: v0.7 Wizard Hardening
+
+**Archived:** 2026-04-22
+**Status:** SHIPPED
+
+For current requirements, see `.planning/REQUIREMENTS.md`.
+
+---
+
 # Requirements: tome v0.7 — Wizard Hardening
 
 **Defined:** 2026-04-18

--- a/.planning/milestones/v0.7-ROADMAP.md
+++ b/.planning/milestones/v0.7-ROADMAP.md
@@ -1,0 +1,80 @@
+# Roadmap: tome
+
+## Milestones
+
+- ✅ **v0.6 Unified Directory Model** — Phases 1-3 (shipped 2026-04-16) — [archive](milestones/v0.6-ROADMAP.md)
+- 🚧 **v0.7 Wizard Hardening** — Phases 4-6 (active since 2026-04-18)
+
+## Phases
+
+<details>
+<summary>✅ v0.6 Unified Directory Model (Phases 1-3) — SHIPPED 2026-04-16</summary>
+
+- [x] Phase 1: Unified Directory Foundation (3/5 plans) — config type system, pipeline rewrite, state schema
+- [x] Phase 2: Git Sources & Selection (4/4 plans) — git clone/update, per-dir filtering, tome remove
+- [x] Phase 3: Import, Reassignment & Browse Polish (2/2 plans) — tome add/reassign/fork, browse TUI polish
+
+**Known gaps:** WIZ-01 through WIZ-05 (wizard rewrite) deferred — old wizard code still functional.
+
+</details>
+
+### v0.7 Wizard Hardening
+
+- [x] **Phase 4: Wizard Correctness** — Wizard rejects invalid configs and circular library paths before save (completed 2026-04-19)
+- [x] **Phase 5: Wizard Test Coverage** — Pure helpers and config assembly have unit + integration test coverage (completed 2026-04-20)
+- [ ] **Phase 6: Display Polish & Docs** — Summary table uses `tabled`; PROJECT.md validates WIZ-01–05 shipped/hardened
+
+## Phase Details
+
+### Phase 4: Wizard Correctness
+**Goal**: Wizard cannot save a config that would fail at sync time
+**Depends on**: Phase 3 (v0.6 unified directory model shipped)
+**Requirements**: WHARD-01, WHARD-02, WHARD-03
+**Success Criteria** (what must be TRUE):
+  1. User running `tome init` with an invalid type/role combo (e.g., Git + Target) sees a clear validation error and the config is not written to disk
+  2. User who picks a `library_dir` that overlaps a Synced/Target directory sees an error suggesting a non-overlapping location and the config is not written
+  3. User who picks a `library_dir` that is a subdirectory of a synced directory sees a circular-symlink validation error before save
+  4. A successful `tome init` still round-trips: the written config passes `Config::validate()` and reloads without changes
+**Plans**: 3 plans
+- [x] 04-01-validate-error-template-PLAN.md — Upgrade existing `Config::validate()` errors to the D-10 Conflict+Why+Suggestion template
+- [x] 04-02-library-overlap-validation-PLAN.md — Add Cases A/B/C overlap detection between `library_dir` and distribution dirs (WHARD-02/03)
+- [x] 04-03-wizard-save-hardening-PLAN.md — Wizard save path calls `Config::save_checked` (expand → validate → round-trip → write); dry-run branch validates too (WHARD-01)
+
+### Phase 5: Wizard Test Coverage
+**Goal**: Wizard logic is testable without a TTY and has enforced coverage of valid/invalid combinations
+**Depends on**: Phase 4
+**Requirements**: WHARD-04, WHARD-05, WHARD-06
+**Success Criteria** (what must be TRUE):
+  1. `cargo test` exercises unit tests for `find_known_directories_in`, `KNOWN_DIRECTORIES` registry lookup, `DirectoryType::default_role`, and pure config-assembly helpers
+  2. An integration test runs `tome init --dry-run --no-input` and asserts the generated config passes validation and round-trips through TOML unchanged
+  3. Every `(DirectoryType, DirectoryRole)` combination the wizard can produce has a test: valid combos save successfully; invalid combos are rejected by the Phase 4 validation path
+  4. CI (ubuntu + macos) passes with the new tests as non-optional gates
+**Plans**: 4 plans
+- [x] 05-01-no-input-plumbing-and-assemble-config-PLAN.md — Plumb `--no-input` through `wizard::run`; extract `pub(crate) fn assemble_config`; remove `lib.rs:164-165` bail (WHARD-04/05 prerequisite)
+- [x] 05-02-pure-helper-unit-tests-PLAN.md — Unit tests for `find_known_directories_in`, `KNOWN_DIRECTORIES` registry invariants, and `assemble_config` (WHARD-04)
+- [x] 05-03-init-integration-test-PLAN.md — Integration tests for `tome init --dry-run --no-input` on empty + seeded HOME (WHARD-05)
+- [x] 05-04-combo-matrix-test-PLAN.md — Table-driven `(DirectoryType, DirectoryRole)` cross-product — 12 combos derived from `valid_roles()` (WHARD-06)
+
+### Phase 6: Display Polish & Docs
+**Goal**: Wizard summary renders cleanly on any terminal width and v0.7 scope is marked complete in project docs
+**Depends on**: Phase 5
+**Requirements**: WHARD-07, WHARD-08
+**Success Criteria** (what must be TRUE):
+  1. User running `tome init` sees the directory summary rendered via `tabled` with `Style::rounded()`, matching the visual language of `tome status`
+  2. Long paths (e.g., git repo clones under `~/.tome/repos/<sha>/`) render without breaking column alignment — either truncated or wrapped, never overflowing
+  3. `PROJECT.md` lists WIZ-01 through WIZ-05 as validated with a note that they shipped in v0.6 and were hardened in v0.7
+**Plans**: 2 plans
+- [x] 06-01-wizard-summary-tabled-PLAN.md — Migrate `wizard::show_directory_summary` to `tabled` with `Style::rounded()` and terminal-width-aware truncation; add `terminal_size` crate dep (WHARD-07)
+- [x] 06-02-project-md-wiz-closure-PLAN.md — Mark WIZ-01–05 as validated/hardened in `.planning/PROJECT.md`, remove stale "Known Gaps" bullet, update footer, add CHANGELOG entry (WHARD-08)
+**UI hint**: yes
+
+## Progress
+
+| Phase | Milestone | Plans Complete | Status | Completed |
+|-------|-----------|----------------|--------|-----------|
+| 1. Unified Directory Foundation | v0.6 | 3/5 | Complete | 2026-04-14 |
+| 2. Git Sources & Selection | v0.6 | 4/4 | Complete | 2026-04-15 |
+| 3. Import, Reassignment & Browse Polish | v0.6 | 2/2 | Complete | 2026-04-16 |
+| 4. Wizard Correctness | v0.7 | 3/3 | Complete   | 2026-04-19 |
+| 5. Wizard Test Coverage | v0.7 | 0/4 | Not started | — |
+| 6. Display Polish & Docs | v0.7 | 0/2 | Not started | — |

--- a/.planning/phases/06-display-polish-docs/06-UAT.md
+++ b/.planning/phases/06-display-polish-docs/06-UAT.md
@@ -1,0 +1,125 @@
+---
+status: complete
+phase: 06-display-polish-docs
+source: [06-01-wizard-summary-tabled-SUMMARY.md, 06-02-project-md-wiz-closure-SUMMARY.md]
+started: 2026-04-21T14:18:38Z
+updated: 2026-04-22T00:45:00Z
+---
+
+## Current Test
+
+[testing complete]
+
+## Session Notes
+
+**Binary-version skew discovered at Test 4** — the `tome` binary on the user's
+`$PATH` (`/opt/homebrew/bin/tome` → Homebrew bottle `0.6.1`, installed
+2026-04-17) pre-dates both Phase 5 (`--no-input` plumbing) and Phase 6 (tabled
+migration). Tests 1-3's initial reports were captured from that stale binary,
+not from the Phase 6 code under verification. Tests 1 and 4 were re-verified by
+running the fresh release build (`target/release/tome` v0.6.2) directly — all
+binary-dependent tests now pass. Homebrew bottle update is a follow-up
+release-engineering task, not a Phase 6 gap.
+
+## Tests
+
+### 1. Wizard summary renders as rounded-border table
+expected: Run `tome init --dry-run --no-input`. Directory summary appears inside a rounded-corner box (╭ ╮ ╰ ╯) with aligned column separators, header clearly demarcated (bold in TTY, plain in pipes).
+result: pass
+note: |
+  Initial user reports ("headers are not lined up correctly" / "still broken") were against the stale `/opt/homebrew/bin/tome` 0.6.1 binary, which predates the Phase 6 tabled migration. Re-verified by building the current branch (`cargo build --release`) and running `target/release/tome` (v0.6.2) directly — output shows:
+
+  ```
+  ╭────────────────┬────────────────┬──────────────────────┬─────────────────────╮
+  │ NAME           │ TYPE           │ ROLE                 │ PATH                │
+  ├────────────────┼────────────────┼──────────────────────┼─────────────────────┤
+  │ antigravity    │ directory      │ Synced (skills disco │ ~/.gemini/antigravi │
+  │ claude-plugins │ claude-plugins │ Managed (read-only,  │ ~/.claude/plugins   │
+  │ claude-skills  │ directory      │ Synced (skills disco │ ~/.claude/skills    │
+  │ codex          │ directory      │ Synced (skills disco │ ~/.codex/skills     │
+  │ codex-agents   │ directory      │ Synced (skills disco │ ~/.agents/skills    │
+  ╰────────────────┴────────────────┴──────────────────────┴─────────────────────╯
+  ```
+
+  Rounded corners ╭ ╮ ╰ ╯ present; header `│` dividers align with body `│` dividers; horizontal-rule `┼` junctions match column boundaries; no spurious trailing column. Header bolding not visible in piped output (expected — `console::style(…).bold()` auto-strips ANSI when stdout is not a TTY); will appear bold in interactive TTY use.
+
+### 2. Columns are NAME / TYPE / ROLE / PATH
+expected: In the same `tome init --dry-run --no-input` output, the table header row shows exactly those four columns left-to-right: NAME, TYPE, ROLE, PATH.
+result: pass
+note: Confirmed via Test 1 screenshot (stale binary) AND fresh Phase 6 build — column order matches NAME / TYPE / ROLE / PATH in both.
+
+### 3. Home paths render with ~/ prefix
+expected: Any PATH cell pointing under your home dir (e.g. `~/.claude`, `~/.tome`, `~/.config/…`) appears with a literal `~/` prefix — no `/Users/martin/…` absolute paths in the table.
+result: pass
+note: Confirmed via both user screenshots AND fresh Phase 6 build — all five rows show `~/.gemini/...`, `~/.claude/plugins`, `~/.claude/skills`, `~/.codex/skills`, `~/.agents/skills`. No absolute paths visible.
+
+### 4. Narrow-terminal truncation keeps table aligned
+expected: When terminal width is constrained, table stays inside the rounded box — rightmost/widest column (PATH or ROLE) is truncated rather than overflowing or wrapping, and column borders stay vertically aligned.
+result: pass
+note: |
+  Verified against fresh `target/release/tome` 0.6.2 with output piped (hits the 80-column fallback branch per Plan 06-01 D-05). Truncation visible in output — ROLE cells show `Synced (skills disco` (truncated), PATH cells show `~/.gemini/antigravi` (truncated). Borders remain aligned inside the rounded box. `PriorityMax::right()` correctly shrinks the widest column first.
+
+  Side note on test command: the `COLUMNS=60` env var does NOT affect rendering because the `terminal_size` crate queries TTY dimensions via ioctl (not env). The 80-column fallback is the deterministic CI/piped path. For true-narrow-TTY verification, user would need to physically resize an interactive terminal and re-run.
+
+### 5. PROJECT.md has "Hardened in v0.7" subsection for WIZ-01..05
+expected: Open `.planning/PROJECT.md`. Under `## Requirements` there is a `### Hardened in v0.7` subsection (placed after `### Previously Validated`) with five bullets for WIZ-01 through WIZ-05, each carrying "Shipped v0.6, hardened v0.7 (Phases 4+5)" provenance. The old `### Known Gaps (deferred from v0.6)` subsection is gone.
+result: pass
+note: |
+  Self-verified via `rg -n '^### (Hardened in v0.7|Previously Validated|Known Gaps)|WIZ-0[1-5]' .planning/PROJECT.md`. Found:
+  - L49: `### Previously Validated (re-verified in v0.7 research)`
+  - L57: `### Hardened in v0.7` (correctly positioned AFTER Previously Validated)
+  - L61-65: five bullets WIZ-01 through WIZ-05, each carrying `Shipped v0.6, hardened v0.7 (Phase N / WHARD-XX)` provenance
+  - No `### Known Gaps (deferred from v0.6)` heading (only a retrospective decision-log table row at L116 — different context, not the removed subsection)
+
+### 6. PROJECT.md footer dated 2026-04-21 / Phase 6 complete
+expected: Last line of `.planning/PROJECT.md` reads something like `*Last updated: 2026-04-21 — Phase 6 (Display Polish & Docs) complete …*` — mentions WHARD-07 and WHARD-08.
+result: pass
+note: |
+  Self-verified via `tail -3 .planning/PROJECT.md`. Footer reads: `*Last updated: 2026-04-21 — Phase 6 (Display Polish & Docs) complete — wizard summary migrated to `tabled` (WHARD-07); WIZ-01–05 marked validated as hardened in v0.7 (WHARD-08)*`. Both WHARD-07 and WHARD-08 cited by name.
+
+### 7. CHANGELOG.md has v0.7 Wizard Hardening block under [Unreleased]
+expected: Open `CHANGELOG.md`. Under `## [Unreleased]` there is a `### Changed — v0.7 Wizard Hardening` subsection citing both WHARD-07 (wizard summary → tabled) and WHARD-08 (PROJECT.md WIZ closure). `Cargo.toml` version is unchanged (still on the v0.6.x line — no release cut).
+result: pass
+note: |
+  Self-verified via `rg -n '^## \[Unreleased\]|^### Changed — v0.7 Wizard Hardening|WHARD-07|WHARD-08' CHANGELOG.md` + Cargo.toml grep:
+  - CHANGELOG.md L8 `## [Unreleased]`, L10 `### Changed — v0.7 Wizard Hardening`, L12 WHARD-07 (tabled migration), L13 WHARD-08 (PROJECT.md closure)
+  - `Cargo.toml:version = "0.6.2"` — no v0.7.0 release-cut bump (matches the "don't bump Cargo.toml; make release handles it" workflow)
+
+## Summary
+
+total: 7
+passed: 7
+issues: 0
+pending: 0
+skipped: 0
+blocked: 0
+observations: 1
+
+## Gaps
+
+[Test 1 gap invalidated 2026-04-22 — see Session Notes above. The "headers not lined up" evidence was from the stale Homebrew tome 0.6.1 binary, not from Phase 6 code. Fresh `target/release/tome` 0.6.2 renders correctly-aligned tabled output.]
+
+# Secondary observations (not tied to a test — logged for triage)
+
+- truth: "Homebrew bottle `tome 0.6.1` is stale on the user's machine"
+  status: observation
+  reason: "User's `$PATH` resolves to /opt/homebrew/bin/tome which symlinks to Cellar/tome/0.6.1/bin/tome (installed 2026-04-17), pre-dating Phases 5 and 6"
+  severity: minor
+  test: general
+  artifacts: []
+  missing:
+    - "Next release (v0.7.0) needs a Homebrew formula bump so `brew upgrade` picks up the wizard hardening work"
+    - "For local development verification, prefer `./target/release/tome ...` over bare `tome` to avoid this class of skew"
+  debug_session: ""
+  hypothesis: "Release workflow is expected (`make release` bumps version and triggers cargo-dist → Homebrew). This observation is informational for the v0.7.0 cut, not a Phase 6 regression."
+
+- truth: "`tome init --dry-run --no-input` exercises the rendering path but does not exercise the interactive-decision surface"
+  status: observation
+  reason: "User observed: 'dry-run seems to skip over all decisions' (from stale 0.6.1 run — may not reproduce the same way against 0.7.x)"
+  severity: minor
+  test: general
+  artifacts: []
+  missing:
+    - "If UAT needs to verify interactive flow, use `tome init --dry-run` (no `--no-input`) inside a real TTY"
+  debug_session: ""
+  hypothesis: "`--no-input` is designed to be non-interactive (Plan 05-01). The combined `--dry-run --no-input` command exists for CI/test use. The comment may have reflected 0.6.1 behavior; observation remains for future UX polish decisions but not a Phase 6 gap."


### PR DESCRIPTION
Closes #

## Summary

Closes the docs-side bookkeeping for the v0.7 Wizard Hardening milestone.

**Important:** The v0.7 Phase 6 code (`wizard.rs` → `tabled`, WHARD-07) and documentation (`PROJECT.md` hardening subsection, `CHANGELOG.md` WHARD-07/08 entries, WHARD-08) **already shipped on main via the v0.6.2 release train (PR #411)**. The original Phase 6 branch was not rebased after that merge, which carried the code into this PR by accident plus a version regression. This PR is now rebased cleanly — only planning/docs delta remains.

## Changes

- Archive `.planning/ROADMAP.md` + `REQUIREMENTS.md` to `.planning/milestones/v0.7-{ROADMAP,REQUIREMENTS}.md`
- Append v0.7 entry to `.planning/MILESTONES.md`
- Collapse v0.7 in live `ROADMAP.md` under `<details>` (matches v0.6 archive pattern); add v0.8 placeholder
- Evolve `PROJECT.md`:
  - Drop stale `Migrate show_directory_summary to tabled` Active bullet (already shipped)
  - Flip `Defer wizard rewrite (WIZ-01–05)` Key Decisions row from `⚠️ Revisit` → `✓ Resolved v0.7`
  - Add 4 new v0.7 architectural decisions (D-10 error template, TOML round-trip byte-equality, `--no-input` flag, `Style::rounded()` divergence)
  - Rewrite `Current Milestone` section → `Current State` reflecting shipped status
- Reset `STATE.md` to `status: between_milestones`
- Record Phase 6 UAT (7/7 passing) at `.planning/phases/06-display-polish-docs/06-UAT.md`

## Not in this PR

- **No code changes** — all v0.7 code shipped on main via PR #411.
- **No `Cargo.toml` version change** — `make release VERSION=0.7.0` owns the bump + tag + Homebrew bottle.

## Test plan

- [x] `make ci` (no code changed; docs-only PR, but sanity-verified main still green)
- [x] Phase 6 UAT completed 7/7 passing — see `.planning/phases/06-display-polish-docs/06-UAT.md`
- [x] `rg -n '### Hardened in v0.7|WIZ-0[1-5]' .planning/PROJECT.md` → WIZ-01..05 subsection present with Phase 4+5 provenance
- [x] `rg -n '^### Changed — v0.7 Wizard Hardening|WHARD-0[78]' CHANGELOG.md` (on main) → CHANGELOG block already in place from v0.6.2 release
- [x] PR diff contains only `.planning/` files (no code, no `Cargo.toml` drift)

## Traceability

- Requirements: WHARD-01..08 (all validated; 4/5/6 hardened Phases 4+5, 7/8 Phase 6)
- Phase artifacts: `.planning/phases/04-wizard-correctness/`, `.planning/phases/05-wizard-test-coverage/`, `.planning/phases/06-display-polish-docs/`
- Milestone archive: `.planning/milestones/v0.7-ROADMAP.md`, `.planning/milestones/v0.7-REQUIREMENTS.md`

Closes the v0.7 milestone docs loop. Next: \`make release VERSION=0.7.0\`.