### PR TITLE
v0.7.1 safety patches: silent-failure fixes + dead-code cleanup

### DIFF
--- a/crates/tome/src/backup.rs
+++ b/crates/tome/src/backup.rs
@@ -147,7 +147,10 @@ pub(crate) fn list(repo_dir: &Path, count: usize) -> Result<Vec<BackupEntry>> {
 /// Restore the tome home to a previous snapshot.
 ///
 /// Automatically creates a pre-restore snapshot of the current state before
-/// checking out files from the target ref.
+/// checking out files from the target ref. Returns an error — and aborts
+/// before the destructive checkout — if the pre-restore snapshot cannot be
+/// created (the snapshot is the user's only recovery path if the restore
+/// was accidental).
 pub(crate) fn restore(repo_dir: &Path, target: &str, dry_run: bool) -> Result<()> {
     if !has_repo(repo_dir) {
         anyhow::bail!("no backup repo found — run `tome backup init` first");
@@ -411,6 +414,54 @@ mod tests {
         // File should be back to original content
         let content = std::fs::read_to_string(lib_dir.join("skill.md")).unwrap();
         assert_eq!(content, "original");
+    }
+
+    #[test]
+    fn restore_bails_when_pre_snapshot_fails() {
+        // Regression guard: pre-restore safety snapshot failure MUST abort the
+        // destructive checkout. If someone ever replaces the `?` with
+        // `let _ = snapshot(...)` again, this test fails.
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let lib_dir = tmp.path().join("library");
+        std::fs::create_dir_all(&lib_dir).unwrap();
+        init_test_repo(&lib_dir);
+
+        // Commit a file (this becomes the restore target)
+        std::fs::write(lib_dir.join("skill.md"), "v1-committed").unwrap();
+        snapshot(&lib_dir, Some("v1"), false).unwrap();
+
+        // Modify the file in the working tree (so restore has something to revert)
+        std::fs::write(lib_dir.join("skill.md"), "v2-modified-uncommitted").unwrap();
+
+        // Install a pre-commit hook that always fails — this forces the
+        // pre-restore safety snapshot to fail.
+        let hooks_dir = lib_dir.join(".git/hooks");
+        std::fs::create_dir_all(&hooks_dir).unwrap();
+        let hook = hooks_dir.join("pre-commit");
+        std::fs::write(&hook, "#!/bin/sh\nexit 1\n").unwrap();
+        std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // Attempt restore — should bail BEFORE checkout.
+        let result = restore(&lib_dir, "HEAD", false);
+        assert!(
+            result.is_err(),
+            "restore should have failed when pre-snapshot failed"
+        );
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            err_msg.contains("pre-restore safety snapshot"),
+            "error should mention safety snapshot context, got: {err_msg}"
+        );
+
+        // Working tree must still hold the uncommitted modification —
+        // the destructive checkout did NOT run.
+        let content = std::fs::read_to_string(lib_dir.join("skill.md")).unwrap();
+        assert_eq!(
+            content, "v2-modified-uncommitted",
+            "restore must not have checked out over the working tree when the safety snapshot failed"
+        );
     }
 
     #[test]

--- a/crates/tome/src/backup.rs
+++ b/crates/tome/src/backup.rs
@@ -160,8 +160,9 @@ pub(crate) fn restore(repo_dir: &Path, target: &str, dry_run: bool) -> Result<()
     // here is intentional: the safety snapshot is the user's only recovery
     // path if the restore was accidental. Without it we must not proceed
     // with the destructive `git checkout`.
-    snapshot(repo_dir, Some("pre-restore auto-snapshot"), false)
-        .context("failed to create pre-restore safety snapshot — aborting restore to protect current state")?;
+    snapshot(repo_dir, Some("pre-restore auto-snapshot"), false).context(
+        "failed to create pre-restore safety snapshot — aborting restore to protect current state",
+    )?;
     // Restore files from target ref
     git_success(repo_dir, &["checkout", target, "--", "."])?;
     println!(

--- a/crates/tome/src/backup.rs
+++ b/crates/tome/src/backup.rs
@@ -156,8 +156,12 @@ pub(crate) fn restore(repo_dir: &Path, target: &str, dry_run: bool) -> Result<()
         println!("Would restore library to {}", target);
         return Ok(());
     }
-    // Auto-snapshot current state before restoring
-    let _ = snapshot(repo_dir, Some("pre-restore auto-snapshot"), false);
+    // Auto-snapshot current state before restoring — propagating failure
+    // here is intentional: the safety snapshot is the user's only recovery
+    // path if the restore was accidental. Without it we must not proceed
+    // with the destructive `git checkout`.
+    snapshot(repo_dir, Some("pre-restore auto-snapshot"), false)
+        .context("failed to create pre-restore safety snapshot — aborting restore to protect current state")?;
     // Restore files from target ref
     git_success(repo_dir, &["checkout", target, "--", "."])?;
     println!(

--- a/crates/tome/src/discover.rs
+++ b/crates/tome/src/discover.rs
@@ -506,7 +506,15 @@ fn scan_for_skills(
                                 None
                             }
                         },
-                        Err(_) => None, // File not readable — already validated by scan
+                        Err(e) => {
+                            warnings.push(format!(
+                                "could not read SKILL.md for {}/{}: {}",
+                                source_name,
+                                skill_dir.display(),
+                                e
+                            ));
+                            None
+                        }
                     };
 
                     skills.push(DiscoveredSkill {

--- a/crates/tome/src/discover.rs
+++ b/crates/tome/src/discover.rs
@@ -508,7 +508,7 @@ fn scan_for_skills(
                         },
                         Err(e) => {
                             warnings.push(format!(
-                                "could not read SKILL.md for {}/{}: {}",
+                                "could not read SKILL.md in source '{}' at {}: {}",
                                 source_name,
                                 skill_dir.display(),
                                 e

--- a/crates/tome/src/distribute.rs
+++ b/crates/tome/src/distribute.rs
@@ -21,8 +21,6 @@ pub struct DistributeResult {
     /// Skills skipped because they originate from the same directory (prevents circular symlinks).
     pub skipped_managed: usize,
     pub directory_name: DirectoryName,
-    /// Deprecated: alias for `directory_name`. Kept for lib.rs until plan 01-05.
-    pub target_name: DirectoryName,
 }
 
 /// Distribute skills from the library to a configured directory.
@@ -48,7 +46,6 @@ pub fn distribute_to_directory(
     }
 
     let mut result = DistributeResult {
-        target_name: dir_name.clone(),
         directory_name: dir_name.clone(),
         changed: 0,
         unchanged: 0,

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -1055,7 +1055,7 @@ fn render_sync_report(report: &SyncReport) {
     for dr in &report.distributions {
         println!(
             "  {}: {} linked, {} unchanged{}{}{}",
-            style(&dr.target_name).bold(),
+            style(&dr.directory_name).bold(),
             style(dr.changed).cyan(),
             dr.unchanged,
             skipped_note(dr.skipped),

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -71,7 +71,6 @@ pub struct SyncReport {
     pub distributions: Vec<DistributeResult>,
     pub cleanup: CleanupResult,
     pub removed_from_targets: usize,
-    pub warnings: Vec<String>,
 }
 
 /// Create a spinner with a consistent style.
@@ -938,7 +937,6 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
         distributions: distribute_results,
         cleanup: cleanup_result,
         removed_from_targets,
-        warnings,
     };
 
     if !quiet {

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -596,6 +596,25 @@ fn resolve_git_directories(
         return resolved;
     }
 
+    // Read HEAD sha and warn (not silently swallow) when the cache is
+    // unreadable — without the warning the lockfile would record
+    // git_commit_sha: null, falsely claiming "no provenance".
+    let read_sha_or_warn = |cache_dir: &Path, name: &DirectoryName| -> Option<String> {
+        match git::read_head_sha(cache_dir) {
+            Ok(sha) => Some(sha),
+            Err(e) => {
+                if !quiet {
+                    eprintln!(
+                        "warning: could not read HEAD sha for '{}' cache at {}: {e}",
+                        name,
+                        cache_dir.display()
+                    );
+                }
+                None
+            }
+        }
+    };
+
     for (name, dir_config) in &config.directories {
         if dir_config.directory_type != DirectoryType::Git {
             continue;
@@ -609,7 +628,7 @@ fn resolve_git_directories(
             // In dry-run, use cached path if it exists, skip otherwise
             if already_cloned {
                 let effective = git::effective_path(&cache_dir, dir_config.subdir.as_deref());
-                let sha = git::read_head_sha(&cache_dir).ok();
+                let sha = read_sha_or_warn(&cache_dir, name);
                 resolved.insert(name.clone(), (effective, sha));
             }
             continue;
@@ -654,7 +673,7 @@ fn resolve_git_directories(
         match result {
             Ok(()) => {
                 let effective = git::effective_path(&cache_dir, dir_config.subdir.as_deref());
-                let sha = git::read_head_sha(&cache_dir).ok();
+                let sha = read_sha_or_warn(&cache_dir, name);
                 resolved.insert(name.clone(), (effective, sha));
             }
             Err(e) => {
@@ -667,7 +686,7 @@ fn resolve_git_directories(
                         );
                     }
                     let effective = git::effective_path(&cache_dir, dir_config.subdir.as_deref());
-                    let sha = git::read_head_sha(&cache_dir).ok();
+                    let sha = read_sha_or_warn(&cache_dir, name);
                     resolved.insert(name.clone(), (effective, sha));
                 } else if !quiet {
                     eprintln!(


### PR DESCRIPTION
## Summary

Quick-win batch for v0.7.1 — five targeted fixes identified by `/pr-review-toolkit` comprehensive review (2026-04-22). Three silent-failure bugs and two dead-code cleanups. Total: **+42 / -12 LOC** across 4 source files.

### Bug fixes (silent failures)

- **Closes #418** `fix(discover): warn on SKILL.md read failure instead of silently dropping frontmatter` — the scan→read gap was silently degrading `tome browse` metadata. Now emits a warning to the scan warnings vec.
- **Closes #417** `fix(git): warn on HEAD sha read failure instead of silently dropping provenance` — three sites doing `read_head_sha(...).ok()` were recording `git_commit_sha: null` in lockfiles when cache was unreadable. Extracted a `read_sha_or_warn` closure; respects `--quiet`.
- **Closes #415** `fix(backup): propagate pre-restore snapshot failure instead of silently proceeding` — `backup::restore` did `let _ = snapshot(...)` before destructive checkout. Now bails with clear message if the safety snapshot fails, protecting the user's recovery path.

### Dead-code cleanup

- **Closes #437** `refactor: remove deprecated DistributeResult.target_name alias` — field comment said "Kept until plan 01-05"; plan 01-05 shipped in v0.6. One reader in lib.rs updated to `directory_name`.
- **Closes #438** `refactor: drop vestigial SyncReport.warnings field` — `discover_all` populates a local `warnings` vec that is printed to stderr inline (`lib.rs:798-800`). The same vec was also stuffed into `SyncReport.warnings`, but `render_sync_report` never read the field.

### Not in this PR (deferred to v0.7.2 / v0.8)

Two P0 safety issues were flagged in the review but need larger refactors — filed separately and **not** included here:

- **#413** `remove::execute` partial-failure reporting (needs `RemoveResult` error aggregation — moderate scope)
- **#414** browse UI cross-platform clipboard (needs platform detection + stdin piping — moderate scope)

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — 525/525 passing (417 unit + 108 integration)
- [x] `typos` runs in CI (not installed locally, will run on GitHub Actions)
- [ ] `make ci` green on ubuntu-latest and macos-latest (awaiting CI)

### Manual verification of behavioral changes

- [x] `backup::restore` path inspection: previously swallowed snapshot error, now bails with `.context(...)` — behavioral regression ruled out because production path just gains an early exit on the error branch (no previously-passing test exercised the error branch)
- [x] `git::read_head_sha` error branch now produces `warning: could not read HEAD sha for '<name>' cache at <path>: <err>` on stderr
- [x] `discover.rs` SKILL.md error now adds entry to `warnings` vec (printed to stderr by `sync()` already)
- [x] `DistributeResult` construction + render code audited — no other readers of `target_name` in repo
- [x] `SyncReport` struct size reduced by one `Vec<String>` field — no external consumers expected (private to crate except via `pub fn sync`)

## Traceability

- Review report: internal `/pr-review-toolkit:review-pr` run 2026-04-22 (whole-codebase architecture + rust-cli + rust-lang pass)
- Issues closed: #415, #417, #418, #437, #438 (5 total)
- Milestone: v0.7.1
- Sibling patches (not in this PR): #413, #414, and 28 others filed as #413-#447

## Notes

- **No `Cargo.toml` version bump** — per project convention, `make release` owns version changes. This branch is ready to be merged to main; the user cuts v0.7.1 via `make release VERSION=0.7.1` when ready.
- First commit is an empty marker per project PR convention.
- Each bug/refactor is its own commit with a `Closes #NNN` footer for squash-merge traceability.