### PR TITLE
docs(changelog): prepare v0.7.0 release notes + backfill v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed — v0.7 Wizard Hardening
+## [0.7.0] - 2026-04-23
+
+The **v0.7 Wizard Hardening** milestone. The Phase 4–6 code shipped to users interim as v0.6.2 (on 2026-04-17); this release is the formal milestone cut and bundles the post-milestone safety patches on top. Users upgrading from v0.6.2 get the safety patches; users on v0.6.1 or earlier get the full wizard hardening surface.
+
+### Changed
 
 - Migrated `tome init` directory summary table to `tabled` with `Style::rounded()` borders and terminal-width-aware truncation via `Width::truncate(..).priority(PriorityMax::right())`. Long paths (including git-repo clones under `~/.tome/repos/<sha>/`) now render cleanly on narrow terminals without breaking column alignment. (WHARD-07)
-- Marked WIZ-01 through WIZ-05 as validated / hardened in `PROJECT.md`; removed the stale "Known Gaps (deferred from v0.6)" entry. Phases 4 + 5 of v0.7 already closed the correctness gaps (validation, overlap detection, test coverage); this update reflects that in the project docs. (WHARD-08)
+- Marked WIZ-01 through WIZ-05 as validated / hardened in `PROJECT.md`; removed the stale "Known Gaps (deferred from v0.6)" entry. Phases 4 + 5 closed the correctness gaps (validation, overlap detection, test coverage) and this release reflects that in the project docs. (WHARD-08)
+- `Config::validate()` now rejects invalid type/role combinations, library-vs-distribution path overlaps (Cases A/B/C), and circular library paths before save. All four validation bail sites use the Conflict/Why/Suggestion error template. (WHARD-01/02/03)
+- `Config::save_checked` enforces expand → validate → TOML round-trip → atomic write. The wizard save path and `--dry-run` branch share this pipeline, so invalid configs can no longer reach disk.
+- Removed deprecated internal APIs: `DistributeResult.target_name` alias and `SyncReport.warnings` field (no external impact — `DistributeResult` is not serialized to JSON).
 
-### Breaking Changes — v0.6 Unified Directory Model
+### Added
 
-The `[[sources]]` and `[targets.*]` config sections have been replaced by a single
-`[directories.*]` section. tome will refuse to parse old-format config files and
-show a migration hint.
+- `--no-input` flag now supported on `tome init` (previously bailed). Runs the wizard non-interactively using sensible defaults — required for CI smoke tests and headless provisioning.
+- Integration tests for `tome init --dry-run --no-input` on empty and seeded `HOME` directories, asserting the generated config validates and round-trips through TOML byte-equal.
+- Table-driven `(DirectoryType × DirectoryRole)` matrix test — exhaustive 12-combo coverage verifying `valid_roles()` ↔ `Config::validate()` agreement. (WHARD-04/05/06)
+- Regression test for `tome backup restore` bail-on-failure: `restore_bails_when_pre_snapshot_fails` guards against future simplification of the safety-snapshot propagation.
+
+### Fixed
+
+- `tome backup restore` now aborts if the pre-restore safety snapshot fails, instead of silently proceeding with the destructive `git checkout`. The safety snapshot is the user's only recovery path if a restore was accidental. (#415)
+- Warn on git cache HEAD-sha read failure instead of silently recording `git_commit_sha: null` in the lockfile (false "no provenance" claim). (#417)
+- Warn on SKILL.md read failure post-scan instead of silently dropping frontmatter metadata. `tome browse` no longer hides affected skills' descriptions. (#418)
+
+### Docs
+
+- Enable `mdbook-mermaid` preprocessor on GitHub Pages — all 10 existing mermaid diagrams across `introduction.md`, `test-setup.md`, and `tool-landscape.md` now render correctly (previously shown as raw code blocks). (#450)
+- Refresh introduction diagram to reflect the v0.6+ unified directory model with current tool names (Codex, Antigravity, Cursor) and type + role annotations.
+- Archive v0.7 milestone planning artifacts to `.planning/milestones/v0.7-ROADMAP.md` and `.planning/milestones/v0.7-REQUIREMENTS.md`.
+
+### Internal
+
+- `/pr-review-toolkit` whole-codebase review produced 36 prioritized findings; 5 shipped in this release (P0 safety fixes + 2 dead-code cleanups). 30 remaining findings filed as issues for v0.8 scoping.
+
+## [0.6.0] - 2026-04-16
+
+The **v0.6 Unified Directory Model** milestone. Phases 1–3 shipped (config type system + git sources + browse TUI polish). Interim patch releases v0.6.1 and v0.6.2 followed without formal CHANGELOG entries; v0.6.2 also carried the v0.7 Wizard Hardening code surface ahead of its formal v0.7.0 release.
+
+### Breaking Changes
+
+The `[[sources]]` and `[targets.*]` config sections have been replaced by a single `[directories.*]` section. tome will refuse to parse old-format config files and show a migration hint.
 
 **Before (v0.5):**
 ```toml
@@ -63,6 +95,15 @@ role = "target"
 - `synced` role = both source and target (discovered here AND distributed here)
 - `enabled`/`method`/`skills_dir` fields removed — `path` is the only location field
 - `disabled_targets` in `machine.toml` renamed to `disabled_directories`
+
+### Added
+
+- Git source type: `type = "git"` directories clone a remote repo into `~/.tome/repos/<sha256>/` with shallow clone, ref pinning (branch / tag / rev), and offline fallback to cached state.
+- Per-directory skill selection via `machine.toml`: `[directories.<name>]` blocks accept `enabled = [...]` allowlist OR `disabled = [...]` blocklist (mutually exclusive).
+- `tome add <url>` — register a git skill repo from URL.
+- `tome remove <name>` — remove a directory from config with full cleanup (symlinks, library entries, manifest, lockfile).
+- `tome reassign` / `tome fork` — change a skill's provenance between directories.
+- Browse TUI polish: adaptive dark/light theming, fuzzy-match highlighting, scrollbar, markdown preview rendering, and help overlay.
 
 ## [0.5.4] - 2026-04-10
 
@@ -270,7 +311,9 @@ role = "target"
 - CI on Ubuntu and macOS (fmt, clippy, test, release build)
 - cargo-dist release workflow for cross-platform binaries
 
-[Unreleased]: https://github.com/MartinP7r/tome/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/MartinP7r/tome/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/MartinP7r/tome/compare/v0.6.2...v0.7.0
+[0.6.0]: https://github.com/MartinP7r/tome/compare/v0.5.4...v0.6.0
 [0.3.3]: https://github.com/MartinP7r/tome/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/MartinP7r/tome/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/MartinP7r/tome/compare/v0.3.0...v0.3.1


### PR DESCRIPTION
Closes #

## Summary

Pre-flight for \`make release VERSION=0.7.0\`: restructure CHANGELOG so the upcoming release has proper release notes, backfill a \`[0.6.0]\` section so the long-standing v0.6 breaking-changes block stops lingering under \`[Unreleased]\`, and update the compare-link refs.

Paired with GitHub milestone cleanup (already applied):

- Re-milestoned 5 closed issues from `v0.7.1` → `v0.7` (#415, #417, #418, #437, #438)
- Removed #267 (Wolpertinger) and #268 (skill lint) from `v0.7` milestone — neither shipped in v0.7; they'll find their home in v0.8 scoping
- Deleted the premature `v0.7.1` milestone
- Closed `v0.7` milestone (all 6 issues closed)

## CHANGELOG changes

### `## [0.7.0] — 2026-04-23` (new section)

Contains:
- **Wizard Hardening** (WHARD-01..08): tabled migration, `Config::validate()` overlap detection, `Config::save_checked` pipeline, WIZ-01..05 closure, combo-matrix tests, `--no-input` plumbing
- **Safety patches** (PR #448): backup-restore safety-snapshot propagation, git cache SHA warning, SKILL.md read warning, target_name alias removal, SyncReport.warnings drop
- **Docs** (PR #450): mdbook-mermaid preprocessor enablement + introduction diagram refresh

Leading paragraph acknowledges that the Wizard Hardening code surface shipped to users interim as v0.6.2 on 2026-04-17 but v0.7.0 is the formal milestone cut.

### `## [0.6.0] — 2026-04-16` (new section, backfilled)

Moves the v0.6 Unified Directory Model breaking-changes block out of `[Unreleased]` into a properly-dated release section. Adds a brief `### Added` recap of milestone features (git sources, per-directory selection, `tome add`/`remove`/`reassign`/`fork`, browse TUI polish).

### Compare-link refs

- `[Unreleased]`: `v0.3.3...HEAD` → `v0.7.0...HEAD` (was months-stale)
- New: `[0.7.0]`: `v0.6.2...v0.7.0`
- New: `[0.6.0]`: `v0.5.4...v0.6.0`

## Not in scope

- Backfilling `[0.6.1]` and `[0.6.2]` formal sections — they were patch releases without formal notes; the `[0.6.0]` intro paragraph documents their purpose
- Cleaning up `v0.6` GitHub milestone's 7 stale "open" issues — unrelated to v0.7.0 cut
- Backfilling pre-v0.6 compare-link refs (v0.4.x, v0.5.x) — out of scope

## Test plan

- [x] `grep -c '^## \[' CHANGELOG.md` → 16 sections (was 14; +2 new)
- [x] Visual inspection of rendered markdown (section ordering, bullet nesting, code-block fences)
- [x] Milestone cleanup verified via \`gh api\`: v0.7 closed, v0.7.1 deleted, #267/#268 removed from v0.7
- [ ] Merge this PR, then user runs \`make release VERSION=0.7.0\` to cut the actual release