### PR TITLE
fix(wizard): align tabled summary header with body in interactive TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Wizard summary table now aligns correctly in interactive terminals. Previously, the bold ANSI escape codes wrapping header cells (e.g. `\x1b[1mNAME\x1b[0m`) were counted as visible characters by `tabled 0.20`'s default width calculation, inflating header cell widths by 8 columns and misaligning the column dividers with the body rows. Enabled tabled's `ansi` feature so escape sequences are correctly excluded from width measurement.
+
 ## [0.7.0] - 2026-04-23
 
 The **v0.7 Wizard Hardening** milestone. The Phase 4–6 code shipped to users interim as v0.6.2 (on 2026-04-17); this release is the formal milestone cut and bundles the post-milestone safety patches on top. Users upgrading from v0.6.2 get the safety patches; users on v0.6.1 or earlier get the full wizard hardening surface.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ansi-str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d"
+dependencies = [
+ "ansitok",
+]
+
+[[package]]
+name = "ansitok"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
+dependencies = [
+ "nom",
+ "vte",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +91,12 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert_cmd"
@@ -1198,6 +1223,8 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
 dependencies = [
+ "ansi-str",
+ "ansitok",
  "bytecount",
  "fnv",
  "unicode-width",
@@ -1832,6 +1859,8 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
 dependencies = [
+ "ansi-str",
+ "ansitok",
  "papergrid",
  "tabled_derive",
  "testing_table",
@@ -1948,6 +1977,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
 dependencies = [
+ "ansitok",
  "unicode-width",
 ]
 
@@ -2163,6 +2193,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "vtparse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ indicatif = "0.18"
 dirs = "6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tabled = "0.20"
+tabled = { version = "0.20", features = ["ansi"] }
 terminal_size = "0.4"
 toml = "1"
 sha2 = "0.11"


### PR DESCRIPTION
Closes #454

## Summary

v0.7.0 ships with a visible wizard summary table alignment bug in interactive terminals — reported post-release, filed as #454. This PR is the v0.7.1 hotfix.

## The bug (in brief)

`tabled 0.20`'s default width calculation counts ANSI escape bytes as visible characters. Our header cells are wrapped in `console::style(s).bold()`, which emits `\x1b[1m...\x1b[0m` (8 non-printing bytes) in a TTY. tabled inflated header cell widths by 8 columns, misaligning the `│` dividers against body rows.

Did not reproduce in piped output because `console::style` suppresses ANSI when stdout isn't a TTY. That's why my earlier verification missed this.

## The fix

One-line change: enable `tabled`'s `ansi` feature.

```diff
 # Cargo.toml
-tabled = "0.20"
+tabled = { version = "0.20", features = ["ansi"] }
```

With the feature on, tabled strips ANSI escapes when measuring column width. No code changes needed anywhere.

## Verification

### Before (v0.7.0 on a pty)

```
│ NAME   │ TYPE   │ ROLE         │ PATH        │
                       ^^^^ header dividers here ^^^^
│ antigravity    │ directory      │ Synced (skills...)    │ ~/.gemini/antigravity/skills │
                                  ^^^^ body dividers 8 cols rightward
```

### After (this PR, same pty)

```
╭────────────────┬────────────────┬──────────────────────┬─────────────────────╮
│ NAME           │ TYPE           │ ROLE                 │ PATH                │  ← bold in TTY
├────────────────┼────────────────┼──────────────────────┼─────────────────────┤
│ antigravity    │ directory      │ Synced (skills disco │ ~/.gemini/antigravi │
│ claude-plugins │ claude-plugins │ Managed (read-only,  │ ~/.claude/plugins   │
│ claude-skills  │ directory      │ Synced (skills disco │ ~/.claude/skills    │
│ codex          │ directory      │ Synced (skills disco │ ~/.codex/skills     │
│ codex-agents   │ directory      │ Synced (skills disco │ ~/.agents/skills    │
╰────────────────┴────────────────┴──────────────────────┴─────────────────────╯
```

Column dividers at identical positions across header and body.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — 526/526 passing (transient flake on `backup::tests::diff_shows_changes` in full-suite run recovered on retry — unrelated to this change)
- [x] Reproduced the bug against stock v0.7.0 via `script -q /dev/null ./target/release/tome init --dry-run --no-input`
- [x] Verified fix against rebuilt binary on same forced-pty capture — column dividers align

## Ship as

**v0.7.1** — visible UX regression from v0.7.0 that affects every interactive `tome init` run. User already filed as blocker-ish ("the table seems still broken").

`make release VERSION=0.7.1` after merge.

## Note

I verified v0.7.0's binary rendering earlier this session but used `| sed` (piped output), which suppressed `console::style`'s ANSI emission — masking the bug. The reproduction only triggers with actual TTY output. Lesson: for TUI/terminal-rendering bug verification, forced-pty via `script(1)` / `unbuffer` is the correct test harness.