### PR TITLE
v0.8.1 hotfix: lockfile regen + save chain reorder + wording fix

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -151,4 +151,6 @@ Config is `directories: BTreeMap<DirectoryName, DirectoryConfig>` where each ent
 This document evolves at phase transitions and milestone boundaries.
 
 ---
+*Last updated: 2026-04-26 — Phase 8.1 (v0.8.1 hotfix) complete. Closes #461 H1 (silent-drop regression in lockfile regen — `resolved_paths_from_lockfile_cache` helper restores git-skill provenance to Remove/Reassign/Fork), H2 (save-chain reorder so partial-failure ⚠ block surfaces before save errors), H3 (failure-summary wording). 590 tests passing (464 unit + 126 integration; +9 since v0.8). 2 Linux-runtime verification items still pending in `08-HUMAN-UAT.md`. v0.8.1 ready for `make release VERSION=0.8.1`.*
+
 *Last updated: 2026-04-24 — Phase 8 shipped via PR #460 (squash commit `b884c31` on main). v0.8 milestone complete — 8 requirements shipped (WUX-01..05 + SAFE-01..03) across Phases 7+8. 581 tests passing (458 unit + 123 integration after post-merge PR review added 5 tests). 2 Linux-runtime verification items tracked in `08-HUMAN-UAT.md`. Post-merge review filed follow-up issues #461 (v0.8.1 hotfix candidates), #462 (v0.8.x polish), #463 (v0.9 polish) — see backlog section above.*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -89,5 +89,5 @@
 **Source:** [#461](https://github.com/MartinP7r/tome/issues/461)
 **Plans:** 3 plans (Wave 1 → Wave 2 → Wave 3, all touch lib.rs)
   - [x] 08.1-01-hotfix-01-lockfile-regen-resolved-paths-PLAN.md — `resolved_paths_from_lockfile_cache` helper + replace empty BTreeMap at Remove/Reassign/Fork sites; integration test (HOTFIX-01 / #461 H1)
-  - [ ] 08.1-02-hotfix-02-remove-save-chain-reorder-PLAN.md — move `if !result.failures.is_empty()` block before save chain in Command::Remove; integration test asserting no disk writes on partial-failure (HOTFIX-02 / #461 H2)
+  - [x] 08.1-02-hotfix-02-remove-save-chain-reorder-PLAN.md — move `if !result.failures.is_empty()` block before save chain in Command::Remove; integration test asserting no disk writes on partial-failure (HOTFIX-02 / #461 H2)
   - [ ] 08.1-03-hotfix-03-failure-summary-reword-PLAN.md — reword leading line to `Run `tome doctor` after resolving:`; stderr-wording test (HOTFIX-03 / #461 H3)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -88,6 +88,6 @@
 **Depends on:** Phase 8
 **Source:** [#461](https://github.com/MartinP7r/tome/issues/461)
 **Plans:** 3 plans (Wave 1 → Wave 2 → Wave 3, all touch lib.rs)
-  - [ ] 08.1-01-hotfix-01-lockfile-regen-resolved-paths-PLAN.md — `resolved_paths_from_lockfile_cache` helper + replace empty BTreeMap at Remove/Reassign/Fork sites; integration test (HOTFIX-01 / #461 H1)
+  - [x] 08.1-01-hotfix-01-lockfile-regen-resolved-paths-PLAN.md — `resolved_paths_from_lockfile_cache` helper + replace empty BTreeMap at Remove/Reassign/Fork sites; integration test (HOTFIX-01 / #461 H1)
   - [ ] 08.1-02-hotfix-02-remove-save-chain-reorder-PLAN.md — move `if !result.failures.is_empty()` block before save chain in Command::Remove; integration test asserting no disk writes on partial-failure (HOTFIX-02 / #461 H2)
   - [ ] 08.1-03-hotfix-03-failure-summary-reword-PLAN.md — reword leading line to `Run `tome doctor` after resolving:`; stderr-wording test (HOTFIX-03 / #461 H3)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -87,7 +87,7 @@
 **Requirements**: HOTFIX-01 (H1), HOTFIX-02 (H2), HOTFIX-03 (H3)
 **Depends on:** Phase 8
 **Source:** [#461](https://github.com/MartinP7r/tome/issues/461)
-**Plans:** 3 plans (Wave 1 → Wave 2 → Wave 3, all touch lib.rs)
+**Plans:** 3/3 plans complete
   - [x] 08.1-01-hotfix-01-lockfile-regen-resolved-paths-PLAN.md — `resolved_paths_from_lockfile_cache` helper + replace empty BTreeMap at Remove/Reassign/Fork sites; integration test (HOTFIX-01 / #461 H1)
   - [x] 08.1-02-hotfix-02-remove-save-chain-reorder-PLAN.md — move `if !result.failures.is_empty()` block before save chain in Command::Remove; integration test asserting no disk writes on partial-failure (HOTFIX-02 / #461 H2)
-  - [ ] 08.1-03-hotfix-03-failure-summary-reword-PLAN.md — reword leading line to `Run `tome doctor` after resolving:`; stderr-wording test (HOTFIX-03 / #461 H3)
+  - [x] 08.1-03-hotfix-03-failure-summary-reword-PLAN.md — reword leading line to `Run `tome doctor` after resolving:`; stderr-wording test (HOTFIX-03 / #461 H3)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -80,3 +80,14 @@
 | 6. Display Polish & Docs | v0.7 | 2/2 | Complete | 2026-04-22 |
 | 7. Wizard UX (Greenfield / Brownfield / Legacy) | v0.8 | 4/4 | Complete | 2026-04-23 |
 | 8. Safety Refactors (Partial-Failure Visibility & Cross-Platform) | v0.8 | 0/3 | Planned | — |
+
+### Phase 08.1: v0.8.1 hotfix — lockfile regen + save chain (INSERTED)
+
+**Goal:** Close 3 post-merge findings from #461 — restore git-skill provenance to the regenerated lockfile in Remove/Reassign/Fork (H1, silent-drop regression introduced by Phase 8), reorder the save chain so partial-failure ⚠ block surfaces before save errors propagate (H2), and reword the failure-summary line for clarity (H3).
+**Requirements**: HOTFIX-01 (H1), HOTFIX-02 (H2), HOTFIX-03 (H3)
+**Depends on:** Phase 8
+**Source:** [#461](https://github.com/MartinP7r/tome/issues/461)
+**Plans:** 3 plans (Wave 1 → Wave 2 → Wave 3, all touch lib.rs)
+  - [ ] 08.1-01-hotfix-01-lockfile-regen-resolved-paths-PLAN.md — `resolved_paths_from_lockfile_cache` helper + replace empty BTreeMap at Remove/Reassign/Fork sites; integration test (HOTFIX-01 / #461 H1)
+  - [ ] 08.1-02-hotfix-02-remove-save-chain-reorder-PLAN.md — move `if !result.failures.is_empty()` block before save chain in Command::Remove; integration test asserting no disk writes on partial-failure (HOTFIX-02 / #461 H2)
+  - [ ] 08.1-03-hotfix-03-failure-summary-reword-PLAN.md — reword leading line to `Run `tome doctor` after resolving:`; stderr-wording test (HOTFIX-03 / #461 H3)

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v0.8
 milestone_name: Wizard UX & Safety Hardening
 status: executing
-stopped_at: Completed 08.1-01-hotfix-01-lockfile-regen-resolved-paths-PLAN.md
-last_updated: "2026-04-26T12:33:55.438Z"
+stopped_at: Completed 08.1-02-hotfix-02-remove-save-chain-reorder-PLAN.md
+last_updated: "2026-04-26T12:41:14.762Z"
 last_activity: 2026-04-26
 progress:
   total_phases: 2
@@ -27,7 +27,7 @@ See: .planning/PROJECT.md (updated 2026-04-23)
 
 Milestone: v0.8 — Wizard UX & Safety Hardening
 Phase: 08.1 (v0-8-1-hotfix-lockfile-regen-and-save-chain) — EXECUTING
-Plan: 2 of 3
+Plan: 3 of 3
 Status: Ready to execute
 Last activity: 2026-04-26
 
@@ -69,6 +69,8 @@ v0.8-specific decisions (from epic #459):
 - [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-01: introduced offline lockfile::resolved_paths_from_lockfile_cache helper (option-(b) lockfile-as-cache) — destructive commands recover git-skill provenance from previous lockfile + on-disk repo cache without network calls
 - [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-01: integration test asserts on git_commit_sha (not source_name) — bug wipes provenance via lockfile::generate's None-fallback, source_name comes from manifest and survives unrelated removes; uses real local file:// git repo so sync's normal clone/update flow seeds the lockfile offline
 - [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: Note: HOTFIX-01/02/03 are referenced in plan frontmatter and ROADMAP.md but were never added to REQUIREMENTS.md —  is a no-op for these. Track via the phase ROADMAP/SUMMARY artifacts and #461 instead.
+- [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-02: Command::Remove ⚠ block moved to fire immediately after remove::execute() returns and BEFORE config.save / manifest::save / lockfile regen — ?-propagation in the save chain can no longer mask the I2/I3 retention messaging
+- [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-02: integration test asserts byte-for-byte equality of tome.toml / .tome-manifest.json / tome.lock pre- vs post-remove under chmod 0o500 partial-failure; tolerates missing tome.lock via unwrap_or_default()
 
 ### Roadmap Evolution
 
@@ -88,6 +90,6 @@ v0.8-specific decisions (from epic #459):
 
 ## Session Continuity
 
-Last session: 2026-04-26T12:33:29.701Z
-Stopped at: Completed 08.1-01-hotfix-01-lockfile-regen-resolved-paths-PLAN.md
+Last session: 2026-04-26T12:41:14.759Z
+Stopped at: Completed 08.1-02-hotfix-02-remove-save-chain-reorder-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,10 +2,10 @@
 gsd_state_version: 1.0
 milestone: v0.8
 milestone_name: Wizard UX & Safety Hardening
-status: verifying
+status: executing
 stopped_at: Completed 08-03-safe-03-relocate-read-link-warning-PLAN.md
-last_updated: "2026-04-24T03:44:52.668Z"
-last_activity: 2026-04-24
+last_updated: "2026-04-26T12:20:54.856Z"
+last_activity: 2026-04-26 -- Phase 08.1 execution started
 progress:
   total_phases: 2
   completed_phases: 2
@@ -21,15 +21,15 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-23)
 
 **Core value:** Every AI coding tool on a developer's machine shares the same skill library without manual copying or per-tool configuration.
-**Current focus:** Phase 08 — safety-refactors-partial-failure-visibility-cross-platform
+**Current focus:** Phase 08.1 — v0-8-1-hotfix-lockfile-regen-and-save-chain
 
 ## Current Position
 
 Milestone: v0.8 — Wizard UX & Safety Hardening
-Phase: 08
-Plan: Not started
-Status: Phase complete — ready for verification
-Last activity: 2026-04-24
+Phase: 08.1 (v0-8-1-hotfix-lockfile-regen-and-save-chain) — EXECUTING
+Plan: 1 of 3
+Status: Executing Phase 08.1
+Last activity: 2026-04-26 -- Phase 08.1 execution started
 
 Progress: [░░░░░░░░░░] 0% (roadmap created, plans pending)
 
@@ -66,6 +66,10 @@ v0.8-specific decisions (from epic #459):
 - [Phase 08-safety-refactors-partial-failure-visibility-cross-platform]: SAFE-02: arboard (default-features = false) replaces sh -c | pbcopy; cfg!(target_os = "macos") dispatches open/xdg-open; App.status_message renders ✓/⚠ in status bar until next keypress (closes #414)
 - [Phase 08-safety-refactors-partial-failure-visibility-cross-platform]: SAFE-02: glyph-prefix dispatch (starts_with('⚠') → theme.alert; else → theme.accent) reuses existing theme fields; no theme.warning added. Test tolerates both ✓/⚠ prefixes — no trait ClipboardBackend (D-17/D-19 held)
 - [Phase 08-safety-refactors-partial-failure-visibility-cross-platform]: SAFE-03: relocate::plan() now surfaces read_link failures via eprintln warning mirroring PR #448's format verbatim; regression test uses chmod 0o000 + documents Unix platform caveat that is_symlink and read_link share the same parent-search permission (closes #449)
+
+### Roadmap Evolution
+
+- Phase 8.1 inserted after Phase 8 (2026-04-26): v0.8.1 hotfix — lockfile regen + save chain (URGENT). Source: post-merge re-review of PR #460 surfaced 3 correctness/UX findings ([#461](https://github.com/MartinP7r/tome/issues/461)). H1 is a silent-drop regression (git skills omitted from regenerated lockfile in Remove/Reassign/Fork), H2 is the I2/I3 retention guarantee being voided by post-execute save failures, H3 is wording. Worth a patch release before v0.9.
 
 ### Pending Todos
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,9 +3,9 @@ gsd_state_version: 1.0
 milestone: v0.8
 milestone_name: Wizard UX & Safety Hardening
 status: executing
-stopped_at: Completed 08-03-safe-03-relocate-read-link-warning-PLAN.md
-last_updated: "2026-04-26T12:20:54.856Z"
-last_activity: 2026-04-26 -- Phase 08.1 execution started
+stopped_at: Completed 08.1-01-hotfix-01-lockfile-regen-resolved-paths-PLAN.md
+last_updated: "2026-04-26T12:33:55.438Z"
+last_activity: 2026-04-26
 progress:
   total_phases: 2
   completed_phases: 2
@@ -27,9 +27,9 @@ See: .planning/PROJECT.md (updated 2026-04-23)
 
 Milestone: v0.8 — Wizard UX & Safety Hardening
 Phase: 08.1 (v0-8-1-hotfix-lockfile-regen-and-save-chain) — EXECUTING
-Plan: 1 of 3
-Status: Executing Phase 08.1
-Last activity: 2026-04-26 -- Phase 08.1 execution started
+Plan: 2 of 3
+Status: Ready to execute
+Last activity: 2026-04-26
 
 Progress: [░░░░░░░░░░] 0% (roadmap created, plans pending)
 
@@ -66,6 +66,9 @@ v0.8-specific decisions (from epic #459):
 - [Phase 08-safety-refactors-partial-failure-visibility-cross-platform]: SAFE-02: arboard (default-features = false) replaces sh -c | pbcopy; cfg!(target_os = "macos") dispatches open/xdg-open; App.status_message renders ✓/⚠ in status bar until next keypress (closes #414)
 - [Phase 08-safety-refactors-partial-failure-visibility-cross-platform]: SAFE-02: glyph-prefix dispatch (starts_with('⚠') → theme.alert; else → theme.accent) reuses existing theme fields; no theme.warning added. Test tolerates both ✓/⚠ prefixes — no trait ClipboardBackend (D-17/D-19 held)
 - [Phase 08-safety-refactors-partial-failure-visibility-cross-platform]: SAFE-03: relocate::plan() now surfaces read_link failures via eprintln warning mirroring PR #448's format verbatim; regression test uses chmod 0o000 + documents Unix platform caveat that is_symlink and read_link share the same parent-search permission (closes #449)
+- [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-01: introduced offline lockfile::resolved_paths_from_lockfile_cache helper (option-(b) lockfile-as-cache) — destructive commands recover git-skill provenance from previous lockfile + on-disk repo cache without network calls
+- [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-01: integration test asserts on git_commit_sha (not source_name) — bug wipes provenance via lockfile::generate's None-fallback, source_name comes from manifest and survives unrelated removes; uses real local file:// git repo so sync's normal clone/update flow seeds the lockfile offline
+- [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: Note: HOTFIX-01/02/03 are referenced in plan frontmatter and ROADMAP.md but were never added to REQUIREMENTS.md —  is a no-op for these. Track via the phase ROADMAP/SUMMARY artifacts and #461 instead.
 
 ### Roadmap Evolution
 
@@ -85,6 +88,6 @@ v0.8-specific decisions (from epic #459):
 
 ## Session Continuity
 
-Last session: 2026-04-24T02:44:38.468Z
-Stopped at: Completed 08-03-safe-03-relocate-read-link-warning-PLAN.md
+Last session: 2026-04-26T12:33:29.701Z
+Stopped at: Completed 08.1-01-hotfix-01-lockfile-regen-resolved-paths-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,7 +4,7 @@ milestone: v0.8
 milestone_name: Wizard UX & Safety Hardening
 status: verifying
 stopped_at: Completed 08.1-03-hotfix-03-failure-summary-reword-PLAN.md — phase 08.1 complete, v0.8.1 ready for make release
-last_updated: "2026-04-26T12:46:50.602Z"
+last_updated: "2026-04-26T12:51:56.881Z"
 last_activity: 2026-04-26
 progress:
   total_phases: 2
@@ -26,8 +26,8 @@ See: .planning/PROJECT.md (updated 2026-04-23)
 ## Current Position
 
 Milestone: v0.8 — Wizard UX & Safety Hardening
-Phase: 08.1 (v0-8-1-hotfix-lockfile-regen-and-save-chain) — EXECUTING
-Plan: 3 of 3
+Phase: 08.1
+Plan: Not started
 Status: Phase complete — ready for verification
 Last activity: 2026-04-26
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v0.8
 milestone_name: Wizard UX & Safety Hardening
-status: executing
-stopped_at: Completed 08.1-02-hotfix-02-remove-save-chain-reorder-PLAN.md
-last_updated: "2026-04-26T12:41:14.762Z"
+status: verifying
+stopped_at: Completed 08.1-03-hotfix-03-failure-summary-reword-PLAN.md — phase 08.1 complete, v0.8.1 ready for make release
+last_updated: "2026-04-26T12:46:50.602Z"
 last_activity: 2026-04-26
 progress:
   total_phases: 2
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-04-23)
 Milestone: v0.8 — Wizard UX & Safety Hardening
 Phase: 08.1 (v0-8-1-hotfix-lockfile-regen-and-save-chain) — EXECUTING
 Plan: 3 of 3
-Status: Ready to execute
+Status: Phase complete — ready for verification
 Last activity: 2026-04-26
 
 Progress: [░░░░░░░░░░] 0% (roadmap created, plans pending)
@@ -71,6 +71,8 @@ v0.8-specific decisions (from epic #459):
 - [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: Note: HOTFIX-01/02/03 are referenced in plan frontmatter and ROADMAP.md but were never added to REQUIREMENTS.md —  is a no-op for these. Track via the phase ROADMAP/SUMMARY artifacts and #461 instead.
 - [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-02: Command::Remove ⚠ block moved to fire immediately after remove::execute() returns and BEFORE config.save / manifest::save / lockfile regen — ?-propagation in the save chain can no longer mask the I2/I3 retention messaging
 - [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-02: integration test asserts byte-for-byte equality of tome.toml / .tome-manifest.json / tome.lock pre- vs post-remove under chmod 0o500 partial-failure; tolerates missing tome.lock via unwrap_or_default()
+- [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-03: leading eprintln! in Command::Remove ⚠ block reworded — trailing colon now introduces the per-kind listing instead of falsely promising tome doctor output (closes #461 H3); inline reword over terminal-line variant for single-line risk profile
+- [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-03: integration test asserts on three substrings (positive 'after resolving:', sentinel 'tome doctor', negative 'addressing these. Run `tome doctor`:' absent) under NO_COLOR=1 so styled output renders as plain literal
 
 ### Roadmap Evolution
 
@@ -90,6 +92,6 @@ v0.8-specific decisions (from epic #459):
 
 ## Session Continuity
 
-Last session: 2026-04-26T12:41:14.759Z
-Stopped at: Completed 08.1-02-hotfix-02-remove-save-chain-reorder-PLAN.md
+Last session: 2026-04-26T12:46:50.600Z
+Stopped at: Completed 08.1-03-hotfix-03-failure-summary-reword-PLAN.md — phase 08.1 complete, v0.8.1 ready for make release
 Resume file: None

--- a/.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-01-SUMMARY.md
+++ b/.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-01-SUMMARY.md
@@ -1,0 +1,147 @@
+---
+phase: 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain
+plan: 01
+subsystem: lockfile
+tags: [lockfile, git-skills, regen, remove, reassign, fork, hotfix, "#461"]
+
+# Dependency graph
+requires:
+  - phase: 08-safety-refactors-partial-failure-visibility-cross-platform
+    provides: "Remove/Reassign/Fork lockfile-regen flow that this plan repairs"
+provides:
+  - "lockfile::resolved_paths_from_lockfile_cache helper — offline (no-network) recovery of git-skill provenance from previous lockfile + on-disk repo cache"
+  - "Per-directory `warning:` lines on stderr replacing the silent drop when lockfile/cache are unavailable"
+  - "Integration test guard for #461 H1 (git_commit_sha preserved across `tome remove`)"
+affects: ["08.1-02-remove-save-chain-reorder", "08.1-03-failure-summary-reword", "v0.8.1 release"]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Offline cache-as-source-of-truth: destructive commands recover git-skill provenance from the previous lockfile + on-disk repo cache rather than re-cloning at regen time"
+    - "Per-directory warning surfacing: silent skips replaced with `warning:` lines naming the affected directory"
+
+key-files:
+  created: []
+  modified:
+    - "crates/tome/src/lockfile.rs (add resolved_paths_from_lockfile_cache helper + 6 unit tests; cargo-fmt rewrap of new test code)"
+    - "crates/tome/src/lib.rs (Remove/Reassign/Fork handlers consume the helper instead of an empty BTreeMap)"
+    - "crates/tome/tests/cli.rs (add remove_preserves_git_lockfile_entries integration test)"
+
+key-decisions:
+  - "Option (b) lockfile-as-cache: helper is offline-only, never clones/fetches — destructive commands stay zero-network"
+  - "Asserted on git_commit_sha (not source_name) in the integration test because the bug wipes provenance via lockfile::generate's None-fallback, not the source_name (which lives on the manifest)"
+  - "Used a real local file:// git repo in the integration fixture (instead of a fake cache + git init) so `tome sync`'s normal clone/update flow seeds the lockfile without needing dry-run hacks"
+
+patterns-established:
+  - "Helper signature mirrors discover::discover_all's resolved_paths input shape exactly: BTreeMap<DirectoryName, (PathBuf, Option<String>)>"
+  - "Per-directory warnings (one per affected git directory) instead of a single global warning — users with multiple git repos see each affected name"
+
+requirements-completed: [HOTFIX-01]
+
+# Metrics
+duration: 10min
+completed: 2026-04-26
+---
+
+# Phase 08.1 Plan 01: Lockfile-Regen Resolved-Paths Hotfix Summary
+
+**Offline `resolved_paths_from_lockfile_cache` helper recovers git-skill provenance from the previous lockfile + on-disk repo cache, wired into `Command::Remove`/`Reassign`/`Fork` so the regenerated `tome.lock` no longer silently drops `git_commit_sha` for git-type directories.**
+
+## Performance
+
+- **Duration:** ~10 min (578 s wall)
+- **Started:** 2026-04-26T12:22:02Z
+- **Completed:** 2026-04-26T12:31:40Z
+- **Tasks:** 3 / 3
+- **Files modified:** 3
+
+## Accomplishments
+
+- Added `pub(crate) fn resolved_paths_from_lockfile_cache(&Config, &TomePaths) -> (BTreeMap<DirectoryName, (PathBuf, Option<String>)>, Vec<String>)` in `lockfile.rs` — no-network helper that loads the previous lockfile, indexes git-commit SHAs by directory name, and verifies the on-disk cache dir for each git-type directory. Emits per-directory `warning:` strings when the lockfile or cache is unavailable.
+- Wired the helper into all three lib.rs handlers (`Command::Remove` line 401, `Command::Reassign` line 475, `Command::Fork` line 531), replacing the `let resolved_paths = std::collections::BTreeMap::new();` empty-map placeholder that was the root cause of #461 H1.
+- Added `remove_preserves_git_lockfile_entries` integration test in `cli.rs`. The test sets up a real local file:// git repo plus a directory-type source, syncs both, runs `tome remove local`, and asserts `git_commit_sha` for the surviving git-source entry is unchanged (regression-confirmed: reverting the fix produces `Some("356e0baf…") != None`).
+
+## Task Commits
+
+1. **Task 1: Add `resolved_paths_from_lockfile_cache` helper + 6 unit tests** — `81ef26e` (feat)
+2. **Task 2: Wire helper into Remove/Reassign/Fork handlers** — `f7ec30c` (fix)
+3. **Task 3: Integration test guards #461 H1 git-skill provenance regression** — `bf8d4eb` (test)
+
+## Files Created/Modified
+
+- `crates/tome/src/lockfile.rs` — Added `resolved_paths_from_lockfile_cache` helper (lines 104–185) plus 6 unit tests covering: no-git-dirs, missing-lockfile, missing-cache-dir, cache-present, subdir, no-skills-for-dir. Hoisted `Config`/`DirectoryName`/`DirectoryType`/`TomePaths`/`PathBuf` into module-level imports for cleaner signatures.
+- `crates/tome/src/lib.rs` — Replaced `let resolved_paths = std::collections::BTreeMap::new();` at three handler call sites (lines 401, 475, 531) with `let (resolved_paths, mut regen_warnings) = lockfile::resolved_paths_from_lockfile_cache(&config, &paths);`.
+- `crates/tome/tests/cli.rs` — Added `remove_preserves_git_lockfile_entries` test (lines 3461–3593). Uses a real local file:// git repo as the upstream so `git clone`/`git fetch` work offline.
+
+## Decisions Made
+
+- **Asserted on `git_commit_sha`, not `source_name`**: The bug only wipes provenance fields, because `source_name` is read from the manifest (which `tome remove` of an unrelated directory leaves intact). The actual provenance loss happens in `lockfile::generate` when `discover_all` returned no matching skill — provenance falls back to `(None, None, None)`. The integration test asserts `git_commit_sha == git_commit_sha_before` to actually exercise the bug.
+- **Real `file://` upstream over dry-run-with-fake-cache**: The plan suggested either a fake cache (with `git init` for `read_head_sha`) or `--dry-run`. A real local bare-ish repo with a `file://` URL is simpler — `tome sync`'s normal clone/update flow runs end-to-end without network, and the lockfile is populated through the production code path.
+- **`#[allow(clippy::type_complexity)]` on the helper**: The return tuple `(BTreeMap<…>, Vec<String>)` matches `discover_all`'s consumer shape verbatim. Factoring into a `type` alias would obscure that one-to-one correspondence.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] `cargo clippy --all-targets` failed on the helper before Task 2 wired its call sites**
+
+- **Found during:** Task 1 verification (`cargo clippy -p tome --all-targets -- -D warnings`)
+- **Issue:** With Task 1 committed atomically (helper present, no production callers yet), clippy's `dead_code` lint failed because the helper was only used in tests. Atomic commits per task is a hard requirement.
+- **Fix:** Added a temporary `#[allow(dead_code)]` to the helper for the Task 1 commit, with a comment noting it would be removed in Task 2. Removed in Task 2 once the three call sites consumed the helper.
+- **Files modified:** `crates/tome/src/lockfile.rs`
+- **Verification:** `cargo clippy --all-targets -- -D warnings` clean for both Task 1 and Task 2 commits.
+- **Committed in:** `81ef26e` (added), `f7ec30c` (removed)
+
+**2. [Rule 3 - Blocking] `cargo clippy` failed on `clippy::type_complexity` for the helper return tuple**
+
+- **Found during:** Task 1 verification
+- **Issue:** Returning `(BTreeMap<DirectoryName, (PathBuf, Option<String>)>, Vec<String>)` triggered `clippy::type-complexity`. The neighbouring `resolve_git_directories` in lib.rs avoided this only because it returns a single map, not a tuple.
+- **Fix:** Added `#[allow(clippy::type_complexity)]` with a comment noting the tuple shape mirrors `discover_all`'s consumer contract verbatim — factoring into a `type` alias would hide that correspondence.
+- **Files modified:** `crates/tome/src/lockfile.rs`
+- **Committed in:** `81ef26e`
+
+**3. [Rule 3 - Blocking] `cargo fmt -- --check` failed on the new integration-test code**
+
+- **Found during:** Task 3 verification (`make ci`)
+- **Issue:** The fixture's helper-array literal and a few `assert!(…, format)` calls exceeded rustfmt's default line-length. Plan's plain-text snippets weren't pre-formatted.
+- **Fix:** Ran `cargo fmt`. Captured the resulting reformatting in the same Task 3 commit.
+- **Files modified:** `crates/tome/src/lockfile.rs` (test helper rewrapping), `crates/tome/tests/cli.rs`
+- **Committed in:** `bf8d4eb`
+
+---
+
+**Total deviations:** 3 auto-fixed (3 blocking — clippy / fmt gates)
+**Impact on plan:** All three are CI-gate fixes; no scope creep, no behavior change. Plan executed exactly as designed.
+
+## Issues Encountered
+
+- **`make ci` failed on `typos` step locally because `typos-cli` was not installed.** Installed via `cargo install typos-cli` (43 s) and re-ran — typos clean. This is an environment issue, not a code issue; CI on GitHub Actions installs typos automatically.
+- **First draft of the integration test asserted on `source_name` only and passed even with the bug reintroduced** — the bug doesn't drop entries by `source_name` (manifest carries those for unrelated removes). Tightened the assertion to `git_commit_sha` equality before/after, which is where the bug actually manifests via `lockfile::generate`'s `(None, None, None)` fallback. Manually verified the new assertion fails when Task 2 is reverted (`Some("356e0baf…") != None`), then restored Task 2 and re-confirmed pass.
+
+## User Setup Required
+
+None — pure code change, no external services.
+
+## Next Phase Readiness
+
+- HOTFIX-01 / #461 H1 closed: regenerated lockfile preserves git-skill provenance across `tome remove`/`reassign`/`fork`.
+- Ready for Plan 02 (HOTFIX-02 — Remove handler save-chain reorder) and Plan 03 (HOTFIX-03 — failure-summary wording). Both are independent of this plan; this one only touched the resolved-paths source, not the save-chain ordering or wording.
+- `make ci` green: 464 unit tests + 124 integration tests + clippy `-D warnings` + fmt-check + typos.
+
+## Self-Check
+
+Verified at end of execution:
+
+- `crates/tome/src/lockfile.rs` exists and contains `pub(crate) fn resolved_paths_from_lockfile_cache` — FOUND
+- `crates/tome/src/lib.rs` contains 3 occurrences of `lockfile::resolved_paths_from_lockfile_cache` and 0 occurrences of `let resolved_paths = std::collections::BTreeMap::new();` — FOUND
+- `crates/tome/tests/cli.rs` contains `remove_preserves_git_lockfile_entries` — FOUND
+- Commits `81ef26e`, `f7ec30c`, `bf8d4eb` exist on `gsd/phase-08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain` — FOUND
+- `make ci` (with `typos-cli` in PATH): all checks passed — VERIFIED
+
+## Self-Check: PASSED
+
+---
+*Phase: 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain*
+*Plan: 01*
+*Completed: 2026-04-26*

--- a/.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-01-hotfix-01-lockfile-regen-resolved-paths-PLAN.md
+++ b/.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-01-hotfix-01-lockfile-regen-resolved-paths-PLAN.md
@@ -1,0 +1,534 @@
+---
+phase: 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - crates/tome/src/lib.rs
+  - crates/tome/src/lockfile.rs
+  - crates/tome/tests/cli.rs
+autonomous: true
+requirements: [HOTFIX-01]
+issue: "https://github.com/MartinP7r/tome/issues/461 (H1)"
+
+must_haves:
+  truths:
+    - "After `tome remove`, `tome reassign`, or `tome fork`, the regenerated `tome.lock` still contains entries for skills sourced from git-type directories that exist in the cache (no silent drop)"
+    - "When the previous lockfile is missing or the git cache dir is gone, the user sees a stderr `warning:` line naming the directory — never a silent skip"
+    - "The lockfile-regen path adds NO network operations to remove/reassign/fork (no `git clone`, no `git fetch`)"
+  artifacts:
+    - path: "crates/tome/src/lockfile.rs"
+      provides: "`pub(crate) fn resolved_paths_from_lockfile_cache(config: &Config, paths: &TomePaths) -> (BTreeMap<DirectoryName, (PathBuf, Option<String>)>, Vec<String>)` (or equivalent shape) that reads the existing lockfile + checks the on-disk cache dir for each git directory and returns a resolved-paths map plus a vec of warnings"
+      contains: "fn resolved_paths_from_lockfile_cache"
+    - path: "crates/tome/src/lib.rs"
+      provides: "All three call sites (Remove ~line 399, Reassign ~line 470, Fork ~line 523) use the helper instead of `std::collections::BTreeMap::new()`"
+      contains: "resolved_paths_from_lockfile_cache"
+    - path: "crates/tome/tests/cli.rs"
+      provides: "Integration test that proves git-source-name entries survive lockfile regen on `tome remove` of an unrelated directory"
+      contains: "remove_preserves_git_lockfile_entries"
+  key_links:
+    - from: "crates/tome/src/lib.rs Command::Remove handler"
+      to: "lockfile::resolved_paths_from_lockfile_cache"
+      via: "called immediately before discover::discover_all"
+      pattern: "let \\(resolved_paths, regen_warnings\\) = lockfile::resolved_paths_from_lockfile_cache"
+    - from: "crates/tome/src/lib.rs Command::Reassign handler (post `manifest::save`)"
+      to: "lockfile::resolved_paths_from_lockfile_cache"
+      via: "called immediately before discover::discover_all"
+      pattern: "resolved_paths_from_lockfile_cache"
+    - from: "crates/tome/src/lib.rs Command::Fork handler (post `manifest::save`)"
+      to: "lockfile::resolved_paths_from_lockfile_cache"
+      via: "called immediately before discover::discover_all"
+      pattern: "resolved_paths_from_lockfile_cache"
+---
+
+<objective>
+Restore git-skill provenance to the lockfile that `tome remove`, `tome reassign`, and `tome fork` regenerate after their in-memory mutations.
+
+**Bug (H1, #461):** All three handlers currently pass `std::collections::BTreeMap::new()` as `resolved_paths` to `discover::discover_all`. `discover.rs:177-183` falls through to `continue;` for every git-type directory when `resolved_paths.get(dir_name).is_none()`. With an empty map, **every git-type directory is silently skipped** during regen — the regenerated lockfile omits all git-provenance skills. After running any of these commands, the next `tome sync` or `tome update` sees a phantom diff where every git-sourced skill appears as "new" or "removed" even though nothing changed.
+
+**Fix (option (b) — lockfile-as-cache):** Introduce a helper that builds `BTreeMap<DirectoryName, (PathBuf, Option<String>)>` from the *previous* lockfile + on-disk cache dir, with no network calls. The user just ran `tome sync` to get into the current state, so the lockfile is fresh enough for these read-mostly destructive commands. Apply the helper at all three handler sites.
+
+Purpose: Closes the silent-drop regression introduced by Phase 8 (#461 H1). Restores the I1 "no silent drift" property that the post-merge re-review identified as broken.
+Output: Helper function + three call-site replacements + one integration test.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/REQUIREMENTS.md
+
+@crates/tome/src/lib.rs
+@crates/tome/src/discover.rs
+@crates/tome/src/lockfile.rs
+@crates/tome/src/git.rs
+@crates/tome/src/paths.rs
+@crates/tome/src/config.rs
+@crates/tome/tests/cli.rs
+
+<interfaces>
+<!-- Key types and exports the executor needs. -->
+
+From `crates/tome/src/discover.rs` (function signature, do NOT change):
+```rust
+pub fn discover_all(
+    config: &Config,
+    resolved_paths: &BTreeMap<DirectoryName, (PathBuf, Option<String>)>,
+    warnings: &mut Vec<String>,
+) -> Result<Vec<DiscoveredSkill>>
+```
+
+For each git-type directory, `discover_all` does:
+```rust
+let dir_skills = if let Some((resolved_path, _sha)) = resolved_paths.get(dir_name) {
+    // use resolved_path
+} else if dir_config.directory_type == DirectoryType::Git {
+    continue;   // <-- THIS is the silent drop
+} else {
+    discover_directory_entry(dir_name, dir_config, warnings)?
+};
+```
+
+From `crates/tome/src/lockfile.rs`:
+```rust
+pub struct Lockfile {
+    pub version: u32,
+    pub skills: BTreeMap<SkillName, LockEntry>,
+}
+pub struct LockEntry {
+    pub source_name: String,
+    pub content_hash: ContentHash,
+    pub registry_id: Option<String>,
+    pub version: Option<String>,
+    pub git_commit_sha: Option<String>,
+}
+pub fn load(tome_home: &Path) -> Result<Option<Lockfile>>;
+```
+
+Note: `LockEntry.source_name` is the *directory name* (`DirectoryName::as_str()`), not a path.
+Note: `tome_home` for `lockfile::load` is the `paths.config_dir()` (same path used by `lockfile::save`).
+
+From `crates/tome/src/git.rs`:
+```rust
+pub(crate) fn repo_cache_dir(repos_dir: &Path, url: &str) -> PathBuf;
+pub(crate) fn effective_path(clone_path: &Path, subdir: Option<&str>) -> PathBuf;
+```
+
+From `crates/tome/src/paths.rs`:
+```rust
+impl TomePaths {
+    pub fn repos_dir(&self) -> PathBuf;       // ~/.tome/repos/
+    pub fn config_dir(&self) -> PathBuf;      // where tome.lock + manifest live
+}
+```
+
+From `crates/tome/src/config.rs`:
+```rust
+pub struct DirectoryConfig {
+    pub path: PathBuf,                         // for git: a URL string
+    pub directory_type: DirectoryType,         // ::Git, ::Directory, ::ClaudePlugins
+    pub subdir: Option<String>,
+    // ...
+}
+pub enum DirectoryType { Directory, ClaudePlugins, Git }
+```
+
+The existing `lib.rs::resolve_git_directories` (~line 693) is the *online* analogue used by `sync()`. **Do NOT call it from the new helper** — it would add `git clone`/`git fetch` work to remove/reassign/fork. The new helper is offline-only and reads the on-disk cache.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add `resolved_paths_from_lockfile_cache` helper in lockfile.rs</name>
+  <files>crates/tome/src/lockfile.rs</files>
+  <read_first>
+    - crates/tome/src/lockfile.rs (full file — extend existing `load`/`save` API)
+    - crates/tome/src/lib.rs lines 685–800 (`resolve_git_directories` — mirror its iteration shape, but with no network)
+    - crates/tome/src/git.rs (`repo_cache_dir`, `effective_path`)
+    - crates/tome/src/config.rs lines 380–500 (DirectoryConfig + discovery_dirs helpers)
+    - crates/tome/src/discover.rs lines 160–200 (consumer contract for `resolved_paths`)
+  </read_first>
+  <behavior>
+    - Test 1 (`resolved_paths_from_lockfile_cache_returns_empty_when_no_git_dirs`): Config with only one Directory-type directory and a missing lockfile → returns `(BTreeMap::new(), Vec::new())`. No warnings.
+    - Test 2 (`resolved_paths_from_lockfile_cache_warns_when_lockfile_missing`): Config with one git-type directory, no `tome.lock` on disk → returns `(BTreeMap::new(), vec![warn])` where warn matches `cannot resolve git directory '<name>'` AND mentions "lockfile". The git directory is NOT inserted into the map (so `discover_all` correctly skips it — but the user is no longer kept in the dark).
+    - Test 3 (`resolved_paths_from_lockfile_cache_warns_when_cache_dir_missing`): Config with one git-type directory, lockfile present and contains `source_name = "myrepo"` with `git_commit_sha = Some("abc..")`, but the on-disk cache dir does NOT exist → returns `(BTreeMap::new(), vec![warn])` where warn names the directory and mentions "cache". The directory is NOT inserted.
+    - Test 4 (`resolved_paths_from_lockfile_cache_populates_when_cache_exists`): Config with one git-type directory `myrepo` (path = some URL, subdir = None), lockfile present with at least one skill whose `source_name = "myrepo"` and `git_commit_sha = Some("deadbeef..")`, AND the cache dir at `repos_dir/<sha256(url)>/` is created on disk via `std::fs::create_dir_all` → returned map contains `(DirectoryName("myrepo"), (cache_dir_path, Some("deadbeef..")))`. No warnings.
+    - Test 5 (`resolved_paths_from_lockfile_cache_respects_subdir`): Same as Test 4 but `subdir = Some("skills".to_string())` → returned PathBuf is `cache_dir/skills`.
+    - Test 6 (`resolved_paths_from_lockfile_cache_falls_back_when_no_lockfile_sha`): Config with one git-type directory `myrepo`, lockfile present but NO entry has `source_name = "myrepo"` (e.g., the directory has no skills yet) → if cache dir exists on disk, the helper still returns `(map_with_entry_sha_None, no_warning)` so the regen does not silently drop. (Rationale: cache is real even if no skills are tracked yet.)
+  </behavior>
+  <action>
+Add a new pub(crate) helper to `crates/tome/src/lockfile.rs`:
+
+```rust
+/// Build a `resolved_paths` map for `discover::discover_all` from the current
+/// lockfile + on-disk git cache, with NO network calls.
+///
+/// Used by destructive commands (`tome remove`/`reassign`/`fork`) when they
+/// regenerate the lockfile after in-memory mutation. Unlike `sync()`'s online
+/// `resolve_git_directories`, this helper:
+///
+///   - reads the previous lockfile to recover `git_commit_sha` per directory,
+///   - checks the on-disk cache dir for each git-type directory,
+///   - emits a stderr-bound warning string when the lockfile is missing OR
+///     the cache dir is gone (so the caller can `eprintln!("warning: {}", w)`),
+///   - never clones, fetches, or talks to a remote.
+///
+/// Returns `(map, warnings)`. Map values are `(effective_path, Option<git_commit_sha>)`
+/// in the shape `discover::discover_all` requires.
+pub(crate) fn resolved_paths_from_lockfile_cache(
+    config: &crate::config::Config,
+    paths: &crate::paths::TomePaths,
+) -> (
+    std::collections::BTreeMap<
+        crate::config::DirectoryName,
+        (std::path::PathBuf, Option<String>),
+    >,
+    Vec<String>,
+) {
+    use crate::config::DirectoryType;
+    let mut resolved = std::collections::BTreeMap::new();
+    let mut warnings = Vec::new();
+
+    // Bail early if config has no git directories — avoid loading lockfile.
+    let has_git = config
+        .directories
+        .values()
+        .any(|d| d.directory_type == DirectoryType::Git);
+    if !has_git {
+        return (resolved, warnings);
+    }
+
+    // Load previous lockfile (offline). On read error, surface and treat as missing.
+    let previous = match load(&paths.config_dir()) {
+        Ok(opt) => opt,
+        Err(e) => {
+            warnings.push(format!(
+                "could not read lockfile for git-directory cache lookup: {e}"
+            ));
+            None
+        }
+    };
+
+    // Build a quick "directory_name -> first git_commit_sha seen" index from the lockfile.
+    let mut sha_by_dir: std::collections::BTreeMap<&str, Option<String>> =
+        std::collections::BTreeMap::new();
+    if let Some(ref lf) = previous {
+        for entry in lf.skills.values() {
+            sha_by_dir
+                .entry(entry.source_name.as_str())
+                .or_insert_with(|| entry.git_commit_sha.clone());
+        }
+    }
+
+    let repos_dir = paths.repos_dir();
+
+    for (name, dir_config) in &config.directories {
+        if dir_config.directory_type != DirectoryType::Git {
+            continue;
+        }
+
+        // The lockfile is our only offline source of `git_commit_sha`. If it's
+        // missing entirely, we can still resolve via the cache dir on disk
+        // (sha = None) — but warn the user that the regen will record no SHA.
+        if previous.is_none() {
+            warnings.push(format!(
+                "cannot resolve git directory '{name}' from lockfile (lockfile missing) — \
+                 git-sourced skills may be omitted from the regenerated lockfile",
+            ));
+            continue;
+        }
+
+        let url = dir_config.path.to_string_lossy();
+        let cache_dir = crate::git::repo_cache_dir(&repos_dir, &url);
+        if !cache_dir.is_dir() {
+            warnings.push(format!(
+                "cannot resolve git directory '{name}' — cache dir {} not found; \
+                 git-sourced skills will be omitted from the regenerated lockfile",
+                cache_dir.display(),
+            ));
+            continue;
+        }
+
+        let effective = crate::git::effective_path(&cache_dir, dir_config.subdir.as_deref());
+        // sha may legitimately be None when the directory has no skills yet.
+        let sha = sha_by_dir
+            .get(name.as_str())
+            .and_then(|opt| opt.clone());
+        resolved.insert(name.clone(), (effective, sha));
+    }
+
+    (resolved, warnings)
+}
+```
+
+**Implementation notes for executor:**
+- Place the helper above the `#[cfg(test)] mod tests` block in `lockfile.rs`.
+- Do NOT add network calls (no `git::clone_repo`, no `git::update_repo`, no `git::read_head_sha`).
+- The `sha_by_dir` lookup intentionally takes the FIRST sha seen per directory — all skills from one directory share a SHA, so any one is correct.
+- The `previous.is_none()` branch issues a warning per git-directory (not just one global warning) so users with multiple git directories see each affected name. This addresses #461 H1 directly: silent drops are replaced with surfaced warnings.
+- Do NOT change the existing `load`/`save`/`generate` functions — additive only.
+
+Add the 6 unit tests in `#[cfg(test)] mod tests {}` of `lockfile.rs`. Reuse the existing `make_manifest` / `make_discovered` test helpers. Use `tempfile::TempDir` for the `paths.config_dir()` and `paths.repos_dir()`. To exercise `repo_cache_dir`, just compute the expected path with `git::repo_cache_dir(&repos_dir, "https://example.invalid/foo.git")` and `std::fs::create_dir_all(&that_path)`.
+
+Build a minimal `Config` and `TomePaths` for the tests:
+```rust
+let tmp = TempDir::new().unwrap();
+let paths = TomePaths::new(tmp.path()).unwrap();    // or whatever the constructor is
+let mut config = Config::default();
+config.directories.insert(
+    DirectoryName::new("myrepo").unwrap(),
+    DirectoryConfig {
+        path: PathBuf::from("https://example.invalid/foo.git"),
+        directory_type: DirectoryType::Git,
+        role: DirectoryRole::Source,
+        subdir: None,
+        // ... minimal other fields
+    },
+);
+```
+If the existing `Config`/`DirectoryConfig` builders feel too noisy, write a small private `make_config(...)` test helper analogous to `make_manifest`.
+
+Run: `cargo test -p tome lockfile::tests::resolved_paths_from_lockfile_cache_`
+  </action>
+  <verify>
+    <automated>cargo test -p tome lockfile::tests::resolved_paths_from_lockfile_cache_</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "pub(crate) fn resolved_paths_from_lockfile_cache" crates/tome/src/lockfile.rs` returns one match.
+    - `cargo test -p tome lockfile::tests::resolved_paths_from_lockfile_cache_` runs at least 6 tests, all pass.
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+    - The helper does NOT call `git::clone_repo`, `git::update_repo`, or `git::read_head_sha` (`rg "clone_repo|update_repo|read_head_sha" crates/tome/src/lockfile.rs` returns no matches).
+  </acceptance_criteria>
+  <done>
+    Helper compiles, has 6 unit tests covering missing-lockfile / missing-cache-dir / cache-present / subdir / no-skills-for-dir / no-git-dirs paths, and is callable from `crate::lockfile::resolved_paths_from_lockfile_cache(&config, &paths)`.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Replace empty `BTreeMap::new()` at the three handler sites in lib.rs</name>
+  <files>crates/tome/src/lib.rs</files>
+  <read_first>
+    - crates/tome/src/lib.rs lines 380–540 (Remove / Reassign / Fork handlers — all three call sites)
+    - crates/tome/src/lockfile.rs (the helper added in Task 1 — confirm exact name/signature)
+    - crates/tome/src/discover.rs lines 158–195 (consumer contract — make sure the new map shape matches)
+  </read_first>
+  <action>
+At each of the three call sites in `crates/tome/src/lib.rs`, replace this 5-line block:
+
+```rust
+let mut regen_warnings = Vec::new();
+let resolved_paths = std::collections::BTreeMap::new();
+let skills = discover::discover_all(&config, &resolved_paths, &mut regen_warnings)?;
+for w in &regen_warnings {
+    eprintln!("warning: {}", w);
+}
+```
+
+with:
+
+```rust
+let (resolved_paths, mut regen_warnings) =
+    lockfile::resolved_paths_from_lockfile_cache(&config, &paths);
+let skills = discover::discover_all(&config, &resolved_paths, &mut regen_warnings)?;
+for w in &regen_warnings {
+    eprintln!("warning: {}", w);
+}
+```
+
+**Three call sites** (verify by searching for `let resolved_paths = std::collections::BTreeMap::new();`):
+1. `Command::Remove` (~lib.rs:399) — runs unconditionally after `manifest::save`.
+2. `Command::Reassign` (~lib.rs:470) — inside the `if !cli.dry_run { ... }` block, after `manifest::save`.
+3. `Command::Fork` (~lib.rs:523) — inside the `if !cli.dry_run { ... }` block, after `manifest::save`.
+
+**Important:**
+- Do NOT change the surrounding code, the order of operations, or the `lockfile::generate(...)` + `lockfile::save(...)` calls. Plan 02 (HOTFIX-02) handles the Remove handler reorder; this plan only swaps the resolved-paths source.
+- Keep `regen_warnings` mutable — `discover::discover_all` may append to it.
+- The helper's first return value (`resolved_paths`) is consumed by `discover::discover_all` by reference, so the destructured binding works as-is.
+- After this change, `rg "let resolved_paths = std::collections::BTreeMap::new\(\);" crates/tome/src/lib.rs` MUST return zero matches.
+
+Run: `cargo build -p tome && cargo test -p tome --lib`
+  </action>
+  <verify>
+    <automated>cargo build -p tome 2>&1 | tail -20 && rg -n "let resolved_paths = std::collections::BTreeMap::new\(\);" crates/tome/src/lib.rs; test $? -eq 1</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "let resolved_paths = std::collections::BTreeMap::new\(\);" crates/tome/src/lib.rs` returns zero matches (exit 1).
+    - `rg -n "lockfile::resolved_paths_from_lockfile_cache" crates/tome/src/lib.rs` returns exactly 3 matches (Remove, Reassign, Fork).
+    - `cargo build -p tome` is clean.
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+    - `cargo test -p tome --lib` passes.
+  </acceptance_criteria>
+  <done>
+    All three handlers consume the lockfile-cache helper. Empty `BTreeMap::new()` is gone from the three regen sites. Build is green.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Integration test — `tome remove` preserves git-source-name lockfile entries</name>
+  <files>crates/tome/tests/cli.rs</files>
+  <read_first>
+    - crates/tome/tests/cli.rs lines 3170–3460 (existing remove tests — match style + `remove_test_env` helper)
+    - crates/tome/tests/cli.rs lines 1–80 (test infrastructure — `tome()` builder, `create_skill`, `TempDir` patterns)
+    - crates/tome/src/lockfile.rs (`Lockfile`/`LockEntry` JSON shape)
+  </read_first>
+  <action>
+Add a new integration test in `crates/tome/tests/cli.rs`, immediately after the existing `remove_partial_failure_exits_nonzero_with_warning_marker` test (around line 3460).
+
+The test exercises HOTFIX-01 end-to-end: a config with both a git-type directory (whose cache is faked on disk) and a directory-type directory; `tome remove` of the directory-type directory MUST regenerate a lockfile that still contains the git-source-name entries.
+
+```rust
+#[cfg(unix)]
+#[test]
+fn remove_preserves_git_lockfile_entries() {
+    // HOTFIX-01 / #461 H1: regenerated lockfile after `tome remove` must NOT
+    // silently drop git-source-name entries. Pre-Phase 8.1, the handler passed
+    // an empty BTreeMap to discover_all, which silently skipped git-type dirs.
+    let tmp = TempDir::new().unwrap();
+
+    // Set up a directory-type "local" source with one skill.
+    let skills_dir = tmp.path().join("skills");
+    create_skill(&skills_dir, "local-skill");
+
+    // Fake a git-type "myrepo" directory: register it in config with a
+    // dummy URL, then create the cache dir at repos_dir/<sha256(url)>/
+    // and seed it with one SKILL.md so discover_flat_directory finds it.
+    let dummy_url = "https://example.invalid/myrepo.git";
+    let repos_dir = tmp.path().join("repos");
+    std::fs::create_dir_all(&repos_dir).unwrap();
+
+    // Compute the cache dir path the same way `git::repo_cache_dir` does.
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(dummy_url.as_bytes());
+    let url_hash: String = hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect();
+    let cache_dir = repos_dir.join(&url_hash);
+    create_skill(&cache_dir, "git-skill");
+
+    // Config: one Directory + one Git directory.
+    remove_test_env(
+        &tmp,
+        &format!(
+            "[directories.local]\n\
+             path = \"{}\"\n\
+             type = \"directory\"\n\
+             role = \"source\"\n\
+             \n\
+             [directories.myrepo]\n\
+             path = \"{}\"\n\
+             type = \"git\"\n\
+             role = \"source\"\n",
+            skills_dir.display(),
+            dummy_url,
+        ),
+    );
+
+    // Sync to populate manifest and lockfile. We pass the cached repo dir via
+    // the standard tome layout: tome-home/repos/<sha>/ . Because the cache is
+    // already present on disk, sync's `resolve_git_directories` should see it
+    // (already_cloned == true) and use it without a network call.
+    tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "sync",
+            "--no-triage",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+
+    // Sanity: lockfile contains an entry whose source_name == "myrepo".
+    let lockfile_path = tmp.path().join("tome.lock");
+    let lockfile_before: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&lockfile_path).unwrap()).unwrap();
+    let has_git_entry = lockfile_before["skills"]
+        .as_object()
+        .unwrap()
+        .values()
+        .any(|v| v["source_name"].as_str() == Some("myrepo"));
+    assert!(
+        has_git_entry,
+        "precondition: post-sync lockfile must contain a myrepo entry, got: {lockfile_before}"
+    );
+
+    // Now remove the OTHER (directory-type) directory. The regen of the
+    // lockfile MUST keep the myrepo entries.
+    tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "remove",
+            "local",
+            "--force",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+
+    let lockfile_after: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&lockfile_path).unwrap()).unwrap();
+    let still_has_git_entry = lockfile_after["skills"]
+        .as_object()
+        .unwrap()
+        .values()
+        .any(|v| v["source_name"].as_str() == Some("myrepo"));
+    assert!(
+        still_has_git_entry,
+        "REGRESSION: lockfile after `tome remove local` is missing myrepo entries — \
+         git-sourced skills were silently dropped during regen. Lockfile: {lockfile_after}"
+    );
+}
+```
+
+**Implementation notes:**
+- `sha2` is already a dependency of the crate (used by `git::repo_cache_dir`); if the `tests/cli.rs` integration test crate cannot import it, swap to a hard-coded SHA-256 hex string for the dummy URL (compute once with `echo -n 'https://example.invalid/myrepo.git' | shasum -a 256` and embed). Prefer the runtime computation.
+- If the hardcoded sha route is needed, add a brief comment with the source URL so future readers know it's reproducible.
+- The fixture relies on `sync`'s offline cache-reuse behavior (`already_cloned == true` branch in `resolve_git_directories`). If sync requires a real `.git` directory inside the cache, simulate one with `git init` in the test (mirror the existing `read_head_sha_returns_40_char_hex` test in `git.rs`).
+- If the test fails because `sync` insists on running `git fetch` or `git clone` against the dummy URL, prefer adding a `git init` + initial commit inside `cache_dir` to satisfy `read_head_sha`. Do NOT mock the network.
+
+Run: `cargo test -p tome --test cli remove_preserves_git_lockfile_entries`
+  </action>
+  <verify>
+    <automated>cargo test -p tome --test cli remove_preserves_git_lockfile_entries</automated>
+  </verify>
+  <acceptance_criteria>
+    - `cargo test -p tome --test cli remove_preserves_git_lockfile_entries` passes.
+    - Removing the test's call to `lockfile::resolved_paths_from_lockfile_cache` (e.g., reverting Task 2 only) makes this test FAIL with the "REGRESSION:" assertion message — confirms it actually exercises the bug. (Manual sanity check, not a CI gate.)
+    - `make ci` passes.
+  </acceptance_criteria>
+  <done>
+    Integration test passes and provably guards #461 H1. `make ci` is green.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- `cargo test -p tome lockfile::tests::resolved_paths_from_lockfile_cache_` — all 6 unit tests pass.
+- `cargo test -p tome --test cli remove_preserves_git_lockfile_entries` — integration test passes.
+- `rg -n "let resolved_paths = std::collections::BTreeMap::new\(\);" crates/tome/src/lib.rs` — zero matches.
+- `rg -n "lockfile::resolved_paths_from_lockfile_cache" crates/tome/src/lib.rs` — exactly 3 matches.
+- `make ci` — clean.
+</verification>
+
+<success_criteria>
+- The three regen sites in Remove/Reassign/Fork no longer pass an empty `BTreeMap` to `discover::discover_all`.
+- The lockfile regenerated by destructive commands preserves `source_name` entries for git-type directories whose cache exists on disk.
+- When the previous lockfile or cache is missing, the user sees a per-directory `warning:` line on stderr — silent drop is replaced with surfaced warning.
+- No new network operations on `tome remove`/`reassign`/`fork`.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-01-SUMMARY.md` recording: helper signature, three lib.rs call-site lines, integration-test name, and a one-line note that HOTFIX-01 / #461 H1 is closed.
+</output>

--- a/.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-02-SUMMARY.md
+++ b/.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-02-SUMMARY.md
@@ -1,0 +1,129 @@
+---
+phase: 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain
+plan: 02
+subsystem: cli-handler
+tags: [remove, save-chain, partial-failure, retention, hotfix, "#461"]
+
+# Dependency graph
+requires:
+  - phase: 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain
+    provides: "lockfile::resolved_paths_from_lockfile_cache helper wired into Command::Remove (Plan 01) — the save chain we reorder around"
+provides:
+  - "Reordered Command::Remove handler: ⚠ partial-failure block fires BEFORE config.save / manifest::save / lockfile regen"
+  - "Disk-state retention guarantee on partial-failure path — config / manifest / lockfile bytes unchanged when remove::execute returns failures"
+  - "Integration test guard for #461 H2 (remove_partial_failure_does_not_save_disk_state)"
+affects: ["08.1-03-failure-summary-reword", "v0.8.1 release"]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Early-return-before-save: surface aggregated failure messaging before any disk-write ? can mask it. Pairs with the existing in-memory retention contract in remove::execute (which leaves config/manifest pre-mutation on failure) — now extended to disk."
+
+key-files:
+  created: []
+  modified:
+    - "crates/tome/src/lib.rs (Command::Remove handler — moved if !result.failures.is_empty() block from after lockfile::save up to immediately after remove::execute; updated leading comment to reflect new ordering rationale)"
+    - "crates/tome/tests/cli.rs (added remove_partial_failure_does_not_save_disk_state integration test — byte-for-byte snapshot equality of tome.toml / .tome-manifest.json / tome.lock pre- vs post-remove under chmod 0o500 partial-failure)"
+
+key-decisions:
+  - "Tolerate missing tome.lock with unwrap_or_default(): tome sync --no-triage in a no-git config may not write tome.lock, but byte-equality of two empty Vecs still proves the contract"
+  - "Restored Task 1 reorder via `git checkout HEAD -- lib.rs` after sanity-check (rather than re-editing) so the working-tree state matches the committed Task 1 verbatim"
+
+patterns-established:
+  - "Integration tests for save-chain ordering: snapshot file bytes pre- and post-command; assert_eq! is the strongest possible 'no disk mutation' assertion (catches even comment / formatting / re-emit drift)"
+
+requirements-completed: [HOTFIX-02]
+
+# Metrics
+duration: 4min
+completed: 2026-04-26
+---
+
+# Phase 08.1 Plan 02: Remove Save-Chain Reorder Summary
+
+**The `if !result.failures.is_empty() { ... return Err(...); }` block in `Command::Remove` now fires immediately after `remove::execute(...)?` and BEFORE `config.save` / `manifest::save` / `discover_all` / `lockfile::save` — closing #461 H2 by guaranteeing the user always sees the I2/I3 retention messaging on partial-failure, even when a save-chain step would have errored.**
+
+## Performance
+
+- **Duration:** ~4 min (218 s wall)
+- **Started:** 2026-04-26T12:36:02Z
+- **Completed:** 2026-04-26T12:39:40Z
+- **Tasks:** 2 / 2
+- **Files modified:** 2
+
+## Accomplishments
+
+- **Reorder.** In `crates/tome/src/lib.rs::run` `Command::Remove` arm, moved the partial-failure early-return block:
+  - **Before (HEAD~2 / pre-Plan-02):** `lib.rs:415` — block sat AFTER `lockfile::save(&lockfile, paths.config_dir())?;` (line 407 pre-move). If any of `config.save` (line 394), `manifest::save` (line 396), `discover::discover_all` (line 402), or `lockfile::save` (line 407) returned `Err`, `?` propagated and the user only saw a bare disk-write error — never the ⚠ block.
+  - **After (Task 1):** `lib.rs:402` — block sits between `let result = remove::execute(&plan, &mut config, &mut manifest, false)?;` (line 391) and `config.save(&paths.config_path())?;` (line 429). Block body is byte-identical (same `eprintln!`, same `FailureKind::ALL` iteration, same `anyhow::anyhow!("remove completed with {k} failures")` return).
+  - **Comment update.** Replaced the "Surface partial-cleanup failures FIRST so they can't be hidden by a ✓ success banner above them" comment (which described the old success-banner-vs-warning-block trade-off) with a comment explaining the new ordering rationale: that `?` propagation in the save chain would otherwise mask the ⚠ block, AND that the early return correctly leaves `config`/`manifest` un-persisted on the failure path because `remove::execute` deliberately leaves them pre-mutation in-memory.
+- **Integration test (`remove_partial_failure_does_not_save_disk_state`).** Added in `crates/tome/tests/cli.rs:3461`, immediately after `remove_partial_failure_exits_nonzero_with_warning_marker`. Reuses the same `chmod 0o500` fixture, snapshots `tome.toml` / `.tome-manifest.json` / `tome.lock` bytes pre- and post-remove, and asserts byte-for-byte equality. Tolerates `tome.lock` not being created by `tome sync --no-triage` via `unwrap_or_default()`. Manually verified the test FAILS on the `tome.toml mutated` assertion when Task 1's reorder is reverted (decoded byte diff showed `exclude = []` and a `[backup]` section appended by the now-running `config.save`), then restored Task 1 and re-confirmed PASS — proving the test actually exercises HOTFIX-02.
+
+## Task Commits
+
+1. **Task 1: Reorder Command::Remove save chain so ⚠ block fires before saves** — `e3a5058` (fix)
+2. **Task 2: Integration test — partial-failure path writes nothing to disk** — `710dc37` (test)
+
+## Files Created/Modified
+
+- `crates/tome/src/lib.rs` — Reordered the `Command::Remove` arm (around line 389–456):
+  - **Before-move source:** `lib.rs:415` (block AFTER `lockfile::save` at line 407)
+  - **After-move source:** `lib.rs:402` (block immediately after `remove::execute` at line 391, before `config.save` at line 429)
+  - **Comment text used:**
+    ```rust
+    // Surface partial-cleanup failures BEFORE the save chain. If any of
+    // config.save / manifest::save / discover_all / lockfile::save returns
+    // Err, `?` would otherwise propagate and the user would only see a
+    // disk-write error — never the ⚠ block or the I2/I3 retention messaging
+    // ("config entry and manifest retained so you can retry"). Returning
+    // here also means in-memory mutations to `config` and `manifest` are
+    // never persisted on the failure path, which is correct: remove::execute
+    // deliberately leaves them in their pre-mutation state when failures
+    // occur, so the disk state on retry matches the in-memory state.
+    ```
+- `crates/tome/tests/cli.rs` — Added `remove_partial_failure_does_not_save_disk_state` test (lines 3461–3567). 107 lines including the doc-comment, fixture, snapshot reads, partial-failure trigger, restoration of permissions, and three assert_eq! byte-equality checks.
+
+## Decisions Made
+
+- **Tolerate missing `tome.lock` via `unwrap_or_default()`**: The plan flagged that `tome sync --no-triage` in a no-git config may not produce `tome.lock`. Reading bytes via `read(...).unwrap_or_default()` returns an empty `Vec` in that case, and `assert_eq!(empty, empty)` still proves the byte-equality contract (missing-then-missing is also "no mutation").
+- **Restore Task 1 via `git checkout HEAD -- lib.rs` after the sanity check**, not by hand-editing back: cleaner — the working tree exactly matches the Task 1 commit byte-for-byte, no risk of typos or whitespace drift between the two states.
+- **Wording change in `eprintln!` deliberately deferred**: Per the plan's strict scope, Task 1 only moved the block. The user-facing message ("⚠ N operations failed during remove of '{name}' — config entry and manifest retained ...") is Plan 03's job. Verified the moved block still emits exactly the substrings the existing `remove_partial_failure_exits_nonzero_with_warning_marker` test asserts on (`⚠`, `operations failed`, `remove completed with`, `retained`/`retry`).
+
+## Deviations from Plan
+
+None — plan executed exactly as written. Both tasks completed in spec, both verifications passed without auto-fixes.
+
+## Issues Encountered
+
+- **`backup::tests::list_returns_entries` flaked under `make ci` once.** Re-running `make ci` produced a clean pass. This is the same module as the documented flake `backup::tests::push_and_pull_roundtrip` (called out in `.planning/PROJECT.md` backlog: "Pre-existing flaky test ... passes in isolation, intermittent in full suite"). Confirmed unrelated to HOTFIX-02 by passing in isolation: `cargo test -p tome --lib backup::tests::list_returns_entries → ok`. Out of scope per the executor's SCOPE BOUNDARY rule; not adding to deferred-items because it's already tracked under the broader `backup::tests::*` flake entry.
+- **`make ci` initially failed at the `typos` step** because `typos` (installed at `~/.cargo/bin/typos` per Wave 1) wasn't on `make`'s PATH. Re-ran with `PATH="$HOME/.cargo/bin:$PATH" make ci` — clean. Same environment quirk Wave 1 hit; not a code issue.
+
+## User Setup Required
+
+None — pure code change, no external services.
+
+## Next Phase Readiness
+
+- **HOTFIX-02 / #461 H2 closed**: regenerated lockfile + manifest + config bytes are unchanged on the partial-failure path; user always sees the ⚠ retention messaging before any save-chain `?` can mask it.
+- **Plan 03 ready to start**: HOTFIX-03 (failure-summary wording) is the only remaining plan in this phase. It's independent of Plan 02 — Plan 03 reworks the `eprintln!` text, while Plan 02 only relocated the block. No coupling.
+- **`make ci` green** (after PATH workaround for typos): 463 unit tests + 125 integration tests + clippy `-D warnings` + fmt-check + typos. (One pre-existing flake in `backup::tests::*` re-run cleared.)
+
+## Self-Check
+
+Verified at end of execution:
+
+- `crates/tome/src/lib.rs` line 402 contains `if !result.failures.is_empty()` (the moved block) — FOUND
+- `rg -n "result\.failures\.is_empty" crates/tome/src/lib.rs` returns exactly 1 match — VERIFIED
+- `crates/tome/tests/cli.rs` contains `remove_partial_failure_does_not_save_disk_state` — FOUND
+- Commits `e3a5058`, `710dc37` exist on `gsd/phase-08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain` — FOUND
+- `cargo test -p tome --test cli remove_partial_failure` — both tests PASS (2/2)
+- Sanity check: reverting Task 1 in-tree caused `remove_partial_failure_does_not_save_disk_state` to FAIL on the `tome.toml mutated` assertion; restoring Task 1 brought the test back to PASS — proves the test exercises HOTFIX-02
+- `make ci` (with `~/.cargo/bin` in PATH): all checks passed — VERIFIED
+
+## Self-Check: PASSED
+
+---
+*Phase: 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain*
+*Plan: 02*
+*Completed: 2026-04-26*

--- a/.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-02-hotfix-02-remove-save-chain-reorder-PLAN.md
+++ b/.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-02-hotfix-02-remove-save-chain-reorder-PLAN.md
@@ -1,0 +1,336 @@
+---
+phase: 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain
+plan: 02
+type: execute
+wave: 2
+depends_on: ["08.1-01"]
+files_modified:
+  - crates/tome/src/lib.rs
+  - crates/tome/tests/cli.rs
+autonomous: true
+requirements: [HOTFIX-02]
+issue: "https://github.com/MartinP7r/tome/issues/461 (H2)"
+
+must_haves:
+  truths:
+    - "When `remove::execute` returns with non-empty `failures`, the user sees the `⚠ N operations failed ... retained ... retry` block on stderr BEFORE any save-chain error can preempt it"
+    - "When `remove::execute` returns with non-empty `failures`, no save-chain side effect (config / manifest / lockfile) is written to disk"
+    - "The success-path (full cleanup, empty failures) still saves config, manifest, and lockfile, and prints the ✓ banner — i.e., this fix does NOT regress the happy path"
+  artifacts:
+    - path: "crates/tome/src/lib.rs"
+      provides: "Reordered `Command::Remove` handler — partial-failure block fires immediately after `remove::execute(...)?` and BEFORE `config.save` / `manifest::save` / lockfile regen"
+      contains: "if !result.failures.is_empty()"
+    - path: "crates/tome/tests/cli.rs"
+      provides: "Integration test that proves the ⚠ block is printed AND no manifest/lockfile is written under partial-failure"
+      contains: "remove_partial_failure_does_not_save_disk_state"
+  key_links:
+    - from: "crates/tome/src/lib.rs Command::Remove handler"
+      to: "the `if !result.failures.is_empty()` early-return block"
+      via: "moved BEFORE `config.save(&paths.config_path())?`"
+      pattern: "result\\.failures\\.is_empty\\(\\)"
+---
+
+<objective>
+Honor the I2/I3 retention contract under partial-failure. When `remove::execute` returns with `failures.is_empty() == false`, surface the ⚠ block and return Err **before** running any save chain — so the user always sees the retry-safe messaging, regardless of whether `config.save` / `manifest::save` / `discover_all` / `lockfile::save` succeeds.
+
+**Bug (H2, #461):** Today, `lib.rs` Command::Remove unconditionally runs the save chain (config → manifest → discover → lockfile) before checking `result.failures`. If any save step returns `Err`, `?` propagates and the user only sees the bare anyhow message — never the `⚠ N operations failed ... retained ... retry` block. The retention guarantee in `remove.rs`'s I2/I3 comments ("user can re-run `tome remove <name>` after addressing the underlying cause") only holds when the save chain succeeds. Under disk-permission failure, the user has no idea retry is safe.
+
+**Fix:** Move the `if !result.failures.is_empty() { eprintln!(...); return Err(...); }` block to fire IMMEDIATELY after `remove::execute(...)?` returns — BEFORE any save-chain `?` can mask it. On the failure path, no disk writes happen at all (in-memory `config`/`manifest` mutations are preserved by `remove::execute`, but they never hit disk).
+
+This plan is Remove-specific. Reassign/Fork do not have a `failures` aggregation (they use a different `reassign::execute` that returns `()` on success); they are out of scope.
+
+Purpose: Closes #461 H2.
+Output: Reordered handler + 1 integration test.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+
+@crates/tome/src/lib.rs
+@crates/tome/src/remove.rs
+@crates/tome/tests/cli.rs
+
+<interfaces>
+From `crates/tome/src/remove.rs`:
+```rust
+pub(crate) struct RemoveResult {
+    pub symlinks_removed: usize,
+    pub library_entries_removed: usize,
+    pub git_cache_removed: bool,
+    pub failures: Vec<RemoveFailure>,
+}
+pub(crate) fn execute(
+    plan: &RemovePlan,
+    config: &mut Config,
+    manifest: &mut Manifest,
+    dry_run: bool,
+) -> Result<RemoveResult>;
+```
+On `failures.is_empty() == false`, `execute` deliberately leaves `config` and `manifest` UNCHANGED in-memory for the retained directory (per the existing comments in remove.rs around the I2/I3 retention gate). The handler must therefore NOT save them in the failure path either.
+
+Current shape (`crates/tome/src/lib.rs:389-437`):
+```rust
+let result = remove::execute(&plan, &mut config, &mut manifest, false)?;
+
+config.save(&paths.config_path())?;       // (A)
+manifest::save(&manifest, paths.config_dir())?;   // (B)
+
+let (resolved_paths, mut regen_warnings) =
+    lockfile::resolved_paths_from_lockfile_cache(&config, &paths);   // (after Plan 01)
+let skills = discover::discover_all(&config, &resolved_paths, &mut regen_warnings)?;  // (C)
+for w in &regen_warnings { eprintln!("warning: {}", w); }
+let lockfile = lockfile::generate(&manifest, &skills);
+lockfile::save(&lockfile, paths.config_dir())?;   // (D)
+
+if !result.failures.is_empty() { /* ⚠ block + return Err */ }
+println!("✓ Removed ...");
+```
+
+Target shape:
+```rust
+let result = remove::execute(&plan, &mut config, &mut manifest, false)?;
+
+// I2/I3 retention contract: surface partial-failure BEFORE the save chain so a
+// disk-write error in (A)-(D) cannot mask the ⚠ block. On failure path,
+// in-memory mutations are preserved by execute() and never hit disk.
+if !result.failures.is_empty() {
+    /* ⚠ block ... return Err */
+}
+
+config.save(&paths.config_path())?;       // (A)
+manifest::save(&manifest, paths.config_dir())?;   // (B)
+let (resolved_paths, mut regen_warnings) =
+    lockfile::resolved_paths_from_lockfile_cache(&config, &paths);
+let skills = discover::discover_all(&config, &resolved_paths, &mut regen_warnings)?;
+for w in &regen_warnings { eprintln!("warning: {}", w); }
+let lockfile = lockfile::generate(&manifest, &skills);
+lockfile::save(&lockfile, paths.config_dir())?;
+
+println!("✓ Removed ...");
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Reorder Command::Remove save chain so ⚠ block fires before saves</name>
+  <files>crates/tome/src/lib.rs</files>
+  <read_first>
+    - crates/tome/src/lib.rs lines 389–451 (current Remove handler — full save chain + ⚠ block + ✓ banner)
+    - crates/tome/src/remove.rs lines 90–180 (RemoveResult / RemoveFailure / FailureKind contract)
+    - The existing test `remove_partial_failure_exits_nonzero_with_warning_marker` in `crates/tome/tests/cli.rs:3377` (must still pass after the reorder)
+  </read_first>
+  <action>
+In `crates/tome/src/lib.rs`, inside the `Command::Remove { ... }` arm (around lines 389–451):
+
+**Step 1 — Cut the entire `if !result.failures.is_empty() { ... return Err(...); }` block** (currently lines ~407–437). This is the block that builds the ⚠ summary, iterates `FailureKind::ALL`, prints per-kind groups, and returns `Err(anyhow::anyhow!("remove completed with {k} failures"))`.
+
+**Step 2 — Paste the block immediately after `let result = remove::execute(&plan, &mut config, &mut manifest, false)?;`** (currently around line 391). It must fire BEFORE `config.save(&paths.config_path())?;` (line ~394).
+
+**Step 3 — Update the leading comment** on the moved block to reflect that it now fires *before* the save chain. The current comment (lines ~407–412) starts with:
+```
+// Surface partial-cleanup failures FIRST so they can't be
+// hidden by a ✓ success banner above them ...
+```
+Replace it with:
+```rust
+// Surface partial-cleanup failures BEFORE the save chain. If any of
+// config.save / manifest::save / discover_all / lockfile::save returns
+// Err, `?` would otherwise propagate and the user would only see a
+// disk-write error — never the ⚠ block or the I2/I3 retention messaging
+// ("config entry and manifest retained so you can retry"). Returning
+// here also means in-memory mutations to `config` and `manifest` are
+// never persisted on the failure path, which is correct: remove::execute
+// deliberately leaves them in their pre-mutation state when failures
+// occur, so the disk state on retry matches the in-memory state.
+```
+
+**Step 4 — Verify the body of the moved block is unchanged** (other than the comment). It MUST still print:
+- The leading line: `⚠ {k} operations failed during remove of '{name}' — config entry and manifest retained so you can retry after addressing these. Run \`tome doctor\`:` (Plan 03 will reword this in Wave 3 — DO NOT touch the wording in this plan.)
+- Per-kind groups via `crate::remove::FailureKind::ALL.iter()`.
+- `return Err(anyhow::anyhow!("remove completed with {k} failures"));`
+
+**Step 5 — Verify the success path is intact:** after the moved block, the code MUST in order: `config.save(...)?` → `manifest::save(...)?` → `lockfile::resolved_paths_from_lockfile_cache(...)` → `discover::discover_all(...)?` → for-loop over `regen_warnings` → `lockfile::generate(...)` → `lockfile::save(...)?` → `println!("\n✓ Removed directory ...")`.
+
+**Do NOT touch:**
+- Reassign or Fork handlers (different failure model — out of scope for HOTFIX-02).
+- The wording inside the `eprintln!` (Plan 03 will handle that).
+- The `remove::execute` function or anything in `remove.rs`.
+
+Run: `cargo build -p tome && cargo test -p tome --test cli remove_partial_failure_exits_nonzero_with_warning_marker`
+  </action>
+  <verify>
+    <automated>cargo build -p tome 2>&1 | tail -10 && cargo test -p tome --test cli remove_partial_failure_exits_nonzero_with_warning_marker</automated>
+  </verify>
+  <acceptance_criteria>
+    - In `crates/tome/src/lib.rs`, between the line `let result = remove::execute(&plan, &mut config, &mut manifest, false)?;` and the line `config.save(&paths.config_path())?;`, there is exactly one occurrence of `if !result.failures.is_empty()` (the moved block).
+    - There is NO `if !result.failures.is_empty()` block AFTER the `lockfile::save(&lockfile, paths.config_dir())?;` line. Verify with `rg -n "result\.failures\.is_empty" crates/tome/src/lib.rs` — exactly 1 match.
+    - `cargo build -p tome` is clean.
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+    - The existing test `remove_partial_failure_exits_nonzero_with_warning_marker` still passes (proves the failure-path stderr output still contains `⚠`, `operations failed`, `remove completed with`, and `retained`/`retry`).
+  </acceptance_criteria>
+  <done>
+    The ⚠ block fires immediately after `remove::execute` returns and before any save-chain step. Existing partial-failure test still passes. Build is green.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Integration test — partial-failure path writes nothing to disk</name>
+  <files>crates/tome/tests/cli.rs</files>
+  <read_first>
+    - crates/tome/tests/cli.rs lines 3370–3460 (existing `remove_partial_failure_exits_nonzero_with_warning_marker` — extend its fixture pattern)
+    - crates/tome/tests/cli.rs lines 1–80 (test helpers)
+    - crates/tome/src/manifest.rs lines 1–50 (manifest file path naming — confirm it's `.tome-manifest.json` in `paths.config_dir()`)
+  </read_first>
+  <action>
+Add a new integration test in `crates/tome/tests/cli.rs`, immediately after `remove_partial_failure_exits_nonzero_with_warning_marker` (around line 3460).
+
+The test reuses the same `chmod 0o500` fixture (so `remove::execute` returns with `failures.is_empty() == false`) and asserts:
+1. The CLI exits non-zero.
+2. Stderr contains the `⚠` and `operations failed` markers.
+3. The pre-remove `tome.toml`, `.tome-manifest.json`, and `tome.lock` snapshots match the post-remove snapshots **byte-for-byte** — i.e., the failure path wrote nothing to disk.
+
+```rust
+#[cfg(unix)]
+#[test]
+fn remove_partial_failure_does_not_save_disk_state() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // HOTFIX-02 / #461 H2: with the save chain reordered, a partial-failure
+    // path must NOT mutate config / manifest / lockfile on disk. The user
+    // retains a clean retry surface — no half-saved state.
+    let tmp = TempDir::new().unwrap();
+    let skills_dir = tmp.path().join("skills");
+    create_skill(&skills_dir, "my-skill");
+
+    let target_dir = tmp.path().join("target");
+    std::fs::create_dir_all(&target_dir).unwrap();
+
+    remove_test_env(
+        &tmp,
+        &format!(
+            "[directories.local]\npath = \"{}\"\ntype = \"directory\"\nrole = \"source\"\n\n[directories.test-target]\npath = \"{}\"\ntype = \"directory\"\nrole = \"target\"\n",
+            skills_dir.display(),
+            target_dir.display()
+        ),
+    );
+
+    // Prime library + target.
+    tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "sync",
+            "--no-triage",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+
+    // Snapshot pre-remove disk state.
+    let config_path = tmp.path().join("tome.toml");
+    let manifest_path = tmp.path().join(".tome-manifest.json");
+    let lockfile_path = tmp.path().join("tome.lock");
+
+    let config_before = std::fs::read(&config_path).unwrap();
+    let manifest_before = std::fs::read(&manifest_path).unwrap();
+    let lockfile_before = std::fs::read(&lockfile_path).unwrap();
+
+    // Trigger partial-failure: chmod 0o500 the target dir so step-1 unlink fails.
+    std::fs::set_permissions(&target_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+    let output = tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "remove",
+            "local",
+            "--force",
+        ])
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+
+    // Restore permissions BEFORE assertions (TempDir::drop cleanup).
+    std::fs::set_permissions(&target_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    // 1. CLI exits non-zero.
+    assert!(
+        !output.status.success(),
+        "remove should fail under chmod 0o500, got status: {:?}",
+        output.status,
+    );
+
+    // 2. Stderr has the ⚠ block (proves the moved block fired BEFORE save).
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("⚠"), "missing ⚠ marker in stderr: {stderr}");
+    assert!(
+        stderr.contains("operations failed"),
+        "missing 'operations failed' in stderr: {stderr}"
+    );
+
+    // 3. Disk state is unchanged byte-for-byte.
+    let config_after = std::fs::read(&config_path).unwrap();
+    let manifest_after = std::fs::read(&manifest_path).unwrap();
+    let lockfile_after = std::fs::read(&lockfile_path).unwrap();
+    assert_eq!(
+        config_before, config_after,
+        "tome.toml mutated on partial-failure path (HOTFIX-02 regression)"
+    );
+    assert_eq!(
+        manifest_before, manifest_after,
+        ".tome-manifest.json mutated on partial-failure path (HOTFIX-02 regression)"
+    );
+    assert_eq!(
+        lockfile_before, lockfile_after,
+        "tome.lock mutated on partial-failure path (HOTFIX-02 regression)"
+    );
+}
+```
+
+**Implementation notes:**
+- If `tome.lock` is not created by `tome sync --no-triage` in the test env (because the lockfile-save in sync is gated on something), check whether the file exists before the snapshot and `unwrap_or_default()` the read. The integrity check still works on missing-then-missing.
+- The exact manifest filename is `.tome-manifest.json` per `manifest.rs`. Confirm by reading `manifest.rs` if uncertain.
+- Do NOT delete or modify the existing `remove_partial_failure_exits_nonzero_with_warning_marker` test — it covers a different behavior (stderr content) and stays as a regression guard.
+
+Run: `cargo test -p tome --test cli remove_partial_failure_does_not_save_disk_state`
+  </action>
+  <verify>
+    <automated>cargo test -p tome --test cli remove_partial_failure_does_not_save_disk_state</automated>
+  </verify>
+  <acceptance_criteria>
+    - `cargo test -p tome --test cli remove_partial_failure_does_not_save_disk_state` passes.
+    - `cargo test -p tome --test cli remove_partial_failure` runs at least 2 tests (existing + new), all pass.
+    - Reverting Task 1's reorder (move the ⚠ block back to its original position) makes this test FAIL on the `assert_eq!(manifest_before, manifest_after, ...)` line — confirms it actually exercises HOTFIX-02. (Manual sanity check.)
+  </acceptance_criteria>
+  <done>
+    Integration test passes and proves the failure path does not mutate disk. Combined with `remove_partial_failure_exits_nonzero_with_warning_marker`, the I2/I3 retention contract is now testably enforced.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- `cargo test -p tome --test cli remove_partial_failure` — both tests pass.
+- `rg -n "result\.failures\.is_empty" crates/tome/src/lib.rs` returns exactly 1 match.
+- `make ci` — clean.
+</verification>
+
+<success_criteria>
+- The ⚠ block in `Command::Remove` fires immediately after `remove::execute` returns and BEFORE the save chain.
+- Partial-failure path leaves `tome.toml`, `.tome-manifest.json`, and `tome.lock` byte-identical on disk.
+- The success path still saves all three files and prints `✓ Removed directory ...`.
+- Both `remove_partial_failure_*` integration tests pass.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-02-SUMMARY.md` recording: file:line of the moved block (before/after), comment text used, integration-test name, and a one-line note that HOTFIX-02 / #461 H2 is closed.
+</output>

--- a/.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-03-SUMMARY.md
+++ b/.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-03-SUMMARY.md
@@ -1,0 +1,130 @@
+---
+phase: 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain
+plan: 03
+subsystem: cli-handler
+tags: [remove, partial-failure, wording, hotfix, "#461", v0.8.1]
+
+# Dependency graph
+requires:
+  - phase: 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain
+    provides: "Plan 02's reordered ⚠ block at lib.rs:402 — the call site whose leading `eprintln!` we reworded"
+provides:
+  - "Reworded partial-failure leading line: ends with `Run \\`tome doctor\\` after resolving:` so the trailing colon unambiguously introduces the per-kind listing instead of falsely promising `tome doctor` output"
+  - "Integration-test guard for #461 H3 (remove_failure_summary_wording) — asserts new wording present, old misleading fragment absent, doctor hint still surfaced"
+affects: ["v0.8.1 release — phase 08.1 complete, ready for `make release VERSION=0.8.1`"]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Punctuation as documentation: when a colon follows a sentence in user-facing CLI output, what comes next must be the thing the colon introduces (the listing) — not a separate call-to-action that just happens to be the last word before it"
+
+key-files:
+  created: []
+  modified:
+    - "crates/tome/src/lib.rs (Command::Remove ⚠ block leading eprintln! at lines 404-411 — single format-string wording change; the four format args, per-kind loop, and anyhow! return are unchanged)"
+    - "crates/tome/tests/cli.rs (added remove_failure_summary_wording integration test at lines 3568–3651 — chmod 0o500 fixture asserts on stderr substrings)"
+
+key-decisions:
+  - "Reword inline (single format-string change) over the terminal-line alternative (move `Run \\`tome doctor\\` to inspect.` to a final line after the listing): keeps the call-to-action close to the headline (most users skim only the first line), single-line diff is lower risk for a hotfix, and the colon now correctly belongs to the listing it introduces"
+  - "Use NO_COLOR=1 in the new test (consistent with the existing partial-failure test family) so the styled `tome doctor` renders as the literal `\\`tome doctor\\`` (with backticks but no ANSI), making the negative-assertion substring match reliably"
+
+patterns-established:
+  - "Stderr-wording integration tests: positive (new fragment present) + negative (old fragment absent) + sentinel (call-to-action survived) — three short assertions per wording fix gives both a regression guard and a forward guard against accidental call-to-action drops"
+
+requirements-completed: [HOTFIX-03]
+
+# Metrics
+duration: 2min 20s
+completed: 2026-04-26
+---
+
+# Phase 08.1 Plan 03: Failure-Summary Reword Summary
+
+**The leading line of `Command::Remove`'s partial-failure ⚠ block now ends with `Run \`tome doctor\` after resolving:` — the trailing colon unambiguously introduces the per-kind listing that follows, instead of falsely promising `tome doctor` output. Closes #461 H3, the final correctness/UX finding from the post-merge review of PR #460. Phase 08.1 is complete; v0.8.1 is ready for `make release VERSION=0.8.1`.**
+
+## Performance
+
+- **Duration:** ~2 min 20 s wall (3 commits)
+- **Started:** 2026-04-26T12:42:59Z
+- **Completed:** 2026-04-26T12:45:19Z
+- **Tasks:** 2 / 2 (plus one fmt-fix commit auto-applied to clear `make ci`)
+- **Files modified:** 2
+
+## Accomplishments
+
+- **Reword (Task 1).** In `crates/tome/src/lib.rs` (`Command::Remove` arm, ⚠ block at line 402 from Plan 02), changed the leading `eprintln!` format string at lines 404–411:
+  - **Before:** `"... config entry and manifest retained so you can retry after addressing these. Run {}:"` — the trailing `:` looked like it introduced `tome doctor`'s output, but what followed was the per-kind grouping (`Distribution symlinks (N): ...`).
+  - **After:** `"... config entry and manifest retained so you can retry after addressing these. Run {} after resolving:"` — the colon now unambiguously introduces the listing. The four format args, the per-kind loop, the `eprintln!("  {} ({}):", kind.label(), group.len())`, and the `return Err(anyhow::anyhow!("remove completed with {k} failures"))` are all byte-identical to Plan 02.
+  - Verified existing `remove_partial_failure_exits_nonzero_with_warning_marker` and `remove_partial_failure_does_not_save_disk_state` tests still pass — neither asserts on the changed clause; both assert on `⚠`, `operations failed`, `remove completed with`, `retained`/`retry` (all preserved).
+- **Integration test (`remove_failure_summary_wording`).** Added in `crates/tome/tests/cli.rs:3568–3651`, immediately after `remove_partial_failure_does_not_save_disk_state`. Reuses the same `chmod 0o500` fixture as the existing partial-failure tests, then asserts on three substrings of the captured stderr:
+  - **Positive:** `stderr.contains("after resolving:")` — new wording is present.
+  - **Sentinel:** `stderr.contains("tome doctor")` — call-to-action still surfaced.
+  - **Negative:** `!stderr.contains("addressing these. Run \`tome doctor\`:")` — old misleading wording is gone.
+  - With `NO_COLOR=1`, `console::style(...).bold()` is a no-op, so `\`tome doctor\`` (with backticks from the format string) appears verbatim — the negative substring match is reliable.
+
+## Task Commits
+
+1. **Task 1: Reword Command::Remove ⚠ leading line to end with "after resolving:"** — `8fb3c46` (fix)
+2. **Task 2: Integration test for partial-failure summary wording** — `2ad7c60` (test)
+3. **Fmt fix: rustfmt wrap of assert! call in remove_failure_summary_wording** — `5705e3d` (style; auto-applied to clear `make ci`'s fmt-check gate)
+
+## Files Created/Modified
+
+- `crates/tome/src/lib.rs` — Single format-string change in the `Command::Remove` ⚠ block.
+  - **File:line:** lines 404–411 (the leading `eprintln!` in `if !result.failures.is_empty() { ... }`)
+  - **Diff:** 1 line removed (`manifest retained so you can retry after addressing these. Run {}:"`), 2 lines added (`manifest retained so you can retry after addressing these. \\` and `Run {} after resolving:"`).
+- `crates/tome/tests/cli.rs` — Added `remove_failure_summary_wording` test (84 lines including doc-comment, fixture, partial-failure trigger, permission restoration, and three substring assertions).
+
+## Decisions Made
+
+- **Inline reword over terminal-line alternative.** #461 H3 listed two fix options. Plan picked inline — keeps the call-to-action close to the headline (single-line skim), single-line diff is lower risk for a hotfix, and the colon now correctly belongs to the listing it introduces. The terminal-line variant ("move `Run \`tome doctor\` to inspect.` to a final line *after* the listing") would require a second `eprintln!` after the loop and would split the call-to-action away from the headline.
+- **`NO_COLOR=1` in the new test.** Matches the `remove_partial_failure_exits_nonzero_with_warning_marker` and `remove_partial_failure_does_not_save_disk_state` family pattern. Without `NO_COLOR=1`, the `console::style(...).bold()` wrapper would emit ANSI escapes (`\\x1b[1m\`tome doctor\`\\x1b[0m`) and the negative-assertion substring `addressing these. Run \`tome doctor\`:` would not match the styled rendering — the test would silently always pass. With `NO_COLOR=1`, both branches assert against the same plain-text rendering.
+- **Three assertions, not two.** The plan specified positive (`after resolving:`) + negative (old fragment absent) + sentinel (`tome doctor` still present). Kept all three: the sentinel guards against accidentally dropping the call-to-action in some future refactor; the negative guards against accidentally re-introducing the old misleading wording; the positive guards against accidentally reverting Task 1.
+
+## Deviations from Plan
+
+- **[Rule 3 - Blocking] Auto-applied `cargo fmt` after Task 2.** The plan's literal test snippet had `assert!(!output.status.success(), "remove should fail under chmod 0o500");` on a single line. `cargo fmt`'s `make ci` gate insisted on the multi-line form. Ran `cargo fmt`, committed as `5705e3d` (style commit, separate from the test commit so the original Task 2 commit matches the plan verbatim). No semantic change — the assertion condition and message are identical.
+
+## Issues Encountered
+
+- **`make ci` initially failed at fmt-check.** Fixed via `cargo fmt` + a separate `style(08.1-03)` commit. Same wrap-line-on-long-message pattern that bites short asserts; informational only.
+- **`typos` PATH workaround still needed.** Same as Plans 01 and 02 — `typos` is installed at `~/.cargo/bin/typos` but `make ci`'s default `PATH` doesn't include it. Used `PATH="$HOME/.cargo/bin:$PATH" make ci`. Not a code issue; tracked under the same Wave 1 environment quirk.
+
+## User Setup Required
+
+None — pure code change, no external services.
+
+## Next Phase Readiness
+
+- **HOTFIX-03 / #461 H3 closed.** The leading line of the partial-failure summary is reworded, the misleading fragment is gone, and the wording is locked in by `remove_failure_summary_wording`.
+- **Phase 08.1 complete.** All three v0.8.1 hotfix plans are merged on `gsd/phase-08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain`:
+  - **Plan 01 (HOTFIX-01 / #461 H1):** offline lockfile-as-cache helper closes the silent-drop of git-source-name entries from the regenerated lockfile in Remove/Reassign/Fork.
+  - **Plan 02 (HOTFIX-02 / #461 H2):** Command::Remove save chain reordered so the ⚠ block fires before any save can `?`-mask it; disk-state retention contract proven byte-for-byte.
+  - **Plan 03 (HOTFIX-03 / #461 H3):** leading line reworded, colon now introduces listing.
+- **v0.8.1 ready for release.** Run `make release VERSION=0.8.1` (per the user's `make release` ownership — no automated tag/release from gsd). The release workflow will:
+  1. Bump `Cargo.toml` version to 0.8.1
+  2. Open + merge a release PR
+  3. Tag and push
+  4. cargo-dist will build artifacts and publish via the release workflow
+- **`make ci` green** (with `~/.cargo/bin` on PATH for `typos`): 464 unit tests + 126 integration tests + clippy `-D warnings` + fmt-check + typos.
+
+## Self-Check
+
+Verified at end of execution:
+
+- `crates/tome/src/lib.rs` line 407 contains `Run {} after resolving:` (new wording) — FOUND
+- `rg -n "Run \\{\\} after resolving:" crates/tome/src/lib.rs` returns exactly 1 match — VERIFIED
+- `rg -n "addressing these\\. Run \\{\\}:" crates/tome/src/lib.rs` returns ZERO matches — VERIFIED
+- `crates/tome/tests/cli.rs` contains `fn remove_failure_summary_wording()` — FOUND
+- Commits `8fb3c46`, `2ad7c60`, `5705e3d` exist on `gsd/phase-08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain` — FOUND
+- `cargo test -p tome --test cli remove_partial_failure` — both existing tests PASS (2/2)
+- `cargo test -p tome --test cli remove_failure_summary_wording` — new test PASSES (1/1)
+- `make ci` (with `~/.cargo/bin` in PATH): 464 unit + 126 integration + clippy + fmt-check + typos all PASS — VERIFIED
+
+## Self-Check: PASSED
+
+---
+*Phase: 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain*
+*Plan: 03*
+*Completed: 2026-04-26*

--- a/.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-03-hotfix-03-failure-summary-reword-PLAN.md
+++ b/.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-03-hotfix-03-failure-summary-reword-PLAN.md
@@ -1,0 +1,297 @@
+---
+phase: 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain
+plan: 03
+type: execute
+wave: 3
+depends_on: ["08.1-02"]
+files_modified:
+  - crates/tome/src/lib.rs
+  - crates/tome/tests/cli.rs
+autonomous: true
+requirements: [HOTFIX-03]
+issue: "https://github.com/MartinP7r/tome/issues/461 (H3)"
+
+must_haves:
+  truths:
+    - "The leading line of the partial-failure summary no longer ends with `Run \\`tome doctor\\`:` (which mispromised that doctor output follows)"
+    - "The user still sees an explicit `tome doctor` hint somewhere in the failure-summary stderr block"
+    - "The trailing colon now belongs unambiguously to the per-kind listing it introduces (e.g., the line right before `Distribution symlinks (N): ...`)"
+  artifacts:
+    - path: "crates/tome/src/lib.rs"
+      provides: "Reworded partial-failure summary in `Command::Remove` — leading line ends with `after resolving:` (introducing the per-kind listing)"
+      contains: "after resolving:"
+    - path: "crates/tome/tests/cli.rs"
+      provides: "Test asserting the new wording is present and the old (misleading) fragment `Run \\`tome doctor\\`:` is absent"
+      contains: "remove_failure_summary_wording"
+  key_links:
+    - from: "crates/tome/src/lib.rs Command::Remove ⚠ block (post-Plan 02 location)"
+      to: "the rewording of the leading `eprintln!`"
+      via: "string literal change only — no control-flow change"
+      pattern: "after resolving:"
+---
+
+<objective>
+Reword the partial-failure summary line in `Command::Remove` so the trailing colon unambiguously introduces the per-kind listing that follows, instead of falsely promising `tome doctor` output.
+
+**Bug (H3, #461):** Today the line reads:
+```
+⚠ N operations failed during remove of 'foo' — config entry and manifest retained so you can retry after addressing these. Run `tome doctor`:
+  Distribution symlinks (2):
+    /path/a: error
+```
+The trailing `:` looks like it introduces `tome doctor`'s output, but what actually follows is the per-kind grouping. UX nit, low severity, but worth a one-line fix in the same patch release.
+
+**Fix (planner pick):** Use the "reword" option from #461 — drop the misleading `Run \`tome doctor\`:` clause from the leading line entirely, end the leading line with `Run \`tome doctor\` after resolving:` so the colon clearly introduces the listing.
+
+The terminal-line alternative (move `Run \`tome doctor\` to inspect.` to a final line *after* the listing) was considered. Picking inline because:
+- Keeps the call-to-action close to the headline (most users skim — only the first line is guaranteed to be read).
+- Single-line change → tiny diff → low risk for a hotfix.
+- The colon now correctly belongs to the listing it introduces.
+
+Purpose: Closes #461 H3.
+Output: One-line wording change in `lib.rs` + one stderr-content test.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+
+@crates/tome/src/lib.rs
+@crates/tome/tests/cli.rs
+
+<interfaces>
+After Plan 02, the partial-failure block in `Command::Remove` looks like (approx):
+
+```rust
+if !result.failures.is_empty() {
+    let k = result.failures.len();
+    eprintln!(
+        "{} {} operations failed during remove of '{}' — config entry and \
+         manifest retained so you can retry after addressing these. Run {}:",
+        style("⚠").yellow(),
+        k,
+        name,
+        style("`tome doctor`").bold(),
+    );
+    for kind in crate::remove::FailureKind::ALL {
+        let group: Vec<&crate::remove::RemoveFailure> =
+            result.failures.iter().filter(|f| f.kind == kind).collect();
+        if group.is_empty() { continue; }
+        eprintln!("  {} ({}):", kind.label(), group.len());
+        for f in group {
+            eprintln!("    {}: {}", paths::collapse_home(&f.path), f.error);
+        }
+    }
+    return Err(anyhow::anyhow!("remove completed with {k} failures"));
+}
+```
+
+Target wording (only the leading `eprintln!` changes — the per-kind loop stays as-is):
+
+```rust
+eprintln!(
+    "{} {} operations failed during remove of '{}' — config entry and \
+     manifest retained so you can retry after addressing these. \
+     Run {} after resolving:",
+    style("⚠").yellow(),
+    k,
+    name,
+    style("`tome doctor`").bold(),
+);
+```
+
+The exact change:
+- BEFORE: `... after addressing these. Run {}:` (where `{}` is the bold-styled `tome doctor`)
+- AFTER:  `... after addressing these. Run {} after resolving:` (where `{}` is the same bold-styled `tome doctor`)
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Reword the partial-failure leading line in lib.rs Command::Remove</name>
+  <files>crates/tome/src/lib.rs</files>
+  <read_first>
+    - crates/tome/src/lib.rs (the `Command::Remove` ⚠ block — post-Plan-02 location, immediately after `remove::execute(...)?`)
+    - crates/tome/tests/cli.rs lines 3370–3460 (existing `remove_partial_failure_exits_nonzero_with_warning_marker` to confirm we don't break its assertions)
+  </read_first>
+  <action>
+In `crates/tome/src/lib.rs`, inside the `Command::Remove` arm, locate the leading `eprintln!` call inside the `if !result.failures.is_empty() { ... }` block (after Plan 02 it sits immediately after `let k = result.failures.len();`).
+
+Change the format string in that single `eprintln!` from:
+```
+"{} {} operations failed during remove of '{}' — config entry and \
+ manifest retained so you can retry after addressing these. Run {}:"
+```
+to (note the addition of ` after resolving` between `Run {}` and `:`):
+```
+"{} {} operations failed during remove of '{}' — config entry and \
+ manifest retained so you can retry after addressing these. \
+ Run {} after resolving:"
+```
+
+The four format arguments stay identical:
+1. `style("⚠").yellow()`
+2. `k`
+3. `name`
+4. `style("`tome doctor`").bold()`
+
+The per-kind loop, the `eprintln!("  {} ({}):", kind.label(), group.len())`, and the `return Err(anyhow::anyhow!("remove completed with {k} failures"))` all stay unchanged.
+
+**Do NOT:**
+- Touch the per-kind format strings inside the loop.
+- Touch the `anyhow!` error string (it is matched verbatim by the existing `remove_partial_failure_exits_nonzero_with_warning_marker` test on `"remove completed with"`).
+- Change the styling/colors/bold of any value.
+- Add a terminal "Run \`tome doctor\` to inspect." line after the listing — we picked the inline reword in the plan objective.
+
+Verify by running the existing partial-failure test, which asserts on `⚠`, `operations failed`, `remove completed with`, and `retained` || `retry` — all of which remain present in the new wording. (The new wording still contains `retained`, `retry`, `operations failed`, and `⚠`.)
+
+Run: `cargo build -p tome && cargo test -p tome --test cli remove_partial_failure_exits_nonzero_with_warning_marker`
+  </action>
+  <verify>
+    <automated>cargo build -p tome 2>&1 | tail -10 && cargo test -p tome --test cli remove_partial_failure_exits_nonzero_with_warning_marker</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "Run \{\} after resolving:" crates/tome/src/lib.rs` returns exactly 1 match (inside the `Command::Remove` ⚠ block).
+    - `rg -n "addressing these\. Run \{\}:" crates/tome/src/lib.rs` returns ZERO matches (old wording is gone).
+    - `cargo build -p tome` is clean.
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+    - The existing `remove_partial_failure_exits_nonzero_with_warning_marker` integration test still passes.
+  </acceptance_criteria>
+  <done>
+    Single-string change applied. Old (misleading) wording is gone. Existing partial-failure test still passes against the new wording.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Add stderr-wording integration test</name>
+  <files>crates/tome/tests/cli.rs</files>
+  <read_first>
+    - crates/tome/tests/cli.rs lines 3370–3460 (existing partial-failure test — model the new test on the same fixture)
+    - crates/tome/src/lib.rs (post-Task-1 wording, to confirm the exact substring being asserted)
+  </read_first>
+  <action>
+Add a new test in `crates/tome/tests/cli.rs`, immediately after `remove_partial_failure_does_not_save_disk_state` (or after `remove_partial_failure_exits_nonzero_with_warning_marker` if Plan 02 hasn't been merged on the branch yet — the placement is informational only, not a constraint).
+
+```rust
+#[cfg(unix)]
+#[test]
+fn remove_failure_summary_wording() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // HOTFIX-03 / #461 H3: the leading line of the partial-failure summary
+    // must end the colon-introduced clause with `after resolving:` (which
+    // introduces the per-kind listing), NOT with `Run `tome doctor`:` (which
+    // falsely promised tome doctor output).
+    let tmp = TempDir::new().unwrap();
+    let skills_dir = tmp.path().join("skills");
+    create_skill(&skills_dir, "my-skill");
+
+    let target_dir = tmp.path().join("target");
+    std::fs::create_dir_all(&target_dir).unwrap();
+
+    remove_test_env(
+        &tmp,
+        &format!(
+            "[directories.local]\npath = \"{}\"\ntype = \"directory\"\nrole = \"source\"\n\n[directories.test-target]\npath = \"{}\"\ntype = \"directory\"\nrole = \"target\"\n",
+            skills_dir.display(),
+            target_dir.display()
+        ),
+    );
+
+    tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "sync",
+            "--no-triage",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+
+    std::fs::set_permissions(&target_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+    let output = tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "remove",
+            "local",
+            "--force",
+        ])
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+
+    std::fs::set_permissions(&target_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    assert!(!output.status.success(), "remove should fail under chmod 0o500");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The new wording is present.
+    assert!(
+        stderr.contains("after resolving:"),
+        "stderr missing reworded fragment 'after resolving:': {stderr}"
+    );
+
+    // The doctor hint is still surfaced (we kept the call-to-action inline).
+    assert!(
+        stderr.contains("tome doctor"),
+        "stderr missing 'tome doctor' hint: {stderr}"
+    );
+
+    // The misleading old wording is gone. Match on the literal trailing
+    // sequence (with NO_COLOR=1 the styled `tome doctor` is wrapped in
+    // backticks but unstyled, so the pattern matches reliably).
+    assert!(
+        !stderr.contains("addressing these. Run `tome doctor`:"),
+        "stderr still contains old misleading wording 'addressing these. Run `tome doctor`:': {stderr}"
+    );
+}
+```
+
+**Implementation notes:**
+- `NO_COLOR=1` is already set in this test family; it makes the `console::style(...).bold()` wrapper a no-op for the `tome doctor` rendering. The literal `\`tome doctor\`` (with backticks from the format string) appears verbatim in stderr.
+- The negative assertion uses `addressing these. Run \`tome doctor\`:` (the OLD trailing fragment). If your local rust-string-literal escapes shift the substring, prefer matching `Run \`tome doctor\`:` alone — but include `addressing these.` if practical, since it disambiguates from any future use of the bare phrase elsewhere.
+- Do NOT change `remove_partial_failure_exits_nonzero_with_warning_marker` — it should keep passing as a separate guard.
+
+Run: `cargo test -p tome --test cli remove_failure_summary_wording`
+  </action>
+  <verify>
+    <automated>cargo test -p tome --test cli remove_failure_summary_wording</automated>
+  </verify>
+  <acceptance_criteria>
+    - `cargo test -p tome --test cli remove_failure_summary_wording` passes.
+    - `cargo test -p tome --test cli remove_partial_failure` runs the existing tests AND the new wording test, all pass.
+    - Reverting Task 1's wording change makes this test FAIL on `stderr.contains("after resolving:")`. (Manual sanity check.)
+  </acceptance_criteria>
+  <done>
+    Wording test passes. The new fragment `after resolving:` is asserted present, the old fragment `addressing these. Run \`tome doctor\`:` is asserted absent, and the `tome doctor` hint is still surfaced.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- `cargo test -p tome --test cli remove_failure_summary_wording` — passes.
+- `cargo test -p tome --test cli remove_partial_failure` — all 3 tests in the family pass.
+- `rg -n "Run \{\} after resolving:" crates/tome/src/lib.rs` — exactly 1 match.
+- `rg -n "addressing these\. Run \{\}:" crates/tome/src/lib.rs` — zero matches.
+- `make ci` — clean.
+</verification>
+
+<success_criteria>
+- Leading line of the ⚠ block now ends with `Run \`tome doctor\` after resolving:` — colon introduces the listing.
+- The old (misleading) trailing fragment is gone from the codebase.
+- All three Remove integration tests pass: `_warning_marker`, `_does_not_save_disk_state`, `_summary_wording`.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-03-SUMMARY.md` recording: the exact before/after wording, the file:line of the change, the new test name, and a note that HOTFIX-03 / #461 H3 is closed and v0.8.1 is ready for `make release VERSION=0.8.1`.
+</output>

--- a/.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-VERIFICATION.md
+++ b/.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/08.1-VERIFICATION.md
@@ -1,0 +1,105 @@
+---
+phase: 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain
+verified: 2026-04-26T13:05:00Z
+status: passed
+score: 9/9 must-haves verified
+requirements: [HOTFIX-01, HOTFIX-02, HOTFIX-03]
+note: "HOTFIX-01/02/03 are intentionally NOT registered in REQUIREMENTS.md per STATE.md decision; tracked via plan/SUMMARY artifacts and GitHub issue #461. Verification cross-references the three plan frontmatters and the #461 narrative directly."
+---
+
+# Phase 08.1: v0.8.1 Hotfix — Lockfile Regen + Save Chain Verification Report
+
+**Phase Goal:** Close 3 post-merge findings from #461 — restore git-skill provenance to the regenerated lockfile in Remove/Reassign/Fork (H1), reorder the save chain so partial-failure ⚠ block surfaces before save errors propagate (H2), and reword the failure-summary line for clarity (H3).
+**Verified:** 2026-04-26T13:05:00Z
+**Status:** passed
+**Re-verification:** No — initial verification.
+
+## Goal Achievement
+
+### Observable Truths (per plan frontmatter)
+
+| Plan | # | Truth | Status | Evidence |
+| ---- | - | ----- | ------ | -------- |
+| 01 (HOTFIX-01) | 1 | After `tome remove`/`reassign`/`fork`, regenerated `tome.lock` still contains entries for skills sourced from git-type directories that exist in cache (no silent drop). | ✓ VERIFIED | Helper `resolved_paths_from_lockfile_cache` exists at `lockfile.rs:105`; integration test `remove_preserves_git_lockfile_entries` (cli.rs:3650) passes — asserts `git_commit_sha` preserved. |
+| 01 (HOTFIX-01) | 2 | When previous lockfile missing or git cache dir gone, user sees stderr `warning:` line naming the directory — never a silent skip. | ✓ VERIFIED | Helper emits per-directory warnings in two branches: lockfile missing (`lockfile.rs:159-164`) and cache dir missing (`lockfile.rs:169-176`); call sites print via `eprintln!("warning: {}", w)` (lib.rs:439-441 and equivalents at Reassign 481, Fork 537). |
+| 01 (HOTFIX-01) | 3 | Lockfile-regen path adds NO network operations to remove/reassign/fork. | ✓ VERIFIED | Helper docstring states "never clones, fetches, or talks to a remote" (lockfile.rs:100). Implementation reads only the previous lockfile via `load(...)` and inspects `cache_dir.is_dir()` — no `git::clone`/`git::fetch`/`git::ensure_repo` invocations. |
+| 02 (HOTFIX-02) | 1 | When `remove::execute` returns non-empty `failures`, user sees ⚠ block on stderr BEFORE any save-chain error preempts it. | ✓ VERIFIED | Block sits at lib.rs:402-427, immediately after `remove::execute(...)?` (line 391) and BEFORE `config.save` (line 430). Test `remove_partial_failure_exits_nonzero_with_warning_marker` (cli.rs:3377) confirms. |
+| 02 (HOTFIX-02) | 2 | When `remove::execute` returns non-empty `failures`, no save-chain side effect (config / manifest / lockfile) is written to disk. | ✓ VERIFIED | The `return Err(...)` at lib.rs:426 short-circuits before any save call. Integration test `remove_partial_failure_does_not_save_disk_state` (cli.rs:3463) snapshot-compares `tome.toml` / `.tome-manifest.json` / `tome.lock` bytes pre/post — passes. |
+| 02 (HOTFIX-02) | 3 | Success path still saves config, manifest, and lockfile and prints ✓ banner — no happy-path regression. | ✓ VERIFIED | Success path at lib.rs:429-457 (config.save, manifest::save, lockfile::generate+save, ✓ banner). Existing tests `test_remove_local_directory`, `test_remove_dry_run`, `test_remove_nonexistent_directory` all pass under `make ci`. |
+| 03 (HOTFIX-03) | 1 | Leading line of partial-failure summary no longer ends with `Run \`tome doctor\`:` (mispromise removed). | ✓ VERIFIED | `rg "addressing these\. Run \{\}:"` returns 0 matches in lib.rs. |
+| 03 (HOTFIX-03) | 2 | User still sees explicit `tome doctor` hint in failure-summary stderr block. | ✓ VERIFIED | lib.rs:411 still emits `style("\`tome doctor\`").bold()` as the 4th format arg; test `remove_failure_summary_wording` (cli.rs:3570) asserts `stderr.contains("tome doctor")`. |
+| 03 (HOTFIX-03) | 3 | Trailing colon now belongs unambiguously to the per-kind listing it introduces. | ✓ VERIFIED | lib.rs:407 reads `Run {} after resolving:` — colon is followed by the per-kind loop at lib.rs:414-424 emitting `eprintln!("  {} ({}):", kind.label(), group.len())`. Test asserts `stderr.contains("after resolving:")`. |
+
+**Score:** 9/9 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+| -------- | -------- | ------ | ------- |
+| `crates/tome/src/lockfile.rs::resolved_paths_from_lockfile_cache` | `pub(crate) fn` exists | ✓ VERIFIED | Found at lockfile.rs:105 with `#[allow(clippy::type_complexity)]`. Returns `(BTreeMap<DirectoryName, (PathBuf, Option<String>)>, Vec<String>)`. |
+| 3 call sites in `crates/tome/src/lib.rs` (Remove / Reassign / Fork) | exactly 3 matches; 0 leftover empty BTreeMap | ✓ VERIFIED | `rg "lockfile::resolved_paths_from_lockfile_cache"` → 3 matches at lib.rs:437, 479, 535. `rg "let resolved_paths = std::collections::BTreeMap::new\(\);"` → 0 matches. |
+| `remove_preserves_git_lockfile_entries` integration test | exists and passes | ✓ VERIFIED | cli.rs:3650; passes individually and in full suite. |
+| `if !result.failures.is_empty()` block placement | Between `remove::execute(...)?` and `config.save(...)?`; exactly 1 occurrence | ✓ VERIFIED | lib.rs:402 (after line 391 `remove::execute`, before line 430 `config.save`). `rg "result\.failures\.is_empty"` → 1 match. |
+| `remove_partial_failure_does_not_save_disk_state` integration test | exists and passes | ✓ VERIFIED | cli.rs:3463; passes. |
+| `remove_partial_failure_exits_nonzero_with_warning_marker` (existing) | still passes | ✓ VERIFIED | cli.rs:3377; passes (no regression from Plan 02 reorder). |
+| `Run {} after resolving:` wording | exactly 1 occurrence in lib.rs | ✓ VERIFIED | lib.rs:407 — only match. |
+| `addressing these. Run {}:` (old wording) | 0 occurrences in lib.rs | ✓ VERIFIED | rg returns 0. |
+| `remove_failure_summary_wording` integration test | exists and passes | ✓ VERIFIED | cli.rs:3570; passes. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+| ---- | -- | --- | ------ | ------- |
+| `lib.rs::Command::Remove` | `lockfile::resolved_paths_from_lockfile_cache` | direct call at lib.rs:436-437 | ✓ WIRED | Result destructured into `(resolved_paths, mut regen_warnings)` and immediately passed to `discover::discover_all`. Warnings printed via `eprintln!("warning: {}", w)` at lib.rs:439-441. |
+| `lib.rs::Command::Reassign` | `lockfile::resolved_paths_from_lockfile_cache` | direct call at lib.rs:478-479 | ✓ WIRED | Same shape as Remove arm — result fed to `discover_all`, warnings printed. |
+| `lib.rs::Command::Fork` | `lockfile::resolved_paths_from_lockfile_cache` | direct call at lib.rs:534-535 | ✓ WIRED | Same shape — Fork arm follows identical pattern. |
+| `lib.rs::Command::Remove` partial-failure block | early `return Err(...)` | `if !result.failures.is_empty() { ...; return Err(...); }` at lib.rs:402-427 | ✓ WIRED | Block emits ⚠ stderr, iterates per-kind groups, returns error before any save call. |
+| `eprintln!` leading line | `tome doctor` call-to-action | `style("\`tome doctor\`").bold()` arg at lib.rs:411 | ✓ WIRED | Format string at lib.rs:407 ends with `Run {} after resolving:` — `{}` is the styled `tome doctor` token. |
+| Tests `remove_partial_failure_*` and `remove_failure_summary_wording` | partial-failure code path | `chmod 0o500` fixture + `NO_COLOR=1` env | ✓ WIRED | All three tests reuse the same fixture; assertions exercise the moved/reworded `eprintln!` and the no-disk-write contract. |
+
+### Data-Flow Trace (Level 4)
+
+| Artifact | Data Variable | Source | Produces Real Data | Status |
+| -------- | ------------- | ------ | ------------------ | ------ |
+| `resolved_paths_from_lockfile_cache` | `resolved` (BTreeMap entries) | Real previous lockfile via `load(paths.config_dir())` + `cache_dir.is_dir()` filesystem check + `sha_by_dir` index built from lockfile entries | ✓ Yes — driven by actual lockfile/cache state, not hardcoded | ✓ FLOWING |
+| `resolved_paths_from_lockfile_cache` | `warnings` (Vec<String>) | Real per-directory checks (lockfile missing, cache dir missing) | ✓ Yes | ✓ FLOWING |
+| ⚠ block stderr output | `eprintln!` format args (`k`, `name`, styled `tome doctor`) | `result.failures.len()`, the user-supplied `name` from CLI, and the static styled token | ✓ Yes | ✓ FLOWING |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+| -------- | ------- | ------ | ------ |
+| 4 phase-specific integration tests pass | `cargo test -p tome --test cli -- remove_partial_failure remove_failure_summary_wording remove_preserves_git_lockfile_entries` | 4 passed; 0 failed | ✓ PASS |
+| Full unit + integration suite passes (no regression) | `make ci` (with `~/.cargo/bin` on PATH for `typos`) | 464 unit tests + 126 integration tests + clippy `-D warnings` + fmt-check + typos all green | ✓ PASS |
+| Helper has 3 call sites, zero empty-BTreeMap placeholders | `rg "lockfile::resolved_paths_from_lockfile_cache"` (3) + `rg "let resolved_paths = std::collections::BTreeMap::new\(\);"` (0) | 3 / 0 | ✓ PASS |
+| Wording is reworded exactly once and old form is absent | `rg "Run \{\} after resolving:"` (1) + `rg "addressing these\. Run \{\}:"` (0) | 1 / 0 | ✓ PASS |
+| `result.failures.is_empty()` guard appears exactly once and is positioned before saves | `rg "result\.failures\.is_empty"` (1 match at lib.rs:402, before `config.save` at lib.rs:430) | 1 match, correct position | ✓ PASS |
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+| ----------- | ----------- | ----------- | ------ | -------- |
+| HOTFIX-01 | 08.1-01-PLAN frontmatter, SUMMARY frontmatter `requirements-completed`, #461 H1 | Restore git-skill provenance in regenerated `tome.lock` for Remove/Reassign/Fork (close silent-drop regression). | ✓ SATISFIED | Helper added, 3 call sites wired, integration test green; Plan 01 truths 1-3 verified. |
+| HOTFIX-02 | 08.1-02-PLAN frontmatter, SUMMARY frontmatter `requirements-completed`, #461 H2 | Reorder `Command::Remove` save chain so ⚠ partial-failure block surfaces before save-chain `?` propagation. | ✓ SATISFIED | Block moved to lib.rs:402, integration test `remove_partial_failure_does_not_save_disk_state` green; Plan 02 truths 1-3 verified. |
+| HOTFIX-03 | 08.1-03-PLAN frontmatter, SUMMARY frontmatter `requirements-completed`, #461 H3 | Reword failure-summary leading line so trailing colon unambiguously introduces per-kind listing instead of falsely promising `tome doctor` output. | ✓ SATISFIED | Wording changed to `Run {} after resolving:`, integration test `remove_failure_summary_wording` green; Plan 03 truths 1-3 verified. |
+
+**Note on REQUIREMENTS.md cross-reference:** Per the orchestrator-supplied traceability note (and STATE.md decision), HOTFIX-01/02/03 are intentionally tracked via plan/SUMMARY frontmatters and GitHub issue #461 rather than via `REQUIREMENTS.md`. No orphaned-requirement gap is flagged.
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+| ---- | ---- | ------- | -------- | ------ |
+| (none) | — | — | — | No TODO/FIXME/placeholder/stub patterns introduced by this phase's commits. The single `#[allow(clippy::type_complexity)]` and one `#[allow(dead_code)]` (later removed) were both documented in SUMMARY as deliberate, justified choices. |
+
+### Human Verification Required
+
+None. Every must-have is asserted by an integration test. Stderr wording, save-chain order, and disk-state retention are all verified non-interactively under `make ci`.
+
+### Gaps Summary
+
+None. All 9 truths verified, all 9 artifacts present and substantive, all 6 key links wired, all 3 requirements (HOTFIX-01/02/03) satisfied via integration-test guards. Behavioral spot-checks (5/5) pass. Phase 08.1 is ready for `make release VERSION=0.8.1`.
+
+---
+
+_Verified: 2026-04-26T13:05:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -403,7 +403,8 @@ pub fn run(cli: Cli) -> Result<()> {
                 let k = result.failures.len();
                 eprintln!(
                     "{} {} operations failed during remove of '{}' — config entry and \
-                     manifest retained so you can retry after addressing these. Run {}:",
+                     manifest retained so you can retry after addressing these. \
+                     Run {} after resolving:",
                     style("⚠").yellow(),
                     k,
                     name,

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -390,28 +390,15 @@ pub fn run(cli: Cli) -> Result<()> {
             let mut manifest = manifest;
             let result = remove::execute(&plan, &mut config, &mut manifest, false)?;
 
-            // Save updated config
-            config.save(&paths.config_path())?;
-            // Save updated manifest
-            manifest::save(&manifest, paths.config_dir())?;
-            // Regenerate lockfile. Recover git-skill provenance offline from
-            // the previous lockfile + on-disk cache so git-type directories
-            // are not silently dropped during regen (#461 H1).
-            let (resolved_paths, mut regen_warnings) =
-                lockfile::resolved_paths_from_lockfile_cache(&config, &paths);
-            let skills = discover::discover_all(&config, &resolved_paths, &mut regen_warnings)?;
-            for w in &regen_warnings {
-                eprintln!("warning: {}", w);
-            }
-            let lockfile = lockfile::generate(&manifest, &skills);
-            lockfile::save(&lockfile, paths.config_dir())?;
-
-            // Surface partial-cleanup failures FIRST so they can't be
-            // hidden by a ✓ success banner above them (scripted callers
-            // keying on stdout miss stderr signals; humans dismiss ⚠
-            // after reading ✓). On full success the success banner below
-            // prints; on partial failure the ⚠ block prints and we
-            // return Err (no success banner).
+            // Surface partial-cleanup failures BEFORE the save chain. If any of
+            // config.save / manifest::save / discover_all / lockfile::save returns
+            // Err, `?` would otherwise propagate and the user would only see a
+            // disk-write error — never the ⚠ block or the I2/I3 retention messaging
+            // ("config entry and manifest retained so you can retry"). Returning
+            // here also means in-memory mutations to `config` and `manifest` are
+            // never persisted on the failure path, which is correct: remove::execute
+            // deliberately leaves them in their pre-mutation state when failures
+            // occur, so the disk state on retry matches the in-memory state.
             if !result.failures.is_empty() {
                 let k = result.failures.len();
                 eprintln!(
@@ -437,6 +424,22 @@ pub fn run(cli: Cli) -> Result<()> {
 
                 return Err(anyhow::anyhow!("remove completed with {k} failures"));
             }
+
+            // Save updated config
+            config.save(&paths.config_path())?;
+            // Save updated manifest
+            manifest::save(&manifest, paths.config_dir())?;
+            // Regenerate lockfile. Recover git-skill provenance offline from
+            // the previous lockfile + on-disk cache so git-type directories
+            // are not silently dropped during regen (#461 H1).
+            let (resolved_paths, mut regen_warnings) =
+                lockfile::resolved_paths_from_lockfile_cache(&config, &paths);
+            let skills = discover::discover_all(&config, &resolved_paths, &mut regen_warnings)?;
+            for w in &regen_warnings {
+                eprintln!("warning: {}", w);
+            }
+            let lockfile = lockfile::generate(&manifest, &skills);
+            lockfile::save(&lockfile, paths.config_dir())?;
 
             // Success path — full cleanup completed with no failures.
             println!(

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -394,9 +394,11 @@ pub fn run(cli: Cli) -> Result<()> {
             config.save(&paths.config_path())?;
             // Save updated manifest
             manifest::save(&manifest, paths.config_dir())?;
-            // Regenerate lockfile
-            let mut regen_warnings = Vec::new();
-            let resolved_paths = std::collections::BTreeMap::new();
+            // Regenerate lockfile. Recover git-skill provenance offline from
+            // the previous lockfile + on-disk cache so git-type directories
+            // are not silently dropped during regen (#461 H1).
+            let (resolved_paths, mut regen_warnings) =
+                lockfile::resolved_paths_from_lockfile_cache(&config, &paths);
             let skills = discover::discover_all(&config, &resolved_paths, &mut regen_warnings)?;
             for w in &regen_warnings {
                 eprintln!("warning: {}", w);
@@ -465,9 +467,12 @@ pub fn run(cli: Cli) -> Result<()> {
             reassign::execute(&plan, &mut manifest, &target_dir_path, cli.dry_run)?;
             if !cli.dry_run {
                 manifest::save(&manifest, paths.config_dir())?;
-                // Regenerate lockfile to keep it in sync
-                let mut regen_warnings = Vec::new();
-                let resolved_paths = std::collections::BTreeMap::new();
+                // Regenerate lockfile to keep it in sync. Recover git-skill
+                // provenance offline from the previous lockfile + on-disk
+                // cache so git-type directories are not silently dropped
+                // during regen (#461 H1).
+                let (resolved_paths, mut regen_warnings) =
+                    lockfile::resolved_paths_from_lockfile_cache(&config, &paths);
                 let skills = discover::discover_all(&config, &resolved_paths, &mut regen_warnings)?;
                 for w in &regen_warnings {
                     eprintln!("warning: {}", w);
@@ -518,9 +523,12 @@ pub fn run(cli: Cli) -> Result<()> {
             reassign::execute(&plan, &mut manifest, &target_dir_path, cli.dry_run)?;
             if !cli.dry_run {
                 manifest::save(&manifest, paths.config_dir())?;
-                // Regenerate lockfile to keep it in sync
-                let mut regen_warnings = Vec::new();
-                let resolved_paths = std::collections::BTreeMap::new();
+                // Regenerate lockfile to keep it in sync. Recover git-skill
+                // provenance offline from the previous lockfile + on-disk
+                // cache so git-type directories are not silently dropped
+                // during regen (#461 H1).
+                let (resolved_paths, mut regen_warnings) =
+                    lockfile::resolved_paths_from_lockfile_cache(&config, &paths);
                 let skills = discover::discover_all(&config, &resolved_paths, &mut regen_warnings)?;
                 for w in &regen_warnings {
                     eprintln!("warning: {}", w);

--- a/crates/tome/src/lockfile.rs
+++ b/crates/tome/src/lockfile.rs
@@ -101,10 +101,6 @@ pub fn generate(manifest: &Manifest, skills: &[DiscoveredSkill]) -> Lockfile {
 ///
 /// Returns `(map, warnings)`. Map values are `(effective_path, Option<git_commit_sha>)`
 /// in the shape `discover::discover_all` requires.
-// `#[allow(dead_code)]` is removed in Task 2 once the three handler call sites
-// in `lib.rs` consume this helper. Kept for the Task-1 atomic commit so clippy
-// doesn't fail on a function that has tests but no production callers yet.
-#[allow(dead_code)]
 #[allow(clippy::type_complexity)] // (BTreeMap, Vec<String>) — matches discover_all's input shape
 pub(crate) fn resolved_paths_from_lockfile_cache(
     config: &Config,

--- a/crates/tome/src/lockfile.rs
+++ b/crates/tome/src/lockfile.rs
@@ -5,13 +5,15 @@
 //! It is regenerated after every `tome sync` and is meant to be committed to version control.
 
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+use crate::config::{Config, DirectoryName, DirectoryType};
 use crate::discover::{DiscoveredSkill, SkillName};
 use crate::manifest::Manifest;
+use crate::paths::TomePaths;
 use crate::validation::ContentHash;
 
 pub(crate) const LOCKFILE_NAME: &str = "tome.lock";
@@ -82,6 +84,105 @@ pub fn generate(manifest: &Manifest, skills: &[DiscoveredSkill]) -> Lockfile {
         version: 1,
         skills: entries,
     }
+}
+
+/// Build a `resolved_paths` map for [`crate::discover::discover_all`] from the
+/// current lockfile and on-disk git cache, with **no network calls**.
+///
+/// Used by the destructive commands (`tome remove` / `reassign` / `fork`) when
+/// they regenerate the lockfile after in-memory mutation. Unlike `sync()`'s
+/// online `resolve_git_directories`, this helper:
+///
+/// - reads the previous lockfile to recover `git_commit_sha` per directory,
+/// - checks the on-disk cache dir for each git-type directory,
+/// - emits a stderr-bound warning string when the lockfile is missing OR
+///   the cache dir is gone (so the caller can `eprintln!("warning: {}", w)`),
+/// - never clones, fetches, or talks to a remote.
+///
+/// Returns `(map, warnings)`. Map values are `(effective_path, Option<git_commit_sha>)`
+/// in the shape `discover::discover_all` requires.
+// `#[allow(dead_code)]` is removed in Task 2 once the three handler call sites
+// in `lib.rs` consume this helper. Kept for the Task-1 atomic commit so clippy
+// doesn't fail on a function that has tests but no production callers yet.
+#[allow(dead_code)]
+#[allow(clippy::type_complexity)] // (BTreeMap, Vec<String>) — matches discover_all's input shape
+pub(crate) fn resolved_paths_from_lockfile_cache(
+    config: &Config,
+    paths: &TomePaths,
+) -> (BTreeMap<DirectoryName, (PathBuf, Option<String>)>, Vec<String>) {
+    let mut resolved = BTreeMap::new();
+    let mut warnings = Vec::new();
+
+    // Bail early if config has no git directories — avoid loading the lockfile.
+    let has_git = config
+        .directories()
+        .values()
+        .any(|d| d.directory_type == DirectoryType::Git);
+    if !has_git {
+        return (resolved, warnings);
+    }
+
+    // Load the previous lockfile (offline). On read error, surface it and
+    // proceed as if it were missing.
+    let previous = match load(paths.config_dir()) {
+        Ok(opt) => opt,
+        Err(e) => {
+            warnings.push(format!(
+                "could not read lockfile for git-directory cache lookup: {e}"
+            ));
+            None
+        }
+    };
+
+    // Build a quick "directory_name -> first git_commit_sha seen" index from
+    // the lockfile. All skills sourced from one directory share a SHA, so any
+    // one is correct.
+    let mut sha_by_dir: std::collections::BTreeMap<&str, Option<String>> =
+        std::collections::BTreeMap::new();
+    if let Some(ref lf) = previous {
+        for entry in lf.skills.values() {
+            sha_by_dir
+                .entry(entry.source_name.as_str())
+                .or_insert_with(|| entry.git_commit_sha.clone());
+        }
+    }
+
+    let repos_dir = paths.repos_dir();
+
+    for (name, dir_config) in config.directories() {
+        if dir_config.directory_type != DirectoryType::Git {
+            continue;
+        }
+
+        // The lockfile is our only offline source of `git_commit_sha`. If it's
+        // missing entirely, surface a per-directory warning so the user is
+        // not left in the dark — replaces the silent drop in #461 H1.
+        if previous.is_none() {
+            warnings.push(format!(
+                "cannot resolve git directory '{name}' from lockfile (lockfile missing) — \
+                 git-sourced skills may be omitted from the regenerated lockfile",
+            ));
+            continue;
+        }
+
+        let url = dir_config.path.to_string_lossy();
+        let cache_dir = crate::git::repo_cache_dir(&repos_dir, &url);
+        if !cache_dir.is_dir() {
+            warnings.push(format!(
+                "cannot resolve git directory '{name}' — cache dir {} not found; \
+                 git-sourced skills will be omitted from the regenerated lockfile",
+                cache_dir.display(),
+            ));
+            continue;
+        }
+
+        let effective = crate::git::effective_path(&cache_dir, dir_config.subdir.as_deref());
+        // sha may legitimately be None when the directory has no skills yet.
+        let sha = sha_by_dir.get(name.as_str()).and_then(|opt| opt.clone());
+        resolved.insert(name.clone(), (effective, sha));
+    }
+
+    (resolved, warnings)
 }
 
 /// Load an existing lockfile from the tome home directory.
@@ -440,6 +541,242 @@ mod tests {
             skill.get("version").is_none(),
             "empty version should be omitted from JSON"
         );
+    }
+
+    // -- resolved_paths_from_lockfile_cache tests (HOTFIX-01 / #461 H1) --
+
+    use crate::config::{Config, DirectoryConfig, DirectoryName, DirectoryRole, DirectoryType};
+    use crate::paths::TomePaths;
+
+    /// Build a minimal `DirectoryConfig` for a git-type directory.
+    fn git_dir_config(url: &str, subdir: Option<&str>) -> DirectoryConfig {
+        // Round-trip through TOML so we set the `pub(crate) role` field via
+        // serde — avoids depending on field visibility from this module.
+        let toml_src = format!(
+            "path = \"{}\"\ntype = \"git\"\nrole = \"source\"\n{}",
+            url,
+            match subdir {
+                Some(s) => format!("subdir = \"{}\"\n", s),
+                None => String::new(),
+            },
+        );
+        toml::from_str(&toml_src).expect("valid DirectoryConfig TOML")
+    }
+
+    /// Build a minimal `DirectoryConfig` for a directory-type directory.
+    fn dir_dir_config(path: &Path) -> DirectoryConfig {
+        let toml_src = format!(
+            "path = \"{}\"\ntype = \"directory\"\nrole = \"source\"\n",
+            path.display(),
+        );
+        toml::from_str(&toml_src).expect("valid DirectoryConfig TOML")
+    }
+
+    /// Build a `Config` from a list of `(name, DirectoryConfig)` pairs and a library_dir.
+    fn config_with_dirs(library_dir: &std::path::Path, dirs: Vec<(&str, DirectoryConfig)>) -> Config {
+        let mut config_toml = format!("library_dir = \"{}\"\n", library_dir.display());
+        for (name, dc) in &dirs {
+            config_toml.push_str(&format!(
+                "\n[directories.{name}]\npath = \"{}\"\ntype = \"{}\"\nrole = \"{}\"\n",
+                dc.path.display(),
+                match dc.directory_type {
+                    DirectoryType::Git => "git",
+                    DirectoryType::Directory => "directory",
+                    DirectoryType::ClaudePlugins => "claude-plugins",
+                },
+                match dc.role() {
+                    DirectoryRole::Source => "source",
+                    DirectoryRole::Synced => "synced",
+                    DirectoryRole::Managed => "managed",
+                    DirectoryRole::Target => "target",
+                },
+            ));
+            if let Some(s) = dc.subdir.as_deref() {
+                config_toml.push_str(&format!("subdir = \"{s}\"\n"));
+            }
+        }
+        toml::from_str(&config_toml).expect("valid Config TOML")
+    }
+
+    /// Build `TomePaths` rooted at `tmp` with a `skills` library dir.
+    fn paths_for(tmp: &Path) -> TomePaths {
+        let library_dir = tmp.join("skills");
+        std::fs::create_dir_all(&library_dir).unwrap();
+        TomePaths::new(tmp.to_path_buf(), library_dir).unwrap()
+    }
+
+    /// Write a minimal lockfile to `tome_home` containing a single skill
+    /// whose `source_name = source` and `git_commit_sha = sha`.
+    fn write_lockfile(tome_home: &Path, source: &str, sha: Option<&str>) {
+        let mut skills = BTreeMap::new();
+        skills.insert(
+            SkillName::new("seed-skill").unwrap(),
+            LockEntry {
+                source_name: source.to_string(),
+                content_hash: test_hash("seed"),
+                registry_id: None,
+                version: None,
+                git_commit_sha: sha.map(|s| s.to_string()),
+            },
+        );
+        let lf = Lockfile { version: 1, skills };
+        save(&lf, tome_home).unwrap();
+    }
+
+    /// Write an empty (no skills) lockfile so `load()` returns `Some` but
+    /// `sha_by_dir` is empty — used to test the no-skills-for-dir fallback.
+    fn write_empty_lockfile(tome_home: &Path) {
+        let lf = Lockfile {
+            version: 1,
+            skills: BTreeMap::new(),
+        };
+        save(&lf, tome_home).unwrap();
+    }
+
+    #[test]
+    fn resolved_paths_from_lockfile_cache_returns_empty_when_no_git_dirs() {
+        let tmp = TempDir::new().unwrap();
+        let paths = paths_for(tmp.path());
+
+        let local_path = tmp.path().join("local-skills");
+        std::fs::create_dir_all(&local_path).unwrap();
+        let config = config_with_dirs(paths.library_dir(), vec![
+            ("local", dir_dir_config(&local_path)),
+        ]);
+
+        let (map, warnings) = resolved_paths_from_lockfile_cache(&config, &paths);
+        assert!(map.is_empty(), "no git dirs → empty map, got {map:?}");
+        assert!(warnings.is_empty(), "no git dirs → no warnings, got {warnings:?}");
+    }
+
+    #[test]
+    fn resolved_paths_from_lockfile_cache_warns_when_lockfile_missing() {
+        let tmp = TempDir::new().unwrap();
+        let paths = paths_for(tmp.path());
+
+        // No tome.lock written. One git directory in config.
+        let config = config_with_dirs(paths.library_dir(), vec![
+            (
+                "myrepo",
+                git_dir_config("https://example.invalid/foo.git", None),
+            ),
+        ]);
+
+        let (map, warnings) = resolved_paths_from_lockfile_cache(&config, &paths);
+        assert!(map.is_empty(), "lockfile missing → entry omitted, got {map:?}");
+        assert_eq!(warnings.len(), 1, "expected one warning, got {warnings:?}");
+        let w = &warnings[0];
+        assert!(
+            w.contains("cannot resolve git directory 'myrepo'"),
+            "warning should name the directory: {w}"
+        );
+        assert!(
+            w.contains("lockfile"),
+            "warning should mention 'lockfile': {w}"
+        );
+    }
+
+    #[test]
+    fn resolved_paths_from_lockfile_cache_warns_when_cache_dir_missing() {
+        let tmp = TempDir::new().unwrap();
+        let paths = paths_for(tmp.path());
+
+        // Lockfile present (with a sha for "myrepo") but no cache dir on disk.
+        write_lockfile(paths.config_dir(), "myrepo", Some("deadbeef"));
+
+        let config = config_with_dirs(paths.library_dir(), vec![
+            (
+                "myrepo",
+                git_dir_config("https://example.invalid/foo.git", None),
+            ),
+        ]);
+
+        let (map, warnings) = resolved_paths_from_lockfile_cache(&config, &paths);
+        assert!(
+            map.is_empty(),
+            "cache dir missing → entry omitted, got {map:?}"
+        );
+        assert_eq!(warnings.len(), 1, "expected one warning, got {warnings:?}");
+        let w = &warnings[0];
+        assert!(
+            w.contains("cannot resolve git directory 'myrepo'"),
+            "warning should name the directory: {w}"
+        );
+        assert!(w.contains("cache"), "warning should mention 'cache': {w}");
+    }
+
+    #[test]
+    fn resolved_paths_from_lockfile_cache_populates_when_cache_exists() {
+        let tmp = TempDir::new().unwrap();
+        let paths = paths_for(tmp.path());
+
+        let url = "https://example.invalid/foo.git";
+        write_lockfile(paths.config_dir(), "myrepo", Some("deadbeef00"));
+
+        // Create the cache dir at repos_dir/<sha256(url)>/.
+        let cache_dir = crate::git::repo_cache_dir(&paths.repos_dir(), url);
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        let config = config_with_dirs(paths.library_dir(), vec![
+            ("myrepo", git_dir_config(url, None)),
+        ]);
+
+        let (map, warnings) = resolved_paths_from_lockfile_cache(&config, &paths);
+        assert!(warnings.is_empty(), "cache present → no warnings, got {warnings:?}");
+        assert_eq!(map.len(), 1, "expected one entry, got {map:?}");
+
+        let key = DirectoryName::new("myrepo").unwrap();
+        let (path, sha) = map.get(&key).expect("myrepo entry");
+        assert_eq!(path, &cache_dir);
+        assert_eq!(sha.as_deref(), Some("deadbeef00"));
+    }
+
+    #[test]
+    fn resolved_paths_from_lockfile_cache_respects_subdir() {
+        let tmp = TempDir::new().unwrap();
+        let paths = paths_for(tmp.path());
+
+        let url = "https://example.invalid/foo.git";
+        write_lockfile(paths.config_dir(), "myrepo", Some("cafebabe"));
+
+        let cache_dir = crate::git::repo_cache_dir(&paths.repos_dir(), url);
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        let config = config_with_dirs(paths.library_dir(), vec![
+            ("myrepo", git_dir_config(url, Some("skills"))),
+        ]);
+
+        let (map, warnings) = resolved_paths_from_lockfile_cache(&config, &paths);
+        assert!(warnings.is_empty(), "no warnings expected, got {warnings:?}");
+        let key = DirectoryName::new("myrepo").unwrap();
+        let (path, _) = map.get(&key).expect("myrepo entry");
+        assert_eq!(path, &cache_dir.join("skills"));
+    }
+
+    #[test]
+    fn resolved_paths_from_lockfile_cache_falls_back_when_no_lockfile_sha() {
+        let tmp = TempDir::new().unwrap();
+        let paths = paths_for(tmp.path());
+
+        let url = "https://example.invalid/foo.git";
+        // Lockfile present but no entry references "myrepo" — the directory
+        // has no skills yet. Helper should still resolve via cache (sha = None)
+        // so the regen does not silently drop the directory.
+        write_empty_lockfile(paths.config_dir());
+
+        let cache_dir = crate::git::repo_cache_dir(&paths.repos_dir(), url);
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        let config = config_with_dirs(paths.library_dir(), vec![
+            ("myrepo", git_dir_config(url, None)),
+        ]);
+
+        let (map, warnings) = resolved_paths_from_lockfile_cache(&config, &paths);
+        assert!(warnings.is_empty(), "no warnings expected, got {warnings:?}");
+        let key = DirectoryName::new("myrepo").unwrap();
+        let (path, sha) = map.get(&key).expect("myrepo entry");
+        assert_eq!(path, &cache_dir);
+        assert!(sha.is_none(), "sha should be None when lockfile has no entry, got {sha:?}");
     }
 
     #[test]

--- a/crates/tome/src/lockfile.rs
+++ b/crates/tome/src/lockfile.rs
@@ -105,7 +105,10 @@ pub fn generate(manifest: &Manifest, skills: &[DiscoveredSkill]) -> Lockfile {
 pub(crate) fn resolved_paths_from_lockfile_cache(
     config: &Config,
     paths: &TomePaths,
-) -> (BTreeMap<DirectoryName, (PathBuf, Option<String>)>, Vec<String>) {
+) -> (
+    BTreeMap<DirectoryName, (PathBuf, Option<String>)>,
+    Vec<String>,
+) {
     let mut resolved = BTreeMap::new();
     let mut warnings = Vec::new();
 
@@ -569,7 +572,10 @@ mod tests {
     }
 
     /// Build a `Config` from a list of `(name, DirectoryConfig)` pairs and a library_dir.
-    fn config_with_dirs(library_dir: &std::path::Path, dirs: Vec<(&str, DirectoryConfig)>) -> Config {
+    fn config_with_dirs(
+        library_dir: &std::path::Path,
+        dirs: Vec<(&str, DirectoryConfig)>,
+    ) -> Config {
         let mut config_toml = format!("library_dir = \"{}\"\n", library_dir.display());
         for (name, dc) in &dirs {
             config_toml.push_str(&format!(
@@ -636,13 +642,17 @@ mod tests {
 
         let local_path = tmp.path().join("local-skills");
         std::fs::create_dir_all(&local_path).unwrap();
-        let config = config_with_dirs(paths.library_dir(), vec![
-            ("local", dir_dir_config(&local_path)),
-        ]);
+        let config = config_with_dirs(
+            paths.library_dir(),
+            vec![("local", dir_dir_config(&local_path))],
+        );
 
         let (map, warnings) = resolved_paths_from_lockfile_cache(&config, &paths);
         assert!(map.is_empty(), "no git dirs → empty map, got {map:?}");
-        assert!(warnings.is_empty(), "no git dirs → no warnings, got {warnings:?}");
+        assert!(
+            warnings.is_empty(),
+            "no git dirs → no warnings, got {warnings:?}"
+        );
     }
 
     #[test]
@@ -651,15 +661,19 @@ mod tests {
         let paths = paths_for(tmp.path());
 
         // No tome.lock written. One git directory in config.
-        let config = config_with_dirs(paths.library_dir(), vec![
-            (
+        let config = config_with_dirs(
+            paths.library_dir(),
+            vec![(
                 "myrepo",
                 git_dir_config("https://example.invalid/foo.git", None),
-            ),
-        ]);
+            )],
+        );
 
         let (map, warnings) = resolved_paths_from_lockfile_cache(&config, &paths);
-        assert!(map.is_empty(), "lockfile missing → entry omitted, got {map:?}");
+        assert!(
+            map.is_empty(),
+            "lockfile missing → entry omitted, got {map:?}"
+        );
         assert_eq!(warnings.len(), 1, "expected one warning, got {warnings:?}");
         let w = &warnings[0];
         assert!(
@@ -680,12 +694,13 @@ mod tests {
         // Lockfile present (with a sha for "myrepo") but no cache dir on disk.
         write_lockfile(paths.config_dir(), "myrepo", Some("deadbeef"));
 
-        let config = config_with_dirs(paths.library_dir(), vec![
-            (
+        let config = config_with_dirs(
+            paths.library_dir(),
+            vec![(
                 "myrepo",
                 git_dir_config("https://example.invalid/foo.git", None),
-            ),
-        ]);
+            )],
+        );
 
         let (map, warnings) = resolved_paths_from_lockfile_cache(&config, &paths);
         assert!(
@@ -713,12 +728,16 @@ mod tests {
         let cache_dir = crate::git::repo_cache_dir(&paths.repos_dir(), url);
         std::fs::create_dir_all(&cache_dir).unwrap();
 
-        let config = config_with_dirs(paths.library_dir(), vec![
-            ("myrepo", git_dir_config(url, None)),
-        ]);
+        let config = config_with_dirs(
+            paths.library_dir(),
+            vec![("myrepo", git_dir_config(url, None))],
+        );
 
         let (map, warnings) = resolved_paths_from_lockfile_cache(&config, &paths);
-        assert!(warnings.is_empty(), "cache present → no warnings, got {warnings:?}");
+        assert!(
+            warnings.is_empty(),
+            "cache present → no warnings, got {warnings:?}"
+        );
         assert_eq!(map.len(), 1, "expected one entry, got {map:?}");
 
         let key = DirectoryName::new("myrepo").unwrap();
@@ -738,12 +757,16 @@ mod tests {
         let cache_dir = crate::git::repo_cache_dir(&paths.repos_dir(), url);
         std::fs::create_dir_all(&cache_dir).unwrap();
 
-        let config = config_with_dirs(paths.library_dir(), vec![
-            ("myrepo", git_dir_config(url, Some("skills"))),
-        ]);
+        let config = config_with_dirs(
+            paths.library_dir(),
+            vec![("myrepo", git_dir_config(url, Some("skills")))],
+        );
 
         let (map, warnings) = resolved_paths_from_lockfile_cache(&config, &paths);
-        assert!(warnings.is_empty(), "no warnings expected, got {warnings:?}");
+        assert!(
+            warnings.is_empty(),
+            "no warnings expected, got {warnings:?}"
+        );
         let key = DirectoryName::new("myrepo").unwrap();
         let (path, _) = map.get(&key).expect("myrepo entry");
         assert_eq!(path, &cache_dir.join("skills"));
@@ -763,16 +786,23 @@ mod tests {
         let cache_dir = crate::git::repo_cache_dir(&paths.repos_dir(), url);
         std::fs::create_dir_all(&cache_dir).unwrap();
 
-        let config = config_with_dirs(paths.library_dir(), vec![
-            ("myrepo", git_dir_config(url, None)),
-        ]);
+        let config = config_with_dirs(
+            paths.library_dir(),
+            vec![("myrepo", git_dir_config(url, None))],
+        );
 
         let (map, warnings) = resolved_paths_from_lockfile_cache(&config, &paths);
-        assert!(warnings.is_empty(), "no warnings expected, got {warnings:?}");
+        assert!(
+            warnings.is_empty(),
+            "no warnings expected, got {warnings:?}"
+        );
         let key = DirectoryName::new("myrepo").unwrap();
         let (path, sha) = map.get(&key).expect("myrepo entry");
         assert_eq!(path, &cache_dir);
-        assert!(sha.is_none(), "sha should be None when lockfile has no entry, got {sha:?}");
+        assert!(
+            sha.is_none(),
+            "sha should be None when lockfile has no entry, got {sha:?}"
+        );
     }
 
     #[test]

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -3458,6 +3458,138 @@ fn remove_partial_failure_exits_nonzero_with_warning_marker() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn remove_preserves_git_lockfile_entries() {
+    // HOTFIX-01 / #461 H1: the regenerated lockfile after `tome remove` must
+    // NOT silently drop git-source-name entries. Before the fix, the handler
+    // passed an empty BTreeMap to discover_all, which `continue`'d for every
+    // git-type directory — wiping their entries from the regenerated lockfile.
+    //
+    // Fixture: a "real" local git repo (file:// URL) holding one skill plus
+    // a separate directory-type "local" source holding another skill. We run
+    // `tome sync` to populate the manifest + lockfile from both sources, then
+    // run `tome remove local` and assert the regenerated lockfile still
+    // contains a `source_name = "myrepo"` entry.
+    let tmp = TempDir::new().unwrap();
+
+    // Set up the directory-type "local" source with one skill.
+    let skills_dir = tmp.path().join("skills");
+    create_skill(&skills_dir, "local-skill");
+
+    // Set up a real local git repo to act as the "myrepo" git directory.
+    // Using a file:// URL means `git clone` and `git fetch` work without
+    // network access — sync's resolve_git_directories can clone it normally.
+    let upstream_dir = tmp.path().join("upstream-myrepo.git");
+    std::fs::create_dir_all(&upstream_dir).unwrap();
+    create_skill(&upstream_dir, "git-skill");
+    // Initialize the upstream as a real git repo so `git clone` accepts it.
+    let git_init = |dir: &std::path::Path, args: &[&str]| {
+        StdCommand::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .output()
+            .unwrap();
+    };
+    // `git init -b main` so the initial branch name is stable across host configs.
+    git_init(&upstream_dir, &["init", "-b", "main"]);
+    git_init(&upstream_dir, &["config", "user.email", "test@test.com"]);
+    git_init(&upstream_dir, &["config", "user.name", "Test"]);
+    git_init(&upstream_dir, &["add", "-A"]);
+    git_init(&upstream_dir, &["commit", "-m", "seed"]);
+
+    let dummy_url = format!("file://{}", upstream_dir.display());
+
+    // Config: one Directory + one Git directory.
+    remove_test_env(
+        &tmp,
+        &format!(
+            "[directories.local]\n\
+             path = \"{}\"\n\
+             type = \"directory\"\n\
+             role = \"source\"\n\
+             \n\
+             [directories.myrepo]\n\
+             path = \"{}\"\n\
+             type = \"git\"\n\
+             role = \"source\"\n\
+             branch = \"main\"\n",
+            skills_dir.display(),
+            dummy_url,
+        ),
+    );
+
+    // Sync to populate manifest and lockfile. `--no-triage` avoids the
+    // interactive lockfile diff step on an initial sync.
+    tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "sync",
+            "--no-triage",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+
+    // Sanity: post-sync lockfile must contain a myrepo entry whose
+    // `git_commit_sha` is populated. The bug doesn't drop the entry by
+    // source_name (that comes from the manifest, which `tome remove` of an
+    // unrelated directory does not touch), but it DOES wipe `git_commit_sha`
+    // because `discover_all` skips git directories when resolved_paths is
+    // empty — so `lockfile::generate` falls back to `(None, None, None)` for
+    // provenance. We assert on `git_commit_sha` to actually exercise the bug.
+    let lockfile_path = tmp.path().join("tome.lock");
+    let lockfile_before: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&lockfile_path).unwrap()).unwrap();
+    let myrepo_sha_before: Option<String> = lockfile_before["skills"]
+        .as_object()
+        .unwrap()
+        .values()
+        .find(|v| v["source_name"].as_str() == Some("myrepo"))
+        .and_then(|v| v["git_commit_sha"].as_str().map(|s| s.to_string()));
+    assert!(
+        myrepo_sha_before.is_some(),
+        "precondition: post-sync lockfile must contain a myrepo entry with \
+         git_commit_sha set, got: {lockfile_before}"
+    );
+
+    // Now remove the OTHER (directory-type) directory. The regenerated
+    // lockfile MUST keep the myrepo entries' provenance — pre-fix the
+    // git_commit_sha was silently wiped (skill missing from discover →
+    // lockfile::generate falls back to None).
+    tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "remove",
+            "local",
+            "--force",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+
+    let lockfile_after: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&lockfile_path).unwrap()).unwrap();
+    let myrepo_sha_after: Option<String> = lockfile_after["skills"]
+        .as_object()
+        .unwrap()
+        .values()
+        .find(|v| v["source_name"].as_str() == Some("myrepo"))
+        .and_then(|v| v["git_commit_sha"].as_str().map(|s| s.to_string()));
+    assert_eq!(
+        myrepo_sha_after, myrepo_sha_before,
+        "REGRESSION (#461 H1): lockfile after `tome remove local` lost myrepo \
+         git_commit_sha provenance — git-sourced skills were silently dropped \
+         during regen. Before: {myrepo_sha_before:?}, After: {myrepo_sha_after:?}, \
+         full lockfile: {lockfile_after}"
+    );
+}
+
 // ── tome add integration tests ─────────────────────────────────────
 
 #[test]

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -3460,6 +3460,113 @@ fn remove_partial_failure_exits_nonzero_with_warning_marker() {
 
 #[cfg(unix)]
 #[test]
+fn remove_partial_failure_does_not_save_disk_state() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // HOTFIX-02 / #461 H2: with the save chain reordered, a partial-failure
+    // path must NOT mutate config / manifest / lockfile on disk. The user
+    // retains a clean retry surface — no half-saved state. The reorder
+    // guarantees the early-return ⚠ block fires BEFORE config.save /
+    // manifest::save / lockfile::save can run, so on the failure path none
+    // of those files are touched.
+    let tmp = TempDir::new().unwrap();
+    let skills_dir = tmp.path().join("skills");
+    create_skill(&skills_dir, "my-skill");
+
+    let target_dir = tmp.path().join("target");
+    std::fs::create_dir_all(&target_dir).unwrap();
+
+    remove_test_env(
+        &tmp,
+        &format!(
+            "[directories.local]\npath = \"{}\"\ntype = \"directory\"\nrole = \"source\"\n\n[directories.test-target]\npath = \"{}\"\ntype = \"directory\"\nrole = \"target\"\n",
+            skills_dir.display(),
+            target_dir.display()
+        ),
+    );
+
+    // Prime library + target so there's something to remove.
+    tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "sync",
+            "--no-triage",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+
+    // Snapshot pre-remove disk state. tome.lock may or may not exist
+    // depending on what `tome sync --no-triage` writes for a non-git
+    // config — tolerate either case (read returns empty Vec on missing,
+    // and the byte-equality check still proves "missing-then-missing").
+    let config_path = tmp.path().join("tome.toml");
+    let manifest_path = tmp.path().join(".tome-manifest.json");
+    let lockfile_path = tmp.path().join("tome.lock");
+
+    let config_before = std::fs::read(&config_path).unwrap_or_default();
+    let manifest_before = std::fs::read(&manifest_path).unwrap_or_default();
+    let lockfile_before = std::fs::read(&lockfile_path).unwrap_or_default();
+
+    // Trigger partial-failure: chmod 0o500 the target dir so step-1 unlink
+    // hits EACCES — execute() lands in the partial-failure path with a
+    // non-empty `failures` Vec.
+    std::fs::set_permissions(&target_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+    let output = tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "remove",
+            "local",
+            "--force",
+        ])
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+
+    // Restore permissions BEFORE assertions so TempDir::drop can clean up.
+    std::fs::set_permissions(&target_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    // 1. CLI exits non-zero.
+    assert!(
+        !output.status.success(),
+        "remove should fail under chmod 0o500, got status: {:?}",
+        output.status,
+    );
+
+    // 2. Stderr has the ⚠ block (proves the moved block fired BEFORE save).
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("⚠"), "missing ⚠ marker in stderr: {stderr}");
+    assert!(
+        stderr.contains("operations failed"),
+        "missing 'operations failed' in stderr: {stderr}"
+    );
+
+    // 3. Disk state is unchanged byte-for-byte (the I2/I3 retention contract
+    //    extended to disk: not just in-memory). If the reorder is reverted,
+    //    config.save / manifest::save / lockfile::save run BEFORE the early
+    //    return and these byte-equality assertions fail.
+    let config_after = std::fs::read(&config_path).unwrap_or_default();
+    let manifest_after = std::fs::read(&manifest_path).unwrap_or_default();
+    let lockfile_after = std::fs::read(&lockfile_path).unwrap_or_default();
+    assert_eq!(
+        config_before, config_after,
+        "tome.toml mutated on partial-failure path (HOTFIX-02 regression)"
+    );
+    assert_eq!(
+        manifest_before, manifest_after,
+        ".tome-manifest.json mutated on partial-failure path (HOTFIX-02 regression)"
+    );
+    assert_eq!(
+        lockfile_before, lockfile_after,
+        "tome.lock mutated on partial-failure path (HOTFIX-02 regression)"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn remove_preserves_git_lockfile_entries() {
     // HOTFIX-01 / #461 H1: the regenerated lockfile after `tome remove` must
     // NOT silently drop git-source-name entries. Before the fix, the handler

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -3567,6 +3567,83 @@ fn remove_partial_failure_does_not_save_disk_state() {
 
 #[cfg(unix)]
 #[test]
+fn remove_failure_summary_wording() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // HOTFIX-03 / #461 H3: the leading line of the partial-failure summary
+    // must end the colon-introduced clause with `after resolving:` (which
+    // introduces the per-kind listing), NOT with `Run `tome doctor`:` (which
+    // falsely promised tome doctor output).
+    let tmp = TempDir::new().unwrap();
+    let skills_dir = tmp.path().join("skills");
+    create_skill(&skills_dir, "my-skill");
+
+    let target_dir = tmp.path().join("target");
+    std::fs::create_dir_all(&target_dir).unwrap();
+
+    remove_test_env(
+        &tmp,
+        &format!(
+            "[directories.local]\npath = \"{}\"\ntype = \"directory\"\nrole = \"source\"\n\n[directories.test-target]\npath = \"{}\"\ntype = \"directory\"\nrole = \"target\"\n",
+            skills_dir.display(),
+            target_dir.display()
+        ),
+    );
+
+    tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "sync",
+            "--no-triage",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+
+    std::fs::set_permissions(&target_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+    let output = tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "remove",
+            "local",
+            "--force",
+        ])
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+
+    std::fs::set_permissions(&target_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    assert!(!output.status.success(), "remove should fail under chmod 0o500");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The new wording is present.
+    assert!(
+        stderr.contains("after resolving:"),
+        "stderr missing reworded fragment 'after resolving:': {stderr}"
+    );
+
+    // The doctor hint is still surfaced (we kept the call-to-action inline).
+    assert!(
+        stderr.contains("tome doctor"),
+        "stderr missing 'tome doctor' hint: {stderr}"
+    );
+
+    // The misleading old wording is gone. With NO_COLOR=1 the styled
+    // `tome doctor` is wrapped in backticks but unstyled, so this literal
+    // pattern matches reliably.
+    assert!(
+        !stderr.contains("addressing these. Run `tome doctor`:"),
+        "stderr still contains old misleading wording 'addressing these. Run `tome doctor`:': {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn remove_preserves_git_lockfile_entries() {
     // HOTFIX-01 / #461 H1: the regenerated lockfile after `tome remove` must
     // NOT silently drop git-source-name entries. Before the fix, the handler

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -3617,7 +3617,10 @@ fn remove_failure_summary_wording() {
 
     std::fs::set_permissions(&target_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-    assert!(!output.status.success(), "remove should fail under chmod 0o500");
+    assert!(
+        !output.status.success(),
+        "remove should fail under chmod 0o500"
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
 


### PR DESCRIPTION
Closes #461

## Summary

Phase 08.1 closes the three post-merge re-review findings on PR #460 (Phase 8). All three are scoped tightly to a single patch release; v0.8.1 ships immediately after merge.

**HOTFIX-01 (#461 H1) — silent-drop regression in lockfile regen.** `tome remove`, `tome reassign`, and `tome fork` regenerated `tome.lock` after their in-memory mutations, but passed an empty `BTreeMap::new()` as `resolved_paths` to `discover::discover_all`. The discover pipeline silently `continue`d past every git-type directory, so the regenerated lockfile omitted all git-sourced skills — the next `tome sync` saw a phantom diff of "every git skill removed/re-added." Fix introduces `lockfile::resolved_paths_from_lockfile_cache(&config, &paths)`, an offline helper that recovers `(path, git_commit_sha)` from the previous lockfile + on-disk repo cache (no network calls). Per-directory `warning:` lines surface when the lockfile or cache dir is missing — silent drops are replaced with explicit warnings.

**HOTFIX-02 (#461 H2) — save chain ordering masked partial-failure messaging.** `Command::Remove` ran the save chain (`config.save → manifest::save → discover::discover_all → lockfile::save`) before checking `result.failures`. If any save returned `Err`, `?` propagated and the user only saw the bare anyhow message — the I2/I3 retention contract ("config retained so you can retry") never reached stderr. Fix moves the `if !result.failures.is_empty()` block immediately after `remove::execute(...)?`, before the save chain. On the failure path, no in-memory mutations leak to disk. New integration test snapshots `tome.toml`, `.tome-manifest.json`, and `tome.lock` byte-for-byte and asserts they're unchanged after a `chmod 0o500`-induced partial failure.

**HOTFIX-03 (#461 H3) — failure-summary line mispromised `tome doctor` output.** The leading line ended with `... after addressing these. Run \`tome doctor\`:` — the trailing colon read as if it introduced `tome doctor`'s output, but what actually followed was the per-kind listing. Reworded to `... after addressing these. Run \`tome doctor\` after resolving:` so the colon unambiguously belongs to the listing.

## Traceability

- Issue: [#461](https://github.com/MartinP7r/tome/issues/461) (post-merge re-review of #460)
- Phase artifacts: \`.planning/phases/08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain/\`
- Verification: \`08.1-VERIFICATION.md\` — 9/9 must-haves passed
- Requirements: HOTFIX-01, HOTFIX-02, HOTFIX-03 (tracked via phase artifacts + #461 per project STATE decision)

## Test plan

- [x] \`make ci\` passes (464 unit + 126 integration tests, fmt-check, clippy \`-D warnings\`, typos)
- [x] \`cargo test -p tome lockfile::tests::resolved_paths_from_lockfile_cache_\` — 6 unit tests pass
- [x] \`cargo test -p tome --test cli remove_preserves_git_lockfile_entries\` — guards H1
- [x] \`cargo test -p tome --test cli remove_partial_failure_does_not_save_disk_state\` — guards H2 (manually verified to FAIL when reorder is reverted)
- [x] \`cargo test -p tome --test cli remove_failure_summary_wording\` — guards H3
- [x] Existing \`remove_partial_failure_exits_nonzero_with_warning_marker\` still passes — no regression on the existing partial-failure test

## Release

After merge: \`make release VERSION=0.8.1\`