### PR TITLE
chore: archive v0.8 milestone

### DIFF
--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,5 +1,20 @@
 # Milestones
 
+## v0.8 Wizard UX & Safety Hardening (Shipped: 2026-04-27)
+
+**Phases completed:** 2 phases, 7 plans, 26 tasks
+
+**Key accomplishments:**
+
+- `tome init` now prints `resolved tome_home: <path> (from <source>)` before any Step 1 wizard prompts so users can Ctrl-C before destructive writes — foundation for WUX-01 greenfield gating.
+- `tome init` on a greenfield machine now prompts for `tome_home` location (default `~/.tome`, custom with path validation) and offers to persist a custom choice to `~/.config/tome/config.toml` — closing the silent-default footgun and fixing the latent `default_config_path()` save-path bug at wizard.rs:310.
+- `tome init` on a brownfield machine (existing `tome.toml` at the resolved `tome_home`) now shows a summary and offers 4 choices (use existing / edit / reinitialize-with-backup / cancel) — the dotfiles-sync workflow that triggered the v0.8 milestone is safe: `--no-input` defaults to "use existing" and never overwrites a valid config. `Option<&Config>` prefill threads through every wizard helper so "edit" preserves custom directories that aren't in `KNOWN_DIRECTORIES` (Pitfall 2 fix).
+- `tome remove` now aggregates partial-cleanup failures into a typed `Vec<RemoveFailure>`, prints a grouped `⚠ K operations failed` summary to stderr, and exits non-zero — closing #413 where the command silently reported success while filesystem artifacts leaked.
+- `tome browse` `open` (ViewSource) and `copy path` (CopyPath) actions now work on Linux via `xdg-open` + `arboard` (replacing the macOS-only `open` + `sh -c … | pbcopy` invocation which was also a command-injection vector), and both success (`✓`) and failure (`⚠`) outcomes appear in the TUI status bar in place of the keybind line until the next keypress — closing #414.
+- Replaced silent `std::fs::read_link(..).ok()` drop at `relocate.rs:93` with an explicit match that emits a stderr warning on `Err` in the canonical PR #448 format, plus a regression test engineering the failure via `chmod 0o000`.
+
+---
+
 ## v0.7 Wizard Hardening (Shipped: 2026-04-22)
 
 **Phases completed:** 3 phases, 9 plans, 8 tasks

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -33,25 +33,28 @@ Every AI coding tool on a developer's machine shares the same skill library with
 - ✓ `tome reassign` / `tome fork` — change skill provenance — v0.6
 - ✓ Browse TUI polish (theming, scrollbar, fuzzy highlighting, markdown preview) — v0.6
 
-### Active (v0.8)
+### Validated in v0.8
 
-- [x] **WUX-01** Wizard prompts for `tome_home` on greenfield (#453) — *Validated in Phase 7 (2026-04-23)*
-- [x] **WUX-02** Wizard detects existing `.tome/` config (brownfield: use / edit / reinitialize) (#453) — *Validated in Phase 7 (2026-04-23)*
-- [x] **WUX-03** Wizard detects legacy `~/.config/tome/config.toml` pre-v0.6 file and offers cleanup (#453) — *Validated in Phase 7 (2026-04-23)*
-- [x] **WUX-04** Wizard prints resolved `tome_home` up-front as info line (#453) — *Validated in Phase 7 (2026-04-23)*
-- [x] **WUX-05** Wizard offers to persist custom `tome_home` via XDG config write (#453) — *Validated in Phase 7 (2026-04-23)*
-- [x] **SAFE-01** `remove::execute` aggregates partial-cleanup failures and surfaces them (#413) — *Validated in Phase 8 (2026-04-24)*
-- [x] **SAFE-02** Browse UI `open` and `copy path` actions work on Linux (#414) — *Validated in Phase 8 (2026-04-24); Linux runtime behavior flagged in 08-HUMAN-UAT.md for hands-on verification*
-- [x] **SAFE-03** `relocate.rs` surfaces `fs::read_link` errors instead of silently dropping (#449) — *Validated in Phase 8 (2026-04-24)*
+- ✓ **WUX-01** Wizard prompts for `tome_home` on greenfield — Phase 7 (2026-04-23)
+- ✓ **WUX-02** Wizard detects existing `.tome/` config (brownfield: use / edit / reinitialize) — Phase 7 (2026-04-23)
+- ✓ **WUX-03** Wizard detects legacy `~/.config/tome/config.toml` pre-v0.6 file and offers cleanup — Phase 7 (2026-04-23)
+- ✓ **WUX-04** Wizard prints resolved `tome_home` up-front as info line — Phase 7 (2026-04-23)
+- ✓ **WUX-05** Wizard offers to persist custom `tome_home` via XDG config write — Phase 7 (2026-04-23)
+- ✓ **SAFE-01** `remove::execute` aggregates partial-cleanup failures and surfaces them (#413) — Phase 8 (2026-04-24)
+- ✓ **SAFE-02** Browse UI `open` and `copy path` actions work on Linux (#414) — Phase 8 (2026-04-24); Linux runtime behavior flagged in `08-HUMAN-UAT.md` for hands-on verification (carry-over)
+- ✓ **SAFE-03** `relocate.rs` surfaces `fs::read_link` errors instead of silently dropping (#449) — Phase 8 (2026-04-24)
+- ✓ **HOTFIX-01/02/03** v0.8.1 hotfix — lockfile regen + save chain reorder + wording (#461) — Phase 8.1 (2026-04-27)
 
-### Backlog (not in v0.8)
+### Active (next milestone)
 
-- Expand `KNOWN_DIRECTORIES` registry (Cursor, Windsurf, Aider — if they have skill paths)
-- v0.7.2 quick wins (#456 library default derivation, #457 tilde preservation on save) — prereq patch release
-- v0.8.1 hotfix: Phase 8 post-merge findings — partial-failure state window + silent git-skill drop (#461) — H1 is a genuine silent-drop of git-sourced skills from the regenerated lockfile in Remove/Reassign/Fork; H2 is the I2/I3 retention guarantee being voided by post-execute save failures; H3 is wording. Worth a patch release before v0.9.
+- [ ] Cross-machine config portability via `machine.toml` path overrides (#458) — primary v0.9 driver
+
+### Backlog (deferred)
+
 - v0.8.x polish: Phase 8 test coverage + wording + dead code (#462) — 5 items from the post-merge review (P1-P5): success-banner-absence assertion, retry end-to-end test, ViewSource .status() middle-branch coverage, regen-warning ordering, dead `source_path` field.
 - v0.9 polish: Phase 8 type design + TUI architecture (#463) — 6 items (D1-D6): .status() TUI blocking, StatusMessage type redesign, clipboard auto-retry, FailureKind::ALL compile-enforcement, RemoveFailure::new justification, arboard drift hygiene.
-- v0.9 scope: cross-machine config portability via machine.toml path overrides (#458)
+- Linux runtime UAT carry-over from v0.8: 2 items in `08-HUMAN-UAT.md` (clipboard + xdg-open) — pending Linux desktop hardware
+- Expand `KNOWN_DIRECTORIES` registry (Cursor, Windsurf, Aider — if they have skill paths)
 - Pre-existing flaky test: `backup::tests::push_and_pull_roundtrip` — passes in isolation, intermittent in full suite. Worth a separate investigation pass.
 
 ### Validated in v0.7
@@ -82,27 +85,41 @@ The wizard-surface work below shipped in v0.6 (as WIZ-01–05) but lacked valida
 
 *v0.7 hardening deliverables:* (a) `Config::validate()` path-overlap checks (Phase 4), (b) `Config::save_checked` with TOML round-trip (Phase 4), (c) `--no-input` plumbing (Phase 5), (d) unit + integration test coverage for pure wizard helpers (Phase 5), (e) 12-combo validation matrix (Phase 5), (f) `tabled` summary migration (Phase 6).
 
-## Current Milestone: v0.8 Wizard UX & Safety Hardening
+## Current State
 
-**Goal:** Close the new-machine / dotfiles-sync UX gap on the wizard and address the P0 safety refactors from the v0.7 whole-codebase review that didn't fit in the v0.7.1 hotfix.
+**Shipped:** v0.8.1 (2026-04-27)
 
-**Target features:**
-- Wizard prompts for `tome_home` on new machines; detects existing `.tome/` configs and offers use / edit / reinitialize flows (brownfield support)
-- Wizard surfaces the resolved `tome_home` up-front and offers to persist via XDG config (`~/.config/tome/config.toml`)
-- Wizard detects and cleans up the legacy pre-v0.6 `~/.config/tome/config.toml` file (silent ignore is a footgun)
-- `remove::execute` aggregates partial-cleanup failures and reports them — no more silent "success" when symlinks fail to delete
-- Browse UI's `open` and `copy path` actions work cross-platform (currently macOS-only with silent no-op on Linux)
-- `relocate.rs` surfaces `fs::read_link` failures instead of silently dropping them
+v0.8 milestone complete — Wizard UX & Safety Hardening. 8 requirements shipped (WUX-01..05 + SAFE-01..03) across Phases 7+8, plus the v0.8.1 hotfix (HOTFIX-01..03 across Phase 8.1) closing 3 post-merge findings from #461. Archive: [`milestones/v0.8-ROADMAP.md`](milestones/v0.8-ROADMAP.md).
 
-**Scope anchor:** Epic issue [#459](https://github.com/MartinP7r/tome/issues/459)
+**Highlights:**
+- Wizard handles greenfield, brownfield, and legacy machine states — no more silent overwrites or default-path footguns
+- `tome remove` aggregates partial-cleanup failures with grouped stderr summary + non-zero exit; save chain reordered so retention messaging surfaces before save errors
+- `tome browse` `open` + `copy path` work on Linux (`xdg-open` + `arboard`), with success/failure surfacing in TUI status bar
+- `relocate.rs` surfaces `read_link` failures instead of silently dropping
+- Lockfile regen for `tome remove`/`reassign`/`fork` no longer silently drops git-sourced skills
 
-**Key context:**
-- v0.7.1 (tabled ANSI width hotfix) and v0.7.2 (library_dir default + tilde preservation, #456/#457) are patch cuts that precede this milestone
-- v0.9 will tackle cross-machine config portability via machine.toml path overrides (#458) — larger design, intentionally deferred
+**Carry-over:** 2 Linux-runtime UAT items in `08-HUMAN-UAT.md` (clipboard runtime + xdg-open runtime) pending Linux desktop hardware. Accepted as carry-over.
 
-### Shipped in v0.7 (1-line recap)
+## Next Milestone Goals
 
-v0.7 Wizard Hardening — 8 requirements (WHARD-01..08) across Phases 4-6, shipped 2026-04-22. Archive: [`milestones/v0.7-ROADMAP.md`](milestones/v0.7-ROADMAP.md). Wizard now refuses invalid configs at save time; 525 tests passing; summary renders via `tabled` with rounded borders.
+**v0.9 Cross-Machine Config Portability** — epic [#458](https://github.com/MartinP7r/tome/issues/458)
+
+Primary driver: `machine.toml` path overrides so the same `tome.toml` can be checked into dotfiles and applied across machines with different `~/.tome` layouts. Larger design — new schema fields + override-apply timing in the load pipeline. Intentionally deferred from v0.8.
+
+Secondary candidates (from v0.8 post-merge review):
+- v0.9 polish (#463): 6 type design + TUI architecture items from Phase 8 review
+- v0.8.x polish (#462): 5 test coverage + wording + dead code items — could ship as a v0.8.x patch instead
+
+Run `/gsd:new-milestone` to plan v0.9.
+
+<details>
+<summary>Previous milestones (recap)</summary>
+
+- v0.6 Unified Directory Model (Phases 1-3, shipped 2026-04-16) — `[directories.*]` BTreeMap config, git sources, per-directory selection, `tome add`/`remove`/`reassign`/`fork`, browse TUI polish
+- v0.7 Wizard Hardening (Phases 4-6, shipped 2026-04-22) — `Config::validate()` Conflict+Why+Suggestion errors, `Config::save_checked` round-trip, `--no-input` plumbing, 12-combo matrix test, `tabled` summary
+- v0.8 Wizard UX & Safety Hardening (Phases 7-8 + 8.1 hotfix, shipped 2026-04-27) — wizard greenfield/brownfield/legacy flows, partial-failure visibility, cross-platform browse, lockfile regen safety
+
+</details>
 
 ### Out of Scope
 
@@ -114,9 +131,9 @@ v0.7 Wizard Hardening — 8 requirements (WHARD-01..08) across Phases 4-6, shipp
 
 ## Context
 
-tome is at Cargo.toml `0.6.2` pending the v0.7.0 release cut. Codebase: ~21.8k lines of Rust across 20+ source modules in a single crate. v0.6 introduced the unified directory model; v0.7 hardened the wizard surface around it.
+tome is at Cargo.toml `0.8.1` (released 2026-04-27 via cargo-dist). Codebase: ~25.2k lines of Rust across 20+ source modules in a single crate. v0.6 introduced the unified directory model; v0.7 hardened the wizard surface; v0.8 closed the new-machine/dotfiles-sync UX gap and shipped partial-failure visibility + cross-platform browse actions.
 
-The Rust codebase uses `anyhow` for errors, `serde`/`toml` for config, `clap` for CLI, `ratatui` for the TUI browser, and `nucleo-matcher` for fuzzy search. Tests use `assert_cmd` + `tempfile` + `insta` snapshots. CI runs on Ubuntu and macOS. 525 tests total (417 unit + 108 integration).
+The Rust codebase uses `anyhow` for errors, `serde`/`toml` for config, `clap` for CLI, `ratatui` for the TUI browser, and `nucleo-matcher` for fuzzy search. Tests use `assert_cmd` + `tempfile` + `insta` snapshots. CI runs on Ubuntu and macOS. 590 tests total (464 unit + 126 integration as of v0.8.1).
 
 Config is `directories: BTreeMap<DirectoryName, DirectoryConfig>` where each entry has a `role` (managed/synced/source/target) and `type` (claude-plugins/directory/git). `Config::save_checked` enforces expand → `validate()` → TOML round-trip → write; no invalid config can reach disk.
 
@@ -145,12 +162,17 @@ Config is `directories: BTreeMap<DirectoryName, DirectoryConfig>` where each ent
 | TOML round-trip byte-equality over `PartialEq` (v0.7 Phase 4) | Avoids deriving PartialEq cascade across all config types; compares emitted strings | ✓ Good — `Config::save_checked` enforces in ~20 lines |
 | `--no-input` flag over separate non-interactive binary (v0.7 Phase 5) | One wizard, two modes — integration tests drive the same code path users run | ✓ Good — 12-combo matrix test possible because of this |
 | `tabled` `Style::rounded()` for wizard summary, `Style::blank()` stays for `tome status` (v0.7 Phase 6) | Ceremonial one-shot summary deserves visual weight; repeated inspection wants lightweight | ✓ Good — matching pattern not required |
+| Brownfield default = "use existing" (v0.8 Phase 7 / WUX-02) | Safest for the dotfiles-sync workflow that triggered v0.8; never silently overwrites a valid config | ✓ Good — `--no-input` defaults to use-existing too |
+| Legacy config: warn + offer delete, not silent auto-delete (v0.8 Phase 7 / WUX-03) | File may contain user-valued data worth manual review | ✓ Good |
+| `tome_home` prompt writes XDG config, not `TOME_HOME` env-var injection (v0.8 Phase 7 / WUX-05 / D-2) | XDG file is shell-agnostic; propagates to cron/editor/subshells | ✓ Good |
+| `arboard` (default-features = false) for cross-platform clipboard (v0.8 Phase 8 / SAFE-02) | Replaces `sh -c \| pbcopy` command-injection vector; no `image` crate in dep tree | ✓ Good — Linux runtime carry-over flagged in HUMAN-UAT |
+| Glyph-prefix dispatch (✓ → `theme.accent`, ⚠ → `theme.alert`) for status bar (v0.8 Phase 8 / SAFE-02) | Reuses existing theme fields; no new `theme.warning` needed | ✓ Good |
+| Lockfile-as-cache for offline resolved-paths recovery (v0.8.1 Phase 8.1 / HOTFIX-01) | Reads previous lockfile + on-disk repo cache; no `git fetch` from destructive commands; per-directory warnings replace silent skip | ✓ Good — closes #461 H1 silent-drop regression |
+| `if !result.failures.is_empty()` block fires before save chain in `Command::Remove` (v0.8.1 Phase 8.1 / HOTFIX-02) | Save-chain `?` propagation was masking the I2/I3 retention messaging on disk-write errors | ✓ Good — closes #461 H2 |
 
 ## Evolution
 
 This document evolves at phase transitions and milestone boundaries.
 
 ---
-*Last updated: 2026-04-26 — Phase 8.1 (v0.8.1 hotfix) complete. Closes #461 H1 (silent-drop regression in lockfile regen — `resolved_paths_from_lockfile_cache` helper restores git-skill provenance to Remove/Reassign/Fork), H2 (save-chain reorder so partial-failure ⚠ block surfaces before save errors), H3 (failure-summary wording). 590 tests passing (464 unit + 126 integration; +9 since v0.8). 2 Linux-runtime verification items still pending in `08-HUMAN-UAT.md`. v0.8.1 ready for `make release VERSION=0.8.1`.*
-
-*Last updated: 2026-04-24 — Phase 8 shipped via PR #460 (squash commit `b884c31` on main). v0.8 milestone complete — 8 requirements shipped (WUX-01..05 + SAFE-01..03) across Phases 7+8. 581 tests passing (458 unit + 123 integration after post-merge PR review added 5 tests). 2 Linux-runtime verification items tracked in `08-HUMAN-UAT.md`. Post-merge review filed follow-up issues #461 (v0.8.1 hotfix candidates), #462 (v0.8.x polish), #463 (v0.9 polish) — see backlog section above.*
+*Last updated: 2026-04-27 after v0.8 milestone — v0.8.1 shipped via cargo-dist (commits e13eb31 + 231e52d on main). v0.8 milestone archived: 8 v0.8 requirements (WUX-01..05 + SAFE-01..03) + 3 v0.8.1 hotfix requirements (HOTFIX-01..03) shipped across Phases 7, 8, and 8.1. 590 tests passing (464 unit + 126 integration). Linux-runtime UAT items in `08-HUMAN-UAT.md` accepted as carry-over pending hardware. Ready for v0.9 (cross-machine config portability, #458).*

--- a/.planning/RETROSPECTIVE.md
+++ b/.planning/RETROSPECTIVE.md
@@ -36,13 +36,58 @@
 - **Verification checkboxes must auto-update**: The gap between "code ships" and "requirement marked done" is a manual step that gets missed. Consider automating traceability updates in the verification step
 - **PR review finds what verification misses**: Phase verification checks "does the code do X?" but not "does the code handle edge Y safely?" — both gates are valuable
 
+## Milestone: v0.8 — Wizard UX & Safety Hardening
+
+**Shipped:** 2026-04-27 (v0.8.0 on 2026-04-26 + v0.8.1 hotfix on 2026-04-27)
+**Phases:** 3 (7, 8, 8.1) | **Plans:** 10 | **Tasks:** ~26
+
+### What Was Built
+- Wizard handles greenfield, brownfield, and legacy machine states (WUX-01..05) — `tome init` no longer silently overwrites valid configs or ignores legacy `~/.config/tome/config.toml` files
+- `tome remove` aggregates partial-cleanup failures into a typed `Vec<RemoveFailure>` and surfaces them via grouped stderr summary + non-zero exit (SAFE-01 / #413)
+- `tome browse` `open` and `copy path` actions work on Linux via `xdg-open` + `arboard` — replaces the macOS-only `sh -c | pbcopy` invocation that was also a command-injection vector (SAFE-02 / #414)
+- `relocate.rs` `read_link` failures surface as stderr warnings instead of silent `.ok()` drops (SAFE-03 / #449)
+- v0.8.1 hotfix (Phase 8.1): offline `resolved_paths_from_lockfile_cache` helper restores git-skill provenance after Remove/Reassign/Fork; `Command::Remove` save chain reordered so partial-failure ⚠ block surfaces before save errors; failure-summary wording reworded (HOTFIX-01..03 / #461)
+
+### What Worked
+- **Hotfix discipline held**: Phase 8.1 was scoped tightly to 3 plans / 3 waves / 3 sequential commits per task. No scope creep into "while we're in there" cleanup. v0.8.1 shipped exactly what #461 captured.
+- **Byte-for-byte snapshot tests for "this code path doesn't write to disk"**: HOTFIX-02's integration test reads `tome.toml` / `.tome-manifest.json` / `tome.lock` bytes pre/post and `assert_eq!` — the right shape for proving non-mutation, beats logical assertions that miss timestamp/whitespace re-emit.
+- **Manual test-revert sanity check**: Each hotfix integration test was manually verified to FAIL when the production fix is reverted. Confirms tests actually exercise the bug, not just structurally pass.
+- **Decimal phase numbering**: Inserting Phase 8.1 as a hotfix between Phase 8 and Phase 9 worked cleanly — preserves linear roadmap reading while making the patch-release relationship explicit.
+- **Auto-applied rustfmt as separate commit**: Wave 3's executor committed `style(08.1-03): rustfmt wrap` separately from the test commit. Clean diff, behavior unchanged, no `--no-verify` shenanigans.
+
+### What Was Inefficient
+- **Branch-drift via stray-branch creation**: Two of three Wave 3 executor agent calls created and silently switched to a stray `gsd/phase-01-unified-directory-foundation` branch and committed phase artifacts there instead of the active phase branch. Recovered both times via `git merge --ff-only` + `git branch -d`, but the orchestrator had to detect and clean up. Root cause: `gsd-tools commit` infers branch policy from STATE.md, and post-`phase complete` STATE.md cleared the active phase, defaulting to phase 01. Worth filing upstream.
+- **HOTFIX-01/02/03 not in REQUIREMENTS.md**: By design (project decision in STATE.md), but the verifier and `requirements mark-complete` paths kept hitting `not_found` and surfacing it as a question. Could be smoother — either a formal "hotfix without REQ" workflow or skip-flagging.
+- **`/gsd:complete-milestone` workflow vs project tag policy**: The workflow's `git_tag` step conflicts with this project's `make release` ownership of tagging. Resolved by skipping the step, but the workflow doesn't have a config flag for this — had to recognize the conflict via stored memory and pause for user confirmation.
+- **`typos` CLI not in dev-env path**: `make ci` includes `typos` but it wasn't installed locally. Each wave that ran `make ci` had to install it first. Worth a one-time `cargo install typos-cli` + Makefile bootstrap target.
+- **Linux runtime UAT items deferred indefinitely**: 2 items in `08-HUMAN-UAT.md` (clipboard / xdg-open runtime) accepted as carry-over for two consecutive milestone closures. Either accept-as-carry-over with explicit closure semantics or actually run the test.
+
+### Patterns Established
+- **Lockfile-as-cache for offline-only operations**: When destructive commands need data that `sync()` would normally fetch online, read the previous lockfile + check on-disk artifacts. Better than empty default (silent drop) or running the online resolver (network from local commands).
+- **Save-chain ordering as user-facing contract**: When `Result<T>` flows through multiple `?` gates with side-effecting println before/after, the order of those println relative to `?` *is* the contract. Failure-state messaging must come before any `?` that could short-circuit it.
+- **`chmod 0o500` (not `0o000`) for partial-failure fixtures**: `0o000` makes `read_dir` itself fail, so `plan()` bails before `execute()` runs the partial-failure loop. `0o500` lets enumeration succeed but blocks `unlink`, hitting the actual code path under test.
+
+### Key Lessons
+1. **Empty-default is the laziest bug pattern**: `BTreeMap::new()` passed where `discover_all` expects resolved paths is syntactically valid but semantically a stand-in saying "I didn't do the work." HOTFIX-01 lived through Phase 8 review because no integration test crossed the destructive-command + git-source seam end-to-end. New rule: if a function takes a "context" map populated by a sibling caller, write at least one test exercising every caller with a populated map.
+2. **Phase complete ≠ milestone complete**: v0.8.0 shipped, then post-merge re-review surfaced 3 findings worth a patch release. Build the planning model so a "v0.X.0 ships → review → v0.X.1 hotfix → milestone closes" flow is normal and not exceptional.
+3. **Verifier deviations matter**: Wave 1's executor surfaced a worthwhile deviation (asserting on `git_commit_sha` instead of `source_name` per plan) because the bug actually lives in the SHA fallback, not the source-name field. Plans describe intent; the executor reasoning about the bug catches plan-error cases.
+4. **Spawned agents can switch branches silently**: Always verify branch state after each agent return when running parallel/sequential executors. Spot-check via `git branch --show-current` plus reflog if drift is suspected.
+
+### Cost Observations
+- Model mix: orchestrator on Sonnet 4.6, executors on Opus, verifier on Sonnet — typical balanced profile
+- Phase 8.1 wall time: ~16 min for 3 sequential waves + verification (vs ~30 min projected for 3 plans)
+- Integration test revert-and-rerun sanity checks added ~3 min per plan but caught 0 false-positives this milestone — still worth it as a discipline
+
 ## Cross-Milestone Trends
 
-| Metric | v0.6 |
-|--------|------|
-| Phases | 3 |
-| Plans | 11 |
-| Tasks | ~19 |
-| Timeline | 2 days |
-| Known gaps | 5 (WIZ-01–05) |
-| Critical bugs found in review | 3 |
+| Metric | v0.6 | v0.8 |
+|--------|------|------|
+| Phases | 3 | 3 (7, 8, 8.1) |
+| Plans | 11 | 10 |
+| Tasks | ~19 | ~26 |
+| Timeline | 2 days | ~5 days incl. hotfix |
+| Known gaps | 5 (WIZ-01–05) | 2 (Linux UAT carry-over) |
+| Critical bugs found in review | 3 | 3 (#461 H1/H2/H3) |
+| Hotfix release | — | v0.8.1 (3 fixes) |
+
+**Recurring pattern:** Post-merge review consistently catches issues that phase verification misses — both as a quality gate. v0.6 had a 3-issue PR review; v0.8 had a 3-issue post-merge re-review. Worth formalizing as a phase exit criterion.

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -4,7 +4,8 @@
 
 - ✅ **v0.6 Unified Directory Model** — Phases 1-3 (shipped 2026-04-16) — [archive](milestones/v0.6-ROADMAP.md)
 - ✅ **v0.7 Wizard Hardening** — Phases 4-6 (shipped 2026-04-22) — [archive](milestones/v0.7-ROADMAP.md)
-- 🚧 **v0.8 Wizard UX & Safety Hardening** — Phases 7-8 (active since 2026-04-23) — epic [#459](https://github.com/MartinP7r/tome/issues/459)
+- ✅ **v0.8 Wizard UX & Safety Hardening** — Phases 7-8 + 8.1 hotfix (shipped 2026-04-27) — [archive](milestones/v0.8-ROADMAP.md)
+- 📋 **v0.9 Cross-Machine Config Portability** — planned — epic [#458](https://github.com/MartinP7r/tome/issues/458)
 
 ## Phases
 
@@ -30,43 +31,23 @@
 
 </details>
 
-### v0.8 Wizard UX & Safety Hardening
+<details>
+<summary>✅ v0.8 Wizard UX & Safety Hardening (Phases 7-8 + 8.1) — SHIPPED 2026-04-27</summary>
 
-- [x] **Phase 7: Wizard UX (Greenfield / Brownfield / Legacy)** — `tome init` handles new machines, existing configs, and pre-v0.6 cruft without surprises; resolved `tome_home` is surfaced up-front and optionally persisted via XDG config *(completed 2026-04-23)*
-- [ ] **Phase 8: Safety Refactors (Partial-Failure Visibility & Cross-Platform)** — destructive commands surface partial failures; browse UI's external actions work on Linux; silent `fs::read_link(..).ok()` sites are replaced with surfaced warnings
+- [x] Phase 7: Wizard UX — Greenfield / Brownfield / Legacy (4/4 plans) — `tome init` handles new machines, existing configs, and pre-v0.6 cruft without surprises; resolved `tome_home` surfaced up-front and optionally persisted via XDG config (WUX-01/02/03/04/05)
+- [x] Phase 8: Safety Refactors — Partial-Failure Visibility & Cross-Platform (3/3 plans) — `tome remove` aggregates partial-cleanup failures with non-zero exit, `tome browse` works on Linux via `xdg-open` + `arboard`, silent `read_link().ok()` drops replaced with stderr warnings (SAFE-01/02/03)
+- [x] Phase 8.1: v0.8.1 hotfix — lockfile regen + save chain (3/3 plans) — `resolved_paths_from_lockfile_cache` helper restores git-skill provenance after Remove/Reassign/Fork (H1), `Command::Remove` save chain reordered to surface partial-failure ⚠ block before save errors (H2), failure-summary wording reworded (H3)
 
-## Phase Details
+**Released as:** v0.8.0 (2026-04-26) + v0.8.1 hotfix (2026-04-27)
+**Carry-over:** 2 Linux-runtime UAT items in `08-HUMAN-UAT.md` (clipboard / xdg-open) — accepted as carry-over pending Linux desktop hardware
 
-### Phase 7: Wizard UX (Greenfield / Brownfield / Legacy)
-**Goal**: `tome init` behaves predictably on any machine state — fresh install, dotfiles-synced home, or pre-v0.6 cruft — and tells the user which `tome_home` it is about to populate
-**Depends on**: Phase 6 (v0.7 Wizard Hardening shipped — `Config::save_checked` and `--no-input` plumbing are prerequisites)
-**Requirements**: WUX-01, WUX-02, WUX-03, WUX-04, WUX-05
-**Success Criteria** (what must be TRUE):
-  1. User running `tome init` on a greenfield machine (no `TOME_HOME`, no XDG config, no existing `.tome/tome.toml`) sees a prompt to choose `tome_home` with `~/.tome/` as the default and a custom-path option that is validated before the wizard proceeds
-  2. User running `tome init` on a brownfield machine (existing `tome.toml` at the resolved `tome_home`) sees a summary of the detected config (directory count, library_dir, last-modified date) and can choose **use existing** (default), **edit existing**, **reinitialize** (with backup), or **cancel** — no path silently overwrites a valid config
-  3. User with a legacy pre-v0.6 `~/.config/tome/config.toml` (contains `[[sources]]` or `[targets.*]`) sees a warning that the file is ignored by current tome and is offered a delete-or-move-aside action — no silent ignore, no auto-delete
-  4. Every `tome init` invocation prints a 1-line "resolved tome_home: <path>" info message before Step 1 prompts, so the user can abort immediately if the wrong path is about to be populated
-  5. When the user selects a custom `tome_home` in the greenfield flow, wizard offers to persist the choice by writing `~/.config/tome/config.toml` with a `tome_home = "..."` field; subsequent `tome sync` / `tome status` invocations find it without `TOME_HOME` env var
-**Plans**: 4 plans
-  - [x] 07-01-wux-04-resolved-tome-home-info-PLAN.md — print resolved tome_home + source label at start of tome init (WUX-04)
-  - [x] 07-02-wux-03-legacy-config-detection-PLAN.md — MachineState + has_legacy_sections + legacy cleanup handler (WUX-03)
-  - [x] 07-03-wux-01-05-tome-home-prompt-PLAN.md — Step 0 greenfield tome_home prompt + XDG persist (WUX-01, WUX-05)
-  - [x] 07-04-wux-02-brownfield-decision-PLAN.md — 4-way brownfield decision + prefill plumbing (WUX-02)
-**UI hint**: yes
+</details>
 
-### Phase 8: Safety Refactors (Partial-Failure Visibility & Cross-Platform)
-**Goal**: Destructive commands cannot report success while partial cleanup failed; browse UI's external actions work on Linux; silent `.ok()` drops on symlink reads are replaced with surfaced warnings
-**Depends on**: Phase 7 (independent changesets, but keeping linear ordering simplifies branch strategy and release cut)
-**Requirements**: SAFE-01, SAFE-02, SAFE-03
-**Success Criteria** (what must be TRUE):
-  1. User running `tome remove <name>` in a state where some symlinks/dirs cannot be cleaned (permissions, missing files) sees a distinct "⚠ N operations failed" summary with per-item detail and the command exits non-zero — the clean success path remains quiet as before
-  2. User on Linux pressing the `open` action in `tome browse` has the skill opened via `xdg-open` (and `copy path` via `wl-copy`/`xclip` or an equivalent cross-platform clipboard crate); any failure appears in the TUI status bar instead of being silently discarded by `let _ = ...`
-  3. User running `tome relocate` (or any command transiting the patched `fs::read_link(..).ok()` sites) sees a stderr warning when a symlink cannot be read, with enough context (path + error) to diagnose — the command no longer silently records "no provenance" on such failures
-  4. `cargo test` covers the new `RemoveResult` aggregation (including a partial-failure case) and the Linux-path branches of the browse action dispatcher (under `#[cfg(target_os = "linux")]` or via platform-agnostic abstractions)
-**Plans**: 3 plans
-  - [x] 08-01-safe-01-remove-partial-failure-aggregation-PLAN.md — RemoveResult aggregates per-loop FailureKind records; lib.rs Command::Remove surfaces grouped '⚠ K operations failed' summary + exits non-zero (SAFE-01 / #413)
-  - [x] 08-02-safe-02-browse-cross-platform-status-bar-PLAN.md — arboard clipboard + cfg!-dispatched open/xdg-open + App.status_message rendered in browse status bar (SAFE-02 / #414)
-  - [x] 08-03-safe-03-relocate-read-link-warning-PLAN.md — relocate.rs:93 explicit match + eprintln warning mirroring PR #448 pattern (SAFE-03 / #449)
+### v0.9 Cross-Machine Config Portability (Planned)
+
+Epic: [#458](https://github.com/MartinP7r/tome/issues/458) — `machine.toml` path overrides for cross-machine portability.
+
+Phases TBD — run `/gsd:new-milestone` to plan v0.9.
 
 ## Progress
 
@@ -79,15 +60,5 @@
 | 5. Wizard Test Coverage | v0.7 | 4/4 | Complete | 2026-04-20 |
 | 6. Display Polish & Docs | v0.7 | 2/2 | Complete | 2026-04-22 |
 | 7. Wizard UX (Greenfield / Brownfield / Legacy) | v0.8 | 4/4 | Complete | 2026-04-23 |
-| 8. Safety Refactors (Partial-Failure Visibility & Cross-Platform) | v0.8 | 0/3 | Planned | — |
-
-### Phase 08.1: v0.8.1 hotfix — lockfile regen + save chain (INSERTED)
-
-**Goal:** Close 3 post-merge findings from #461 — restore git-skill provenance to the regenerated lockfile in Remove/Reassign/Fork (H1, silent-drop regression introduced by Phase 8), reorder the save chain so partial-failure ⚠ block surfaces before save errors propagate (H2), and reword the failure-summary line for clarity (H3).
-**Requirements**: HOTFIX-01 (H1), HOTFIX-02 (H2), HOTFIX-03 (H3)
-**Depends on:** Phase 8
-**Source:** [#461](https://github.com/MartinP7r/tome/issues/461)
-**Plans:** 3/3 plans complete
-  - [x] 08.1-01-hotfix-01-lockfile-regen-resolved-paths-PLAN.md — `resolved_paths_from_lockfile_cache` helper + replace empty BTreeMap at Remove/Reassign/Fork sites; integration test (HOTFIX-01 / #461 H1)
-  - [x] 08.1-02-hotfix-02-remove-save-chain-reorder-PLAN.md — move `if !result.failures.is_empty()` block before save chain in Command::Remove; integration test asserting no disk writes on partial-failure (HOTFIX-02 / #461 H2)
-  - [x] 08.1-03-hotfix-03-failure-summary-reword-PLAN.md — reword leading line to `Run `tome doctor` after resolving:`; stderr-wording test (HOTFIX-03 / #461 H3)
+| 8. Safety Refactors (Partial-Failure Visibility & Cross-Platform) | v0.8 | 3/3 | Complete | 2026-04-24 |
+| 8.1. v0.8.1 hotfix — lockfile regen + save chain | v0.8 | 3/3 | Complete | 2026-04-27 |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,16 +1,16 @@
 ---
 gsd_state_version: 1.0
-milestone: v0.8
-milestone_name: Wizard UX & Safety Hardening
-status: verifying
-stopped_at: Completed 08.1-03-hotfix-03-failure-summary-reword-PLAN.md — phase 08.1 complete, v0.8.1 ready for make release
-last_updated: "2026-04-26T12:51:56.881Z"
-last_activity: 2026-04-26
+milestone: null
+milestone_name: null
+status: between-milestones
+stopped_at: v0.8 milestone shipped (v0.8.1 — 2026-04-27); ready to plan v0.9
+last_updated: "2026-04-27T00:00:00.000Z"
+last_activity: 2026-04-27
 progress:
-  total_phases: 2
-  completed_phases: 2
-  total_plans: 7
-  completed_plans: 7
+  total_phases: 0
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
   percent: 0
 ---
 
@@ -18,28 +18,18 @@ progress:
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-04-23)
+See: .planning/PROJECT.md (updated 2026-04-27)
 
 **Core value:** Every AI coding tool on a developer's machine shares the same skill library without manual copying or per-tool configuration.
-**Current focus:** Phase 08.1 — v0-8-1-hotfix-lockfile-regen-and-save-chain
+**Current focus:** Between milestones — v0.8 shipped, v0.9 not yet planned
 
 ## Current Position
 
-Milestone: v0.8 — Wizard UX & Safety Hardening
-Phase: 08.1
-Plan: Not started
-Status: Phase complete — ready for verification
-Last activity: 2026-04-26
+Milestone: (none — between milestones)
+Last shipped: v0.8.1 (2026-04-27)
+Next: v0.9 — Cross-Machine Config Portability (epic [#458](https://github.com/MartinP7r/tome/issues/458)) — not yet planned
 
-Progress: [░░░░░░░░░░] 0% (roadmap created, plans pending)
-
-## Performance Metrics
-
-- Requirements defined: 8 (v1 — 5 WUX + 3 SAFE)
-- Requirements mapped to phases: 8/8 ✓
-- Phases: 2 (Phase 7 WUX, Phase 8 SAFE)
-- Scope anchor: GitHub issue #459 (epic)
-- Prerequisites (not in v0.8): v0.7.1 (PR #455) + v0.7.2 (#456, #457) — both patch releases
+Run `/gsd:new-milestone` to plan v0.9.
 
 ## Accumulated Context
 
@@ -47,51 +37,24 @@ Progress: [░░░░░░░░░░] 0% (roadmap created, plans pending)
 
 Historical decisions are archived in:
 
-- `.planning/PROJECT.md` — rolling Key Decisions table (v0.6 + v0.7)
+- `.planning/PROJECT.md` — rolling Key Decisions table (v0.6 + v0.7 + v0.8)
+- `.planning/milestones/v0.8-ROADMAP.md` — per-phase decisions for v0.8
 - `.planning/milestones/v0.7-ROADMAP.md` — per-phase decisions for v0.7
 - `.planning/milestones/v0.6-ROADMAP.md` — per-phase decisions for v0.6
 
-v0.8-specific decisions (from epic #459):
+### Pending Todos / Carry-over
 
-- **D-1 (v0.8 scope):** machine.toml path overrides are NOT in v0.8 — deferred to v0.9 because it's a bigger design requiring new schema fields and override-apply timing in the load pipeline.
-- **D-2 (v0.8 scope):** `tome_home` prompt writes XDG config (not `TOME_HOME` env-var injection into shell rc) — XDG file is shell-agnostic and propagates to cron/editor/subshells.
-- **D-3 (v0.8 scope):** Wizard brownfield flow default = "use existing" — safest for the dotfiles-sync workflow the reporter described.
-- **D-4 (v0.8 scope):** Legacy `~/.config/tome/config.toml` detection = warn + offer delete, NOT silent auto-delete — file may contain user-valued data worth manual review.
-- [Phase 07-wizard-ux-greenfield-brownfield-legacy]: WUX-04: additive resolve_tome_home_with_source — kept existing resolve_tome_home for non-init call sites; only Command::Init consumes the tagged variant
-- [Phase 07-wizard-ux-greenfield-brownfield-legacy]: WUX-03: parse TOML (not substring-match) for legacy-schema detection; graceful no-op on malformed files; interactive default is move-aside (non-destructive backup); --no-input default is leave with stderr note
-- [Phase 07-wizard-ux-greenfield-brownfield-legacy]: WUX-01/05: Step 0 gated on matches!(source, TomeHomeSource::Default) && !no_input; custom tome_home persisted to XDG via merge-preserve write; configure_library default derives from <tome_home>/skills; fixed wizard.rs:310 latent bug by using resolve_config_dir(tome_home)
-- [Phase 07-wizard-ux-greenfield-brownfield-legacy]: WUX-02: brownfield decision 4-way dispatch (UseExisting/Edit/Reinit/Cancel); --no-input + invalid config = Cancel (no silent advance); backup_brownfield_config uses copy-not-rename so Cancel-after-backup is safe; prefill union in configure_directories preserves custom dirs through edit (Pitfall 2 fix)
-- [Phase 08-safety-refactors-partial-failure-visibility-cross-platform]: SAFE-01: RemoveResult.failures Vec<RemoveFailure> with typed FailureKind enum; Command::Remove surfaces grouped ⚠ K operations failed stderr block and returns Err on partial cleanup failures — exit ≠ 0 (closes #413)
-- [Phase 08-safety-refactors-partial-failure-visibility-cross-platform]: SAFE-01: Integration test uses chmod 0o500 (not 0o000 per plan) — 0o000 causes plan() to bail before execute() partial-failure loop runs; 0o500 lets read_dir enumerate but blocks remove_file unlink
-- [Phase 08-safety-refactors-partial-failure-visibility-cross-platform]: SAFE-02: arboard (default-features = false) replaces sh -c | pbcopy; cfg!(target_os = "macos") dispatches open/xdg-open; App.status_message renders ✓/⚠ in status bar until next keypress (closes #414)
-- [Phase 08-safety-refactors-partial-failure-visibility-cross-platform]: SAFE-02: glyph-prefix dispatch (starts_with('⚠') → theme.alert; else → theme.accent) reuses existing theme fields; no theme.warning added. Test tolerates both ✓/⚠ prefixes — no trait ClipboardBackend (D-17/D-19 held)
-- [Phase 08-safety-refactors-partial-failure-visibility-cross-platform]: SAFE-03: relocate::plan() now surfaces read_link failures via eprintln warning mirroring PR #448's format verbatim; regression test uses chmod 0o000 + documents Unix platform caveat that is_symlink and read_link share the same parent-search permission (closes #449)
-- [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-01: introduced offline lockfile::resolved_paths_from_lockfile_cache helper (option-(b) lockfile-as-cache) — destructive commands recover git-skill provenance from previous lockfile + on-disk repo cache without network calls
-- [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-01: integration test asserts on git_commit_sha (not source_name) — bug wipes provenance via lockfile::generate's None-fallback, source_name comes from manifest and survives unrelated removes; uses real local file:// git repo so sync's normal clone/update flow seeds the lockfile offline
-- [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: Note: HOTFIX-01/02/03 are referenced in plan frontmatter and ROADMAP.md but were never added to REQUIREMENTS.md —  is a no-op for these. Track via the phase ROADMAP/SUMMARY artifacts and #461 instead.
-- [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-02: Command::Remove ⚠ block moved to fire immediately after remove::execute() returns and BEFORE config.save / manifest::save / lockfile regen — ?-propagation in the save chain can no longer mask the I2/I3 retention messaging
-- [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-02: integration test asserts byte-for-byte equality of tome.toml / .tome-manifest.json / tome.lock pre- vs post-remove under chmod 0o500 partial-failure; tolerates missing tome.lock via unwrap_or_default()
-- [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-03: leading eprintln! in Command::Remove ⚠ block reworded — trailing colon now introduces the per-kind listing instead of falsely promising tome doctor output (closes #461 H3); inline reword over terminal-line variant for single-line risk profile
-- [Phase 08.1-v0-8-1-hotfix-lockfile-regen-and-save-chain]: HOTFIX-03: integration test asserts on three substrings (positive 'after resolving:', sentinel 'tome doctor', negative 'addressing these. Run `tome doctor`:' absent) under NO_COLOR=1 so styled output renders as plain literal
-
-### Roadmap Evolution
-
-- Phase 8.1 inserted after Phase 8 (2026-04-26): v0.8.1 hotfix — lockfile regen + save chain (URGENT). Source: post-merge re-review of PR #460 surfaced 3 correctness/UX findings ([#461](https://github.com/MartinP7r/tome/issues/461)). H1 is a silent-drop regression (git skills omitted from regenerated lockfile in Remove/Reassign/Fork), H2 is the I2/I3 retention guarantee being voided by post-execute save failures, H3 is wording. Worth a patch release before v0.9.
-
-### Pending Todos
-
-- **First:** merge PR #455 + ship v0.7.1 via `make release VERSION=0.7.1`
-- **Then:** ship v0.7.2 patch with #456 + #457 (small scope, could bundle with v0.8 Phase 7 or ship separately)
-- **Then:** `/gsd:plan-phase 7` to decompose the first v0.8 phase (Wizard UX)
-- **Then:** `/gsd:plan-phase 8` for the safety refactors
+- **Linux UAT (v0.8 carry-over):** 2 pending items in `.planning/phases/08-*/08-HUMAN-UAT.md` — clipboard runtime + xdg-open runtime tests on a Linux desktop. Pending hardware. Run `/gsd:verify-work 08` when on Linux.
+- **v0.8.x polish (#462):** 5 items from Phase 8 post-merge review (success-banner-absence assertion, retry end-to-end test, ViewSource .status() middle-branch coverage, regen-warning ordering, dead `source_path` field). Could ship as a v0.8.x patch.
+- **v0.9 polish (#463):** 6 type design + TUI architecture items from Phase 8 review — natural fit for v0.9 scope.
+- **Pre-existing flake:** `backup::tests::push_and_pull_roundtrip` — passes in isolation, intermittent in full suite. Worth a separate investigation pass.
 
 ### Blockers/Concerns
 
-- `make release VERSION=0.7.1` is user-triggered (not gsd automation) — can happen in parallel with v0.8 phase planning
-- Cross-machine portability (#458) intentionally punted to v0.9 — users needing it before v0.9 can use the manual workaround in epic #459
+- None for v0.9 planning.
 
 ## Session Continuity
 
-Last session: 2026-04-26T12:46:50.600Z
-Stopped at: Completed 08.1-03-hotfix-03-failure-summary-reword-PLAN.md — phase 08.1 complete, v0.8.1 ready for make release
+Last session: 2026-04-27T00:00:00.000Z
+Stopped at: v0.8 milestone archived to milestones/v0.8-ROADMAP.md and milestones/v0.8-REQUIREMENTS.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -44,7 +44,6 @@ Historical decisions are archived in:
 
 ### Pending Todos / Carry-over
 
-- **Open Dependabot PR (#466):** dependency-group bump — clap 4.6.0→4.6.1, clap_complete 4.6.1→4.6.2, assert_cmd 2.2.0→2.2.1. All CI checks pass, MERGEABLE/CLEAN. Routine maintenance — merge at user discretion (squash). Not blocking v0.9 planning.
 - **Linux UAT (v0.8 carry-over):** 2 pending items in `.planning/phases/08-*/08-HUMAN-UAT.md` — clipboard runtime + xdg-open runtime tests on a Linux desktop. Pending hardware. Run `/gsd:verify-work 08` when on Linux.
 - **v0.8.x polish (#462):** 5 items from Phase 8 post-merge review (success-banner-absence assertion, retry end-to-end test, ViewSource .status() middle-branch coverage, regen-warning ordering, dead `source_path` field). Could ship as a v0.8.x patch.
 - **v0.9 polish (#463):** 6 type design + TUI architecture items from Phase 8 review — natural fit for v0.9 scope.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -44,6 +44,7 @@ Historical decisions are archived in:
 
 ### Pending Todos / Carry-over
 
+- **Open Dependabot PR (#466):** dependency-group bump — clap 4.6.0→4.6.1, clap_complete 4.6.1→4.6.2, assert_cmd 2.2.0→2.2.1. All CI checks pass, MERGEABLE/CLEAN. Routine maintenance — merge at user discretion (squash). Not blocking v0.9 planning.
 - **Linux UAT (v0.8 carry-over):** 2 pending items in `.planning/phases/08-*/08-HUMAN-UAT.md` — clipboard runtime + xdg-open runtime tests on a Linux desktop. Pending hardware. Run `/gsd:verify-work 08` when on Linux.
 - **v0.8.x polish (#462):** 5 items from Phase 8 post-merge review (success-banner-absence assertion, retry end-to-end test, ViewSource .status() middle-branch coverage, regen-warning ordering, dead `source_path` field). Could ship as a v0.8.x patch.
 - **v0.9 polish (#463):** 6 type design + TUI architecture items from Phase 8 review — natural fit for v0.9 scope.

--- a/.planning/milestones/v0.8-REQUIREMENTS.md
+++ b/.planning/milestones/v0.8-REQUIREMENTS.md
@@ -1,3 +1,12 @@
+# Requirements Archive: v0.8 Wizard UX & Safety Hardening
+
+**Archived:** 2026-04-27
+**Status:** SHIPPED
+
+For current requirements, see `.planning/REQUIREMENTS.md`.
+
+---
+
 # Requirements: tome v0.8 — Wizard UX & Safety Hardening
 
 **Defined:** 2026-04-23

--- a/.planning/milestones/v0.8-ROADMAP.md
+++ b/.planning/milestones/v0.8-ROADMAP.md
@@ -1,0 +1,93 @@
+# Roadmap: tome
+
+## Milestones
+
+- ✅ **v0.6 Unified Directory Model** — Phases 1-3 (shipped 2026-04-16) — [archive](milestones/v0.6-ROADMAP.md)
+- ✅ **v0.7 Wizard Hardening** — Phases 4-6 (shipped 2026-04-22) — [archive](milestones/v0.7-ROADMAP.md)
+- 🚧 **v0.8 Wizard UX & Safety Hardening** — Phases 7-8 (active since 2026-04-23) — epic [#459](https://github.com/MartinP7r/tome/issues/459)
+
+## Phases
+
+<details>
+<summary>✅ v0.6 Unified Directory Model (Phases 1-3) — SHIPPED 2026-04-16</summary>
+
+- [x] Phase 1: Unified Directory Foundation (3/5 plans) — config type system, pipeline rewrite, state schema
+- [x] Phase 2: Git Sources & Selection (4/4 plans) — git clone/update, per-dir filtering, tome remove
+- [x] Phase 3: Import, Reassignment & Browse Polish (2/2 plans) — tome add/reassign/fork, browse TUI polish
+
+**Known gaps:** WIZ-01 through WIZ-05 (wizard rewrite) deferred — closed as "hardened" in v0.7.
+
+</details>
+
+<details>
+<summary>✅ v0.7 Wizard Hardening (Phases 4-6) — SHIPPED 2026-04-22</summary>
+
+- [x] Phase 4: Wizard Correctness (3/3 plans) — `Config::validate()` Conflict+Why+Suggestion errors, library↔distribution overlap detection (Cases A/B/C), `Config::save_checked` expand→validate→round-trip→write pipeline (WHARD-01/02/03)
+- [x] Phase 5: Wizard Test Coverage (4/4 plans) — `--no-input` plumbing + `assemble_config` helper extraction, pure-helper unit tests, `tome init --dry-run --no-input` integration tests, 12-combo `(DirectoryType, DirectoryRole)` matrix (WHARD-04/05/06)
+- [x] Phase 6: Display Polish & Docs (2/2 plans) — wizard summary migrated to `tabled::Table` with `Style::rounded()` + `PriorityMax::right()` truncation, PROJECT.md "Hardened in v0.7" subsection, CHANGELOG WHARD-07/08 entries (WHARD-07/08)
+
+**Closed WIZ-01..05:** v0.6's known wizard gaps are now shipped AND hardened.
+
+</details>
+
+### v0.8 Wizard UX & Safety Hardening
+
+- [x] **Phase 7: Wizard UX (Greenfield / Brownfield / Legacy)** — `tome init` handles new machines, existing configs, and pre-v0.6 cruft without surprises; resolved `tome_home` is surfaced up-front and optionally persisted via XDG config *(completed 2026-04-23)*
+- [ ] **Phase 8: Safety Refactors (Partial-Failure Visibility & Cross-Platform)** — destructive commands surface partial failures; browse UI's external actions work on Linux; silent `fs::read_link(..).ok()` sites are replaced with surfaced warnings
+
+## Phase Details
+
+### Phase 7: Wizard UX (Greenfield / Brownfield / Legacy)
+**Goal**: `tome init` behaves predictably on any machine state — fresh install, dotfiles-synced home, or pre-v0.6 cruft — and tells the user which `tome_home` it is about to populate
+**Depends on**: Phase 6 (v0.7 Wizard Hardening shipped — `Config::save_checked` and `--no-input` plumbing are prerequisites)
+**Requirements**: WUX-01, WUX-02, WUX-03, WUX-04, WUX-05
+**Success Criteria** (what must be TRUE):
+  1. User running `tome init` on a greenfield machine (no `TOME_HOME`, no XDG config, no existing `.tome/tome.toml`) sees a prompt to choose `tome_home` with `~/.tome/` as the default and a custom-path option that is validated before the wizard proceeds
+  2. User running `tome init` on a brownfield machine (existing `tome.toml` at the resolved `tome_home`) sees a summary of the detected config (directory count, library_dir, last-modified date) and can choose **use existing** (default), **edit existing**, **reinitialize** (with backup), or **cancel** — no path silently overwrites a valid config
+  3. User with a legacy pre-v0.6 `~/.config/tome/config.toml` (contains `[[sources]]` or `[targets.*]`) sees a warning that the file is ignored by current tome and is offered a delete-or-move-aside action — no silent ignore, no auto-delete
+  4. Every `tome init` invocation prints a 1-line "resolved tome_home: <path>" info message before Step 1 prompts, so the user can abort immediately if the wrong path is about to be populated
+  5. When the user selects a custom `tome_home` in the greenfield flow, wizard offers to persist the choice by writing `~/.config/tome/config.toml` with a `tome_home = "..."` field; subsequent `tome sync` / `tome status` invocations find it without `TOME_HOME` env var
+**Plans**: 4 plans
+  - [x] 07-01-wux-04-resolved-tome-home-info-PLAN.md — print resolved tome_home + source label at start of tome init (WUX-04)
+  - [x] 07-02-wux-03-legacy-config-detection-PLAN.md — MachineState + has_legacy_sections + legacy cleanup handler (WUX-03)
+  - [x] 07-03-wux-01-05-tome-home-prompt-PLAN.md — Step 0 greenfield tome_home prompt + XDG persist (WUX-01, WUX-05)
+  - [x] 07-04-wux-02-brownfield-decision-PLAN.md — 4-way brownfield decision + prefill plumbing (WUX-02)
+**UI hint**: yes
+
+### Phase 8: Safety Refactors (Partial-Failure Visibility & Cross-Platform)
+**Goal**: Destructive commands cannot report success while partial cleanup failed; browse UI's external actions work on Linux; silent `.ok()` drops on symlink reads are replaced with surfaced warnings
+**Depends on**: Phase 7 (independent changesets, but keeping linear ordering simplifies branch strategy and release cut)
+**Requirements**: SAFE-01, SAFE-02, SAFE-03
+**Success Criteria** (what must be TRUE):
+  1. User running `tome remove <name>` in a state where some symlinks/dirs cannot be cleaned (permissions, missing files) sees a distinct "⚠ N operations failed" summary with per-item detail and the command exits non-zero — the clean success path remains quiet as before
+  2. User on Linux pressing the `open` action in `tome browse` has the skill opened via `xdg-open` (and `copy path` via `wl-copy`/`xclip` or an equivalent cross-platform clipboard crate); any failure appears in the TUI status bar instead of being silently discarded by `let _ = ...`
+  3. User running `tome relocate` (or any command transiting the patched `fs::read_link(..).ok()` sites) sees a stderr warning when a symlink cannot be read, with enough context (path + error) to diagnose — the command no longer silently records "no provenance" on such failures
+  4. `cargo test` covers the new `RemoveResult` aggregation (including a partial-failure case) and the Linux-path branches of the browse action dispatcher (under `#[cfg(target_os = "linux")]` or via platform-agnostic abstractions)
+**Plans**: 3 plans
+  - [x] 08-01-safe-01-remove-partial-failure-aggregation-PLAN.md — RemoveResult aggregates per-loop FailureKind records; lib.rs Command::Remove surfaces grouped '⚠ K operations failed' summary + exits non-zero (SAFE-01 / #413)
+  - [x] 08-02-safe-02-browse-cross-platform-status-bar-PLAN.md — arboard clipboard + cfg!-dispatched open/xdg-open + App.status_message rendered in browse status bar (SAFE-02 / #414)
+  - [x] 08-03-safe-03-relocate-read-link-warning-PLAN.md — relocate.rs:93 explicit match + eprintln warning mirroring PR #448 pattern (SAFE-03 / #449)
+
+## Progress
+
+| Phase | Milestone | Plans Complete | Status | Completed |
+|-------|-----------|----------------|--------|-----------|
+| 1. Unified Directory Foundation | v0.6 | 3/5 | Complete | 2026-04-14 |
+| 2. Git Sources & Selection | v0.6 | 4/4 | Complete | 2026-04-15 |
+| 3. Import, Reassignment & Browse Polish | v0.6 | 2/2 | Complete | 2026-04-16 |
+| 4. Wizard Correctness | v0.7 | 3/3 | Complete | 2026-04-19 |
+| 5. Wizard Test Coverage | v0.7 | 4/4 | Complete | 2026-04-20 |
+| 6. Display Polish & Docs | v0.7 | 2/2 | Complete | 2026-04-22 |
+| 7. Wizard UX (Greenfield / Brownfield / Legacy) | v0.8 | 4/4 | Complete | 2026-04-23 |
+| 8. Safety Refactors (Partial-Failure Visibility & Cross-Platform) | v0.8 | 0/3 | Planned | — |
+
+### Phase 08.1: v0.8.1 hotfix — lockfile regen + save chain (INSERTED)
+
+**Goal:** Close 3 post-merge findings from #461 — restore git-skill provenance to the regenerated lockfile in Remove/Reassign/Fork (H1, silent-drop regression introduced by Phase 8), reorder the save chain so partial-failure ⚠ block surfaces before save errors propagate (H2), and reword the failure-summary line for clarity (H3).
+**Requirements**: HOTFIX-01 (H1), HOTFIX-02 (H2), HOTFIX-03 (H3)
+**Depends on:** Phase 8
+**Source:** [#461](https://github.com/MartinP7r/tome/issues/461)
+**Plans:** 3/3 plans complete
+  - [x] 08.1-01-hotfix-01-lockfile-regen-resolved-paths-PLAN.md — `resolved_paths_from_lockfile_cache` helper + replace empty BTreeMap at Remove/Reassign/Fork sites; integration test (HOTFIX-01 / #461 H1)
+  - [x] 08.1-02-hotfix-02-remove-save-chain-reorder-PLAN.md — move `if !result.failures.is_empty()` block before save chain in Command::Remove; integration test asserting no disk writes on partial-failure (HOTFIX-02 / #461 H2)
+  - [x] 08.1-03-hotfix-03-failure-summary-reword-PLAN.md — reword leading line to `Run `tome doctor` after resolving:`; stderr-wording test (HOTFIX-03 / #461 H3)

--- a/.planning/milestones/v0.8-ROADMAP.md
+++ b/.planning/milestones/v0.8-ROADMAP.md
@@ -4,7 +4,7 @@
 
 - ✅ **v0.6 Unified Directory Model** — Phases 1-3 (shipped 2026-04-16) — [archive](milestones/v0.6-ROADMAP.md)
 - ✅ **v0.7 Wizard Hardening** — Phases 4-6 (shipped 2026-04-22) — [archive](milestones/v0.7-ROADMAP.md)
-- 🚧 **v0.8 Wizard UX & Safety Hardening** — Phases 7-8 (active since 2026-04-23) — epic [#459](https://github.com/MartinP7r/tome/issues/459)
+- ✅ **v0.8 Wizard UX & Safety Hardening** — Phases 7-8 + 8.1 hotfix (shipped 2026-04-27) — epic [#459](https://github.com/MartinP7r/tome/issues/459)
 
 ## Phases
 
@@ -30,10 +30,13 @@
 
 </details>
 
-### v0.8 Wizard UX & Safety Hardening
+### v0.8 Wizard UX & Safety Hardening — SHIPPED 2026-04-27
+
+Released as v0.8.0 (2026-04-26) + v0.8.1 hotfix (2026-04-27).
 
 - [x] **Phase 7: Wizard UX (Greenfield / Brownfield / Legacy)** — `tome init` handles new machines, existing configs, and pre-v0.6 cruft without surprises; resolved `tome_home` is surfaced up-front and optionally persisted via XDG config *(completed 2026-04-23)*
-- [ ] **Phase 8: Safety Refactors (Partial-Failure Visibility & Cross-Platform)** — destructive commands surface partial failures; browse UI's external actions work on Linux; silent `fs::read_link(..).ok()` sites are replaced with surfaced warnings
+- [x] **Phase 8: Safety Refactors (Partial-Failure Visibility & Cross-Platform)** — destructive commands surface partial failures; browse UI's external actions work on Linux; silent `fs::read_link(..).ok()` sites are replaced with surfaced warnings *(completed 2026-04-24)*
+- [x] **Phase 8.1: v0.8.1 hotfix — lockfile regen + save chain** — restore git-skill provenance to regenerated lockfile after Remove/Reassign/Fork (H1), reorder Command::Remove save chain so partial-failure ⚠ block surfaces before save errors (H2), reword failure-summary leading line (H3) *(completed 2026-04-27)*
 
 ## Phase Details
 
@@ -79,7 +82,8 @@
 | 5. Wizard Test Coverage | v0.7 | 4/4 | Complete | 2026-04-20 |
 | 6. Display Polish & Docs | v0.7 | 2/2 | Complete | 2026-04-22 |
 | 7. Wizard UX (Greenfield / Brownfield / Legacy) | v0.8 | 4/4 | Complete | 2026-04-23 |
-| 8. Safety Refactors (Partial-Failure Visibility & Cross-Platform) | v0.8 | 0/3 | Planned | — |
+| 8. Safety Refactors (Partial-Failure Visibility & Cross-Platform) | v0.8 | 3/3 | Complete | 2026-04-24 |
+| 8.1. v0.8.1 hotfix — lockfile regen + save chain | v0.8 | 3/3 | Complete | 2026-04-27 |
 
 ### Phase 08.1: v0.8.1 hotfix — lockfile regen + save chain (INSERTED)
 


### PR DESCRIPTION
## Summary

Archives the v0.8 Wizard UX & Safety Hardening milestone now that v0.8.1 has shipped.

- 8 v0.8 requirements (WUX-01..05 + SAFE-01..03) + 3 v0.8.1 hotfix requirements (HOTFIX-01..03) all validated
- Phases 7, 8, and 8.1 archived to \`.planning/milestones/v0.8-ROADMAP.md\` and \`.planning/milestones/v0.8-REQUIREMENTS.md\`
- \`ROADMAP.md\` collapses v0.8 into a \`<details>\` block matching v0.6/v0.7 conventions and adds a v0.9 placeholder
- \`PROJECT.md\` evolved: shipped requirements moved to Validated, Current State reflects v0.8.1, Key Decisions table extended with 8 new v0.8 + 8.1 entries
- \`RETROSPECTIVE.md\` extended with v0.8 milestone retrospective and updated cross-milestone trends
- \`STATE.md\` reset to between-milestones, ready for v0.9 planning
- \`REQUIREMENTS.md\` renamed to \`milestones/v0.8-REQUIREMENTS.md\` (fresh one will be created by \`/gsd:new-milestone\`)

No code changes. Documentation/planning artifacts only.

## Note on tags

v0.8.0 + v0.8.1 release tags already exist (created by cargo-dist via \`make release\`). The GSD complete-milestone workflow's \`git tag -a v0.8\` step was intentionally skipped — the patch tags already mark the shipped commits, and adding a separate \`v0.8\` umbrella tag conflicts with the project's \`make release\` ownership of tagging.

## Carry-over

- 2 Linux-runtime UAT items in \`08-HUMAN-UAT.md\` (clipboard runtime + xdg-open runtime) accepted as carry-over pending Linux desktop hardware. Tracked in STATE.md "Pending Todos".

## Test plan

- [x] \`make ci\` (no code changes; planning docs only)