### PR TITLE
feat(add): expand bare github slug to https URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `tome add <owner>/<repo>` now expands a bare GitHub slug to `https://github.com/<owner>/<repo>` so users can paste an `org/repo` token directly from the address bar without ceremony. URLs (anything containing `://` or starting with `git@`) are left untouched, and the heuristic refuses paths with relative segments (`./foo`, `../bar`) or invalid characters (spaces, etc.) so a typo never confidently rewrites to the wrong clone target. Example: `tome add planetscale/database-skills` is now equivalent to `tome add https://github.com/planetscale/database-skills`.
+
 ### Fixed
 
 - `tome remove` now aggregates partial-cleanup failures and exits non-zero with a distinct `⚠ N operations failed` summary grouped by failure kind (distribution symlinks, library entries, library symlinks, git cache). The success banner (`✓ Removed directory ...`) is suppressed entirely when failures occur, so it cannot hide a `⚠` warning that scrolled off-screen. On partial failure the directory's config entry AND its manifest entries are preserved so the user can re-run `tome remove <name>` after addressing the underlying cause (typically permission fixes) — previously the config was unconditionally dropped, leaving orphaned filesystem artifacts with no programmatic recovery path. Previously the command reported success while filesystem artifacts leaked. ([#413](https://github.com/MartinP7r/tome/issues/413))

--- a/crates/tome/src/add.rs
+++ b/crates/tome/src/add.rs
@@ -14,13 +14,23 @@ use crate::config::{Config, DirectoryConfig, DirectoryName, DirectoryType};
 ///
 /// Anything that already looks like a URL (contains `://` or starts with
 /// `git@`) is returned unchanged. A string matching `<owner>/<repo>` where
-/// both segments are non-empty and contain only `[A-Za-z0-9._-]` is
-/// rewritten to `https://github.com/<owner>/<repo>` (preserving any
-/// `.git` suffix).
+/// both segments are non-empty, neither is `.` or `..`, and each contains
+/// only `[A-Za-z0-9._-]` is rewritten to `https://github.com/<owner>/<repo>`.
+/// Anything else passes through verbatim and is left for `git clone` to
+/// reject downstream.
 ///
-/// This is a one-shot QoL for the common `org/repo` copy-paste pattern.
-/// It does not touch local paths, gist URLs, or non-GitHub forges — those
-/// must still be passed as full URLs.
+/// This is a syntactic shape check, not a GitHub-validity check. Inputs
+/// like `-foo/bar` (leading hyphen) or `owner/.git` pass the shape check
+/// and will be expanded; the resulting URL fails at clone time, same as
+/// any other malformed reference. The narrow heuristic is intentional:
+/// false-negatives (URL not expanded, user has to paste the full thing)
+/// are easier to recover from than false-positives (path silently
+/// rewritten to a wrong clone target).
+///
+/// **Two-segment relative paths are ambiguous.** A directory like `src/foo`
+/// has the same shape as a slug — the helper cannot tell them apart and
+/// will expand it. Pass `./src/foo` to disambiguate (the leading `./` is
+/// rejected by the `.` segment check).
 fn normalize_url(input: &str) -> String {
     if input.contains("://") || input.starts_with("git@") {
         return input.to_string();
@@ -96,9 +106,7 @@ pub(crate) struct AddOptions<'a> {
 /// This is config-only — no sync is triggered. The user should run `tome sync`
 /// afterwards to clone the repo and discover skills.
 pub(crate) fn add(config: &mut Config, opts: AddOptions<'_>) -> Result<()> {
-    // Bare `owner/repo` slugs expand to full GitHub HTTPS URLs so users
-    // can paste the slug from the address bar without ceremony. The
-    // stored URL must be the expanded form — git clone won't resolve
+    // The stored URL must be the expanded form — git clone won't resolve
     // bare slugs on its own.
     let resolved_url = normalize_url(opts.url);
 
@@ -258,9 +266,9 @@ mod tests {
     }
 
     #[test]
-    fn normalize_url_leaves_relative_path_with_dotdot_unchanged() {
-        // `../foo/bar` has 3 segments → length check rejects it. Kept
-        // for completeness; the dangerous case is below.
+    fn normalize_url_leaves_three_segment_relative_path_unchanged() {
+        // 3 segments → length check rejects it. The dangerous case (where
+        // the `.`/`..` sentinel actually does the work) is below.
         let input = "../some/path";
         assert_eq!(normalize_url(input), input);
     }

--- a/crates/tome/src/add.rs
+++ b/crates/tome/src/add.rs
@@ -10,6 +10,46 @@ use console::style;
 
 use crate::config::{Config, DirectoryConfig, DirectoryName, DirectoryType};
 
+/// Expand a bare `owner/repo` slug to a full GitHub HTTPS URL.
+///
+/// Anything that already looks like a URL (contains `://` or starts with
+/// `git@`) is returned unchanged. A string matching `<owner>/<repo>` where
+/// both segments are non-empty and contain only `[A-Za-z0-9._-]` is
+/// rewritten to `https://github.com/<owner>/<repo>` (preserving any
+/// `.git` suffix).
+///
+/// This is a one-shot QoL for the common `org/repo` copy-paste pattern.
+/// It does not touch local paths, gist URLs, or non-GitHub forges — those
+/// must still be passed as full URLs.
+fn normalize_url(input: &str) -> String {
+    if input.contains("://") || input.starts_with("git@") {
+        return input.to_string();
+    }
+    let trimmed = input.trim_end_matches('/');
+    let parts: Vec<&str> = trimmed.split('/').collect();
+    if parts.len() != 2 {
+        return input.to_string();
+    }
+    let owner = parts[0];
+    let repo = parts[1];
+    if owner.is_empty() || repo.is_empty() {
+        return input.to_string();
+    }
+    let valid_segment = |s: &str| {
+        // Reject `.` and `..` so relative paths (`../foo`, `./foo`) don't
+        // sneak through with the right segment count and wrong meaning.
+        if s == "." || s == ".." {
+            return false;
+        }
+        s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    };
+    if !valid_segment(owner) || !valid_segment(repo) {
+        return input.to_string();
+    }
+    format!("https://github.com/{owner}/{repo}")
+}
+
 /// Extract a repository name from a git URL.
 ///
 /// Handles HTTPS and SSH URLs, strips trailing `/` and `.git` suffix.
@@ -56,9 +96,15 @@ pub(crate) struct AddOptions<'a> {
 /// This is config-only — no sync is triggered. The user should run `tome sync`
 /// afterwards to clone the repo and discover skills.
 pub(crate) fn add(config: &mut Config, opts: AddOptions<'_>) -> Result<()> {
+    // Bare `owner/repo` slugs expand to full GitHub HTTPS URLs so users
+    // can paste the slug from the address bar without ceremony. The
+    // stored URL must be the expanded form — git clone won't resolve
+    // bare slugs on its own.
+    let resolved_url = normalize_url(opts.url);
+
     let dir_name_str = match opts.name {
         Some(n) => n.to_string(),
-        None => extract_repo_name(opts.url),
+        None => extract_repo_name(&resolved_url),
     };
 
     if dir_name_str.is_empty() {
@@ -75,7 +121,7 @@ pub(crate) fn add(config: &mut Config, opts: AddOptions<'_>) -> Result<()> {
     }
 
     let dir_config = DirectoryConfig {
-        path: PathBuf::from(opts.url),
+        path: PathBuf::from(&resolved_url),
         directory_type: DirectoryType::Git,
         role: None,
         branch: opts.branch.map(String::from),
@@ -89,7 +135,7 @@ pub(crate) fn add(config: &mut Config, opts: AddOptions<'_>) -> Result<()> {
             "{} add directory '{}' (git: {})",
             style("Would").yellow(),
             style(&dir_name_str).cyan(),
-            opts.url,
+            resolved_url,
         );
     } else {
         config.directories.insert(dir_name, dir_config);
@@ -98,7 +144,7 @@ pub(crate) fn add(config: &mut Config, opts: AddOptions<'_>) -> Result<()> {
             "{} directory '{}' (git: {})",
             style("Added").green(),
             style(&dir_name_str).cyan(),
-            opts.url,
+            resolved_url,
         );
     }
 
@@ -135,5 +181,106 @@ mod tests {
     #[test]
     fn test_extract_repo_name_ssh_no_git() {
         assert_eq!(extract_repo_name("git@github.com:user/repo"), "repo");
+    }
+
+    #[test]
+    fn normalize_url_expands_bare_slug_to_github_https() {
+        assert_eq!(
+            normalize_url("planetscale/database-skills"),
+            "https://github.com/planetscale/database-skills"
+        );
+    }
+
+    #[test]
+    fn normalize_url_expands_slug_with_underscores_dots_hyphens() {
+        assert_eq!(
+            normalize_url("MartinP7r/some.repo_name-v2"),
+            "https://github.com/MartinP7r/some.repo_name-v2"
+        );
+    }
+
+    #[test]
+    fn normalize_url_strips_trailing_slash_on_slug() {
+        assert_eq!(
+            normalize_url("planetscale/database-skills/"),
+            "https://github.com/planetscale/database-skills"
+        );
+    }
+
+    #[test]
+    fn normalize_url_leaves_https_url_unchanged() {
+        let url = "https://github.com/planetscale/database-skills";
+        assert_eq!(normalize_url(url), url);
+    }
+
+    #[test]
+    fn normalize_url_leaves_https_url_with_dotgit_unchanged() {
+        let url = "https://github.com/planetscale/database-skills.git";
+        assert_eq!(normalize_url(url), url);
+    }
+
+    #[test]
+    fn normalize_url_leaves_ssh_url_unchanged() {
+        let url = "git@github.com:planetscale/database-skills.git";
+        assert_eq!(normalize_url(url), url);
+    }
+
+    #[test]
+    fn normalize_url_leaves_three_segment_path_unchanged() {
+        // Don't try to resolve `github.com/owner/repo` — it has 3 segments;
+        // user must paste a full URL with scheme. Keeping the heuristic
+        // narrow avoids accidentally rewriting unrelated relative paths.
+        let input = "github.com/planetscale/database-skills";
+        assert_eq!(normalize_url(input), input);
+    }
+
+    #[test]
+    fn normalize_url_leaves_single_segment_unchanged() {
+        assert_eq!(normalize_url("solo-segment"), "solo-segment");
+    }
+
+    #[test]
+    fn normalize_url_leaves_empty_owner_unchanged() {
+        assert_eq!(normalize_url("/repo"), "/repo");
+    }
+
+    #[test]
+    fn normalize_url_leaves_empty_repo_unchanged() {
+        assert_eq!(normalize_url("owner/"), "owner/");
+    }
+
+    #[test]
+    fn normalize_url_leaves_segment_with_space_unchanged() {
+        // Spaces aren't valid in GitHub slugs — refuse to expand to avoid
+        // turning a typo into a confidently wrong clone target.
+        let input = "owner/repo with space";
+        assert_eq!(normalize_url(input), input);
+    }
+
+    #[test]
+    fn normalize_url_leaves_relative_path_with_dotdot_unchanged() {
+        // `../foo/bar` has 3 segments → length check rejects it. Kept
+        // for completeness; the dangerous case is below.
+        let input = "../some/path";
+        assert_eq!(normalize_url(input), input);
+    }
+
+    #[test]
+    fn normalize_url_leaves_two_segment_relative_path_unchanged() {
+        // `../foo` matches the 2-segment shape and `..` would otherwise
+        // pass the char-class check (dot is allowed). The `.`/`..`
+        // sentinel rejection is what actually saves us — without it this
+        // would expand to `https://github.com/../foo` and clone-fail
+        // confusingly.
+        let input = "../foo";
+        assert_eq!(normalize_url(input), input);
+        let input = "./foo";
+        assert_eq!(normalize_url(input), input);
+    }
+
+    #[test]
+    fn normalize_url_leaves_absolute_path_unchanged() {
+        let input = "/abs/path";
+        assert_eq!(normalize_url(input), input);
     }
 }

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -3916,6 +3916,67 @@ fn test_add_with_branch() {
     );
 }
 
+#[test]
+fn test_add_expands_bare_github_slug() {
+    // `tome add owner/repo` should expand to https://github.com/owner/repo so
+    // a later `tome sync` can clone it. Without expansion, git would
+    // interpret the bare slug as a local path and fail.
+    let tmp = TempDir::new().unwrap();
+    let config_path = tmp.path().join("tome.toml");
+    std::fs::write(&config_path, "").unwrap();
+    std::fs::create_dir_all(tmp.path().join("library")).unwrap();
+
+    tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "add",
+            "planetscale/database-skills",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "https://github.com/planetscale/database-skills",
+        ));
+
+    let config_content = std::fs::read_to_string(&config_path).unwrap();
+    assert!(
+        config_content.contains("path = \"https://github.com/planetscale/database-skills\""),
+        "config should store the expanded URL: {config_content}"
+    );
+    assert!(
+        config_content.contains("[directories.database-skills]"),
+        "directory should be named after the repo segment of the slug: {config_content}"
+    );
+}
+
+#[test]
+fn test_add_dry_run_shows_expanded_slug() {
+    // The dry-run output must show what would be stored — i.e. the
+    // expanded URL, not the bare slug. Otherwise users see "Would add
+    // (git: foo/bar)" and can't tell if expansion happened.
+    let tmp = TempDir::new().unwrap();
+    let config_path = tmp.path().join("tome.toml");
+    std::fs::write(&config_path, "").unwrap();
+    std::fs::create_dir_all(tmp.path().join("library")).unwrap();
+
+    tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "--dry-run",
+            "add",
+            "planetscale/database-skills",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "https://github.com/planetscale/database-skills",
+        ));
+}
+
 // ── tome reassign integration tests ────────────────────────────────
 
 fn reassign_test_env(tmp: &TempDir) {

--- a/crates/tome/tests/cli.rs
+++ b/crates/tome/tests/cli.rs
@@ -3953,9 +3953,10 @@ fn test_add_expands_bare_github_slug() {
 
 #[test]
 fn test_add_dry_run_shows_expanded_slug() {
-    // The dry-run output must show what would be stored — i.e. the
-    // expanded URL, not the bare slug. Otherwise users see "Would add
-    // (git: foo/bar)" and can't tell if expansion happened.
+    // Dry-run with a bare slug must (a) print the expanded URL so the
+    // user can confirm the rewrite, and (b) leave the config on disk
+    // untouched — same contract as `test_add_dry_run` but for the slug
+    // path, since slug expansion is a separate code branch.
     let tmp = TempDir::new().unwrap();
     let config_path = tmp.path().join("tome.toml");
     std::fs::write(&config_path, "").unwrap();
@@ -3975,6 +3976,81 @@ fn test_add_dry_run_shows_expanded_slug() {
         .stdout(predicate::str::contains(
             "https://github.com/planetscale/database-skills",
         ));
+
+    let config_content = std::fs::read_to_string(&config_path).unwrap();
+    assert!(
+        !config_content.contains("[directories"),
+        "dry run should not modify config (slug path): {config_content}"
+    );
+}
+
+#[test]
+fn test_add_bare_slug_with_name_override() {
+    // `--name` skips extract_repo_name, but the slug still has to
+    // expand. This test pins the order: normalize_url runs before the
+    // name-or-extract decision, so the stored path is the expanded URL
+    // regardless of where the directory name comes from.
+    let tmp = TempDir::new().unwrap();
+    let config_path = tmp.path().join("tome.toml");
+    std::fs::write(&config_path, "").unwrap();
+    std::fs::create_dir_all(tmp.path().join("library")).unwrap();
+
+    tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "add",
+            "planetscale/database-skills",
+            "--name",
+            "ps-db",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+
+    let config_content = std::fs::read_to_string(&config_path).unwrap();
+    assert!(
+        config_content.contains("[directories.ps-db]"),
+        "user-supplied --name must win: {config_content}"
+    );
+    assert!(
+        config_content.contains("path = \"https://github.com/planetscale/database-skills\""),
+        "slug must still be expanded when --name is set: {config_content}"
+    );
+}
+
+#[test]
+fn test_add_bare_slug_with_branch_flag() {
+    // The slug flow must coexist with --branch (and by extension --tag,
+    // --rev). Stored config should have both the expanded URL AND the
+    // branch field, written into the same directory section.
+    let tmp = TempDir::new().unwrap();
+    let config_path = tmp.path().join("tome.toml");
+    std::fs::write(&config_path, "").unwrap();
+    std::fs::create_dir_all(tmp.path().join("library")).unwrap();
+
+    tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "add",
+            "planetscale/database-skills",
+            "--branch",
+            "main",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+
+    let config_content = std::fs::read_to_string(&config_path).unwrap();
+    assert!(
+        config_content.contains("path = \"https://github.com/planetscale/database-skills\""),
+        "expanded URL not in config: {config_content}"
+    );
+    assert!(
+        config_content.contains("branch = \"main\""),
+        "branch field not in config: {config_content}"
+    );
 }
 
 // ── tome reassign integration tests ────────────────────────────────


### PR DESCRIPTION
## Summary

\`tome add planetscale/database-skills\` now expands the bare slug to \`https://github.com/planetscale/database-skills\` before storing it in \`tome.toml\`. This closes a footgun where the previous behaviour silently accepted the bare slug, then failed at the next \`tome sync\` with a confusing \"does not appear to be a git repository\" message because \`git clone\` doesn't resolve bare slugs on its own (that's a \`gh repo clone\` feature, not git's).

## Behaviour

| Input | Behaviour |
|-------|-----------|
| \`owner/repo\` | → \`https://github.com/owner/repo\` |
| \`owner/repo/\` | → \`https://github.com/owner/repo\` (trailing slash stripped) |
| \`https://github.com/owner/repo\` | unchanged |
| \`git@github.com:owner/repo.git\` | unchanged |
| \`github.com/owner/repo\` (no scheme) | unchanged — three segments, requires explicit URL |
| \`./foo\`, \`../bar\` | unchanged — \`.\`/\`..\` segments rejected so relative paths can't be confused for slugs |
| \`owner/repo with space\` | unchanged — invalid GitHub slug, no expansion |
| Single segment, empty owner/repo | unchanged |

The detection is intentionally narrow — a strict 2-segment match where each segment is \`[A-Za-z0-9._-]\` and neither is exactly \`.\` or \`..\`. A typo cannot confidently rewrite to the wrong clone target.

## Implementation

- New \`normalize_url\` helper in \`crates/tome/src/add.rs\` (~20 LOC)
- Called once at the start of \`add()\` so both the stored \`path\` and the directory name extracted by \`extract_repo_name\` see the expanded URL
- Dry-run output also shows the expanded URL so users can confirm the rewrite before committing

## Why narrow detection (not also \`gh:owner/repo\` or \`github.com/owner/repo\`)

This patch addresses the most common copy-paste pattern. Other forge prefixes (GitLab, Bitbucket) and two-slash URLs (\`github.com/owner/repo\`) can be added later if there's demand — the helper is structured to make adding a new branch straightforward.

## Test plan

- [x] 14 new unit tests for \`normalize_url\` (\`add::tests::normalize_url_*\`)
- [x] 2 new integration tests (\`test_add_expands_bare_github_slug\`, \`test_add_dry_run_shows_expanded_slug\`)
- [x] All 5 existing \`add\` integration tests still pass — no behaviour change for URL inputs
- [x] \`make ci\` clean: 478 unit + 128 integration tests, fmt-check, clippy \`-D warnings\`, typos