### PR TITLE
chore: start milestone v0.9 (cross-machine portability + polish)

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -116,6 +116,16 @@ v0.8 milestone complete — Wizard UX & Safety Hardening. 8 requirements shipped
 - Single-user constraint still holds — no migration tooling; users with existing `tome.toml` get explicit migration docs if schema changes.
 - Cross-machine portability has been intentionally deferred since v0.8 epic #459 because the design needs new schema fields + override-apply timing — a bigger lift than fits a single phase.
 
+## Looking Beyond v0.9
+
+**v1.0 tome Desktop (Tauri GUI)** — drafted 2026-04-28
+
+Forward-planning artifacts: [`milestones/v1.0-REQUIREMENTS.md`](milestones/v1.0-REQUIREMENTS.md) + [`milestones/v1.0-ROADMAP.md`](milestones/v1.0-ROADMAP.md). 32 requirements across 7 categories (CORE / VIEW / SYNC / CFG / OPS / BAK / DIST) + 5 cross-cutting NF gates. 7 phases (10–16). Rough size: 15–22 weeks of focused work; alpha after Phase 11, beta after Phase 13, ship after Phase 16.
+
+Tauri 2 chosen over Electron + napi-rs (D-GUI-01): the Rust crate becomes the native backend directly, ~8 MB bundle, built-in code-signed auto-update, reuses Developer ID flow. CLI ships unchanged from `crates/tome`; the GUI lives in a new `crates/tome-desktop` workspace member.
+
+Sequenced after v0.9 by default (D-GUI-09). Ratify via `/gsd:new-milestone` when v0.9 ships and v1.0 becomes the active milestone.
+
 <details>
 <summary>Previous milestones (recap)</summary>
 

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -100,17 +100,21 @@ v0.8 milestone complete — Wizard UX & Safety Hardening. 8 requirements shipped
 
 **Carry-over:** 2 Linux-runtime UAT items in `08-HUMAN-UAT.md` (clipboard runtime + xdg-open runtime) pending Linux desktop hardware. Accepted as carry-over.
 
-## Next Milestone Goals
+## Current Milestone: v0.9 Cross-Machine Config Portability & Polish
 
-**v0.9 Cross-Machine Config Portability** — epic [#458](https://github.com/MartinP7r/tome/issues/458)
+**Goal:** A single `tome.toml` checked into dotfiles can be applied across machines with different filesystem layouts — without manual edits per machine. Bundled with two polish backlogs (#462, #463) to clear the v0.8 review tail in one cut.
 
-Primary driver: `machine.toml` path overrides so the same `tome.toml` can be checked into dotfiles and applied across machines with different `~/.tome` layouts. Larger design — new schema fields + override-apply timing in the load pipeline. Intentionally deferred from v0.8.
+**Target features:**
+- **Cross-machine portability** ([#458](https://github.com/MartinP7r/tome/issues/458)) — `machine.toml` path overrides allow per-machine remapping of directory paths so the same `tome.toml` is portable across machines. New schema fields + override-apply timing in the config load pipeline.
+- **Type design + TUI architecture polish** ([#463](https://github.com/MartinP7r/tome/issues/463)) — 6 items from the Phase 8 post-merge review: StatusMessage type redesign, `.status()` TUI blocking, clipboard auto-retry, `FailureKind::ALL` compile-enforcement, `RemoveFailure::new` justification, arboard drift hygiene.
+- **Test coverage + wording + dead code polish** ([#462](https://github.com/MartinP7r/tome/issues/462)) — 5 items from the same review: success-banner-absence assertion, retry e2e test, `ViewSource .status()` middle-branch coverage, regen-warning ordering, dead `source_path` field cleanup.
 
-Secondary candidates (from v0.8 post-merge review):
-- v0.9 polish (#463): 6 type design + TUI architecture items from Phase 8 review
-- v0.8.x polish (#462): 5 test coverage + wording + dead code items — could ship as a v0.8.x patch instead
+**Scope anchor:** Epic [#458](https://github.com/MartinP7r/tome/issues/458) (primary) + #462/#463 (carry-over from v0.8 post-merge review).
 
-Run `/gsd:new-milestone` to plan v0.9.
+**Key context:**
+- Bare-slug expansion in `tome add` (PR #471) merged to main 2026-04-27; ships with v0.9 (no v0.8.2 patch release planned).
+- Single-user constraint still holds — no migration tooling; users with existing `tome.toml` get explicit migration docs if schema changes.
+- Cross-machine portability has been intentionally deferred since v0.8 epic #459 because the design needs new schema fields + override-apply timing — a bigger lift than fits a single phase.
 
 <details>
 <summary>Previous milestones (recap)</summary>
@@ -175,4 +179,6 @@ Config is `directories: BTreeMap<DirectoryName, DirectoryConfig>` where each ent
 This document evolves at phase transitions and milestone boundaries.
 
 ---
-*Last updated: 2026-04-27 after v0.8 milestone — v0.8.1 shipped via cargo-dist (commits e13eb31 + 231e52d on main). v0.8 milestone archived: 8 v0.8 requirements (WUX-01..05 + SAFE-01..03) + 3 v0.8.1 hotfix requirements (HOTFIX-01..03) shipped across Phases 7, 8, and 8.1. 590 tests passing (464 unit + 126 integration). Linux-runtime UAT items in `08-HUMAN-UAT.md` accepted as carry-over pending hardware. Ready for v0.9 (cross-machine config portability, #458).*
+*Last updated: 2026-04-28 — v0.9 milestone started. Goal: cross-machine config portability (#458) bundled with #463 (type design + TUI architecture polish, 6 items) and #462 (test coverage + dead code polish, 5 items) from the v0.8 post-merge review. Bare-slug `tome add` improvement (PR #471, merged 2026-04-27) ships with v0.9 — no v0.8.2 patch release planned.*
+
+*Last updated: 2026-04-27 after v0.8 milestone — v0.8.1 shipped via cargo-dist (commits e13eb31 + 231e52d on main). v0.8 milestone archived: 8 v0.8 requirements (WUX-01..05 + SAFE-01..03) + 3 v0.8.1 hotfix requirements (HOTFIX-01..03) shipped across Phases 7, 8, and 8.1. 590 tests passing (464 unit + 126 integration). Linux-runtime UAT items in `08-HUMAN-UAT.md` accepted as carry-over pending hardware.*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -64,19 +64,19 @@ Phase mapping is filled by `/gsd:plan-phase` after roadmap creation.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| PORT-01 | TBD | Pending |
-| PORT-02 | TBD | Pending |
-| PORT-03 | TBD | Pending |
-| PORT-04 | TBD | Pending |
-| PORT-05 | TBD | Pending |
-| POLISH-01 | TBD | Pending |
-| POLISH-02 | TBD | Pending |
-| POLISH-03 | TBD | Pending |
-| POLISH-04 | TBD | Pending |
-| POLISH-05 | TBD | Pending |
-| POLISH-06 | TBD | Pending |
-| TEST-01 | TBD | Pending |
-| TEST-02 | TBD | Pending |
-| TEST-03 | TBD | Pending |
-| TEST-04 | TBD | Pending |
-| TEST-05 | TBD | Pending |
+| PORT-01 | Phase 9 | Pending |
+| PORT-02 | Phase 9 | Pending |
+| PORT-03 | Phase 9 | Pending |
+| PORT-04 | Phase 9 | Pending |
+| PORT-05 | Phase 9 | Pending |
+| POLISH-01 | Phase 10 | Pending |
+| POLISH-02 | Phase 10 | Pending |
+| POLISH-03 | Phase 10 | Pending |
+| POLISH-04 | Phase 10 | Pending |
+| POLISH-05 | Phase 10 | Pending |
+| POLISH-06 | Phase 10 | Pending |
+| TEST-01 | Phase 10 | Pending |
+| TEST-02 | Phase 10 | Pending |
+| TEST-03 | Phase 10 | Pending |
+| TEST-04 | Phase 10 | Pending |
+| TEST-05 | Phase 10 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,82 @@
+# v0.9 Requirements: Cross-Machine Config Portability & Polish
+
+## Milestone Goals
+
+A single `tome.toml` checked into dotfiles can be applied across machines with different filesystem layouts — without manual edits per machine. Bundled with two polish backlogs (#462, #463) to clear the v0.8 post-merge review tail in one cut.
+
+**Scope anchor:** Epic [#458](https://github.com/MartinP7r/tome/issues/458) (primary) + #462 (test/wording/dead-code) + #463 (type-design + TUI architecture).
+
+## v1 Requirements
+
+### Cross-Machine Portability (PORT)
+
+Source: [#458](https://github.com/MartinP7r/tome/issues/458). Mechanism: new `[directory_overrides.<name>]` table in `machine.toml`.
+
+- [ ] **PORT-01**: User can declare `[directory_overrides.<name>]` blocks in `~/.config/tome/machine.toml` (or per-tome-home equivalent) to remap a directory's `path` field on this machine, without editing the synced `tome.toml`.
+- [ ] **PORT-02**: Per-machine overrides apply at config load time (after tilde expansion, before `Config::validate`), so all downstream code (`sync`, `status`, `doctor`, `lockfile::generate`) operates on the merged result.
+- [ ] **PORT-03**: An override that targets a directory name not present in `tome.toml` produces a stderr `warning:` line (typo guard) without aborting load.
+- [ ] **PORT-04**: Validation failures triggered by an override (e.g., overridden path now overlaps `library_dir`) surface as a distinct error class so the user knows to fix `machine.toml`, not `tome.toml`.
+- [ ] **PORT-05**: `tome status` and `tome doctor` indicate which directory entries are subject to a per-machine override, so the user can answer "why is this path different on this machine?" without diffing files.
+
+### Type-Design + TUI Architecture Polish (POLISH)
+
+Source: [#463](https://github.com/MartinP7r/tome/issues/463). Each item closes a specific D# from the post-merge review.
+
+- [ ] **POLISH-01** (D1): `tome browse` `open` action surfaces an "Opening: <path>..." status message immediately before blocking on `xdg-open`/`open`, and any keystrokes that arrived during the block are drained from the tty buffer afterward instead of replayed as actions.
+- [ ] **POLISH-02** (D2): `StatusMessage` is a single enum (`Success(String) | Warning(String)`) with accessor methods (`body()`, `glyph()`, `severity()`) — pre-formatted glyph in `text` is gone. UI formats `"{glyph} {body}"` at render time. Visibility narrowed to `pub(super)`. Test-only `Clone`/`PartialEq`/`Eq` derives audited.
+- [ ] **POLISH-03** (D3): `ClipboardOccupied` errors auto-retry once with a 100ms backoff before the warning reaches the status bar.
+- [ ] **POLISH-04** (D4): `FailureKind::ALL` cannot drift from the enum — either compile-enforced (e.g., `strum::EnumIter` or exhaustive-match sentinel) or replaced by an iteration mechanism that doesn't require manual sync.
+- [ ] **POLISH-05** (D5): `RemoveFailure::new` either gains a real invariant (`debug_assert!(path.is_absolute(), ...)`) or is removed in favor of struct-literal construction at the four call sites in `execute`.
+- [ ] **POLISH-06** (D6): `arboard` is pinned to a patch-version range with a documented "review changelog on bump" policy in `Cargo.toml` (or a `#[cfg(test)]` enum-growth canary).
+
+### Test Coverage + Wording + Dead Code (TEST)
+
+Source: [#462](https://github.com/MartinP7r/tome/issues/462). Each item closes a specific P# from the post-merge review.
+
+- [ ] **TEST-01** (P1): `remove_partial_failure_exits_nonzero_with_warning_marker` asserts the `✓ Removed directory` success banner is **absent** from stdout on partial failure (not just that the `⚠` block is present).
+- [ ] **TEST-02** (P2): End-to-end test pins the I2/I3 retention contract: partial failure → user fixes the underlying condition → second `tome remove <name>` succeeds with empty `failures`, config entry gone, manifest empty, library dir gone.
+- [ ] **TEST-03** (P3): `ViewSource .status()` match is factored into a `status_message_from_open_result(...)` helper, with unit tests covering all three arms (Ok+success, Ok+non-zero exit, Err) using synthetic `ExitStatus` values via `ExitStatusExt::from_raw`.
+- [ ] **TEST-04** (P4): `regen_warnings` no longer print **before** the success banner on the happy path. Either deferred until after the banner (option a) or scoped with a `[lockfile regen]` prefix (option b) — pin the choice in code and regression-test the ordering.
+- [ ] **TEST-05** (P5): The dead `SkillMoveEntry.source_path` field is either removed (option a) or wired into `copy_library` / `recreate_target_symlinks` (option b) — `#[allow(dead_code)]` is gone from `relocate.rs`.
+
+## Future Requirements
+
+Deferred to a later milestone:
+
+- **Linux runtime UAT** — 2 carry-over items from v0.8's `08-HUMAN-UAT.md` (clipboard runtime, `xdg-open` runtime). Not blocking v0.9; will resolve when the user has Linux desktop hardware.
+- **Pre-existing flake** — `backup::tests::push_and_pull_roundtrip` intermittent failure in full suite. Out of scope for v0.9 unless it surfaces during polish work.
+- **`KNOWN_DIRECTORIES` registry expansion** — adding Cursor / Windsurf / Aider entries. Not driven by user request yet.
+- **Path templates / variable expansion** (`${HOME}/...`, `${WORK_ROOT}/...`) — explicitly rejected in #458 in favor of `[directory_overrides.<name>]`. Re-evaluate post-v0.9 if override semantics prove insufficient.
+
+## Out of Scope
+
+Explicit exclusions for v0.9:
+
+- **Multiple named configs** (`tome.macos.toml`, `tome.linux.toml`) — rejected in #458 in favor of single-file + machine.toml overrides.
+- **Migration tooling** for users adopting overrides — single-user constraint; documented manually if schema changes.
+- **Connector trait abstraction** (#192) — unified directory model already solves config flexibility.
+- **Watch mode** (#59) — low priority; orthogonal to portability.
+- **Format transforms / rule syncing** (#57, #193, #194) — different concern entirely.
+
+## Traceability
+
+Phase mapping is filled by `/gsd:plan-phase` after roadmap creation.
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| PORT-01 | TBD | Pending |
+| PORT-02 | TBD | Pending |
+| PORT-03 | TBD | Pending |
+| PORT-04 | TBD | Pending |
+| PORT-05 | TBD | Pending |
+| POLISH-01 | TBD | Pending |
+| POLISH-02 | TBD | Pending |
+| POLISH-03 | TBD | Pending |
+| POLISH-04 | TBD | Pending |
+| POLISH-05 | TBD | Pending |
+| POLISH-06 | TBD | Pending |
+| TEST-01 | TBD | Pending |
+| TEST-02 | TBD | Pending |
+| TEST-03 | TBD | Pending |
+| TEST-04 | TBD | Pending |
+| TEST-05 | TBD | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -5,7 +5,8 @@
 - ✅ **v0.6 Unified Directory Model** — Phases 1-3 (shipped 2026-04-16) — [archive](milestones/v0.6-ROADMAP.md)
 - ✅ **v0.7 Wizard Hardening** — Phases 4-6 (shipped 2026-04-22) — [archive](milestones/v0.7-ROADMAP.md)
 - ✅ **v0.8 Wizard UX & Safety Hardening** — Phases 7-8 + 8.1 hotfix (shipped 2026-04-27) — [archive](milestones/v0.8-ROADMAP.md)
-- 📋 **v0.9 Cross-Machine Config Portability** — planned — epic [#458](https://github.com/MartinP7r/tome/issues/458)
+- 🚧 **v0.9 Cross-Machine Config Portability & Polish** (active since 2026-04-28) — epic [#458](https://github.com/MartinP7r/tome/issues/458) + #462 + #463
+- 📋 **v1.0 tome Desktop (Tauri GUI)** — drafted — see [milestones/v1.0-REQUIREMENTS.md](milestones/v1.0-REQUIREMENTS.md) and [milestones/v1.0-ROADMAP.md](milestones/v1.0-ROADMAP.md). Sequenced after v0.9 by default; ratify via `/gsd:new-milestone` when v0.9 ships.
 
 ## Phases
 
@@ -43,11 +44,51 @@
 
 </details>
 
-### v0.9 Cross-Machine Config Portability (Planned)
+### v0.9 Cross-Machine Config Portability & Polish (Active)
 
-Epic: [#458](https://github.com/MartinP7r/tome/issues/458) — `machine.toml` path overrides for cross-machine portability.
+Epic: [#458](https://github.com/MartinP7r/tome/issues/458) — `machine.toml` path overrides for cross-machine portability. Bundled with #462 (test/wording/dead-code polish) and #463 (type-design + TUI architecture polish) to clear the v0.8 post-merge review tail in one cut.
 
-Phases TBD — run `/gsd:new-milestone` to plan v0.9.
+- [ ] **Phase 9: Cross-Machine Path Overrides** — `[directory_overrides.<name>]` in `machine.toml` lets a single `tome.toml` work across machines with different filesystem layouts (PORT-01..05)
+- [ ] **Phase 10: Phase 8 Review Tail — Type Design, TUI Polish & Test Coverage** — close the 11 post-merge review items from #462 + #463 (POLISH-01..06, TEST-01..05)
+
+### v1.0 tome Desktop — Tauri GUI (Drafted)
+
+Forward-planning artifacts:
+- [`milestones/v1.0-REQUIREMENTS.md`](milestones/v1.0-REQUIREMENTS.md) — 32 requirements across 7 categories (CORE / VIEW / SYNC / CFG / OPS / BAK / DIST) plus 5 cross-cutting NF gates.
+- [`milestones/v1.0-ROADMAP.md`](milestones/v1.0-ROADMAP.md) — 7 phases (10–16) with three intermediate cuts (alpha after 11, beta after 13, rc after 15, v1.0 after 16). Rough size: 15–22 weeks of focused work.
+
+**Sequencing:** v0.9 → v1.0 by default (D-GUI-09). v0.9 hardens `machine.toml` semantics that v1.0 leans on. Swap allowed; parallelism not recommended.
+
+**Framework:** Tauri 2 (D-GUI-01). Reuses Rust crate as native backend; no N-API. ~8 MB bundle vs Electron's ~150 MB; built-in code-signed auto-update; same Developer ID flow as the CLI.
+
+Phases will be planned via `/gsd:new-milestone` when v1.0 becomes active. Phase numbering assumes v0.9 takes Phases 9–10; renumber if v0.9's phase footprint differs.
+
+## Phase Details
+
+### Phase 9: Cross-Machine Path Overrides
+**Goal**: A single `tome.toml` checked into dotfiles can be applied across machines with different filesystem layouts via per-machine `[directory_overrides.<name>]` blocks in `machine.toml`.
+**Depends on**: Phase 8.1 (v0.8.1 baseline — load pipeline + machine.toml schema stable)
+**Requirements**: PORT-01, PORT-02, PORT-03, PORT-04, PORT-05
+**Success Criteria** (what must be TRUE):
+  1. User can add `[directory_overrides.<name>]` blocks to `machine.toml` and a subsequent `tome sync` / `tome status` operates on the overridden `path` for that directory without any edits to the synced `tome.toml`.
+  2. Override application happens once at config load time (after tilde expansion, before `Config::validate`), so every downstream command (`sync`, `status`, `doctor`, `lockfile::generate`) sees the same merged result — no second code path can observe pre-override paths.
+  3. An override targeting a directory name that doesn't exist in `tome.toml` produces a single stderr `warning:` line naming the typo and continues loading; it does not abort the command.
+  4. A validation failure caused by an override (e.g., overridden path overlaps `library_dir`) surfaces with a distinct error class that names `machine.toml` as the file to edit, not `tome.toml`.
+  5. `tome status` and `tome doctor` mark each overridden directory entry visibly (e.g., `(override)` annotation or dedicated column) so the user can answer "why is this path different on this machine?" without diffing files.
+**Plans**: TBD
+
+### Phase 10: Phase 8 Review Tail — Type Design, TUI Polish & Test Coverage
+**Goal**: Close the 11 post-merge review items from #462 (P1-P5) and #463 (D1-D6) so the v0.8 review tail is fully cleared in one cut.
+**Depends on**: Phase 9 (sequential — keeps PORT delivery clean and avoids interleaving review-tail churn with the portability epic)
+**Requirements**: POLISH-01, POLISH-02, POLISH-03, POLISH-04, POLISH-05, POLISH-06, TEST-01, TEST-02, TEST-03, TEST-04, TEST-05
+**Success Criteria** (what must be TRUE):
+  1. `tome browse` `open` shows an "Opening: <path>..." status before blocking on `xdg-open`/`open`, any keystrokes typed during the block are drained instead of replayed, and `ClipboardOccupied` errors are auto-retried once with a 100ms backoff before any warning reaches the status bar.
+  2. `StatusMessage` is a single `Success(String) | Warning(String)` enum with `body()`/`glyph()`/`severity()` accessors, `pub(super)` visibility, and audited test-only derives — pre-formatted glyphs in `text` are gone and `ViewSource .status()` routes through a tested `status_message_from_open_result(...)` helper covering Ok+success, Ok+non-zero exit, and Err arms.
+  3. `FailureKind::ALL` cannot drift from the enum (compile-enforced via `EnumIter` or equivalent), `RemoveFailure::new` either carries a real `debug_assert!` invariant or is replaced by struct-literal construction at the four call sites, and `arboard` is pinned to a patch range with a documented bump-review policy in `Cargo.toml`.
+  4. `regen_warnings` ordering on the happy path is pinned in code (deferred until after the success banner OR scoped with a `[lockfile regen]` prefix) and a regression test fails if the order regresses; the dead `SkillMoveEntry.source_path` field is either removed or wired into `copy_library`/`recreate_target_symlinks`, and `#[allow(dead_code)]` is gone from `relocate.rs`.
+  5. `remove_partial_failure_exits_nonzero_with_warning_marker` asserts the `✓ Removed directory` success banner is **absent** from stdout on partial failure, and an end-to-end test pins the I2/I3 retention contract: partial failure → user fixes the underlying condition → second `tome remove <name>` succeeds with empty `failures`, config entry gone, manifest empty, library dir gone.
+**Plans**: TBD
+**UI hint**: yes
 
 ## Progress
 
@@ -62,3 +103,5 @@ Phases TBD — run `/gsd:new-milestone` to plan v0.9.
 | 7. Wizard UX (Greenfield / Brownfield / Legacy) | v0.8 | 4/4 | Complete | 2026-04-23 |
 | 8. Safety Refactors (Partial-Failure Visibility & Cross-Platform) | v0.8 | 3/3 | Complete | 2026-04-24 |
 | 8.1. v0.8.1 hotfix — lockfile regen + save chain | v0.8 | 3/3 | Complete | 2026-04-27 |
+| 9. Cross-Machine Path Overrides | v0.9 | 0/N | Not started | — |
+| 10. Phase 8 Review Tail — Type Design, TUI Polish & Test Coverage | v0.9 | 0/N | Not started | — |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,12 +2,12 @@
 gsd_state_version: 1.0
 milestone: v0.9
 milestone_name: Cross-Machine Config Portability & Polish
-status: defining-requirements
-stopped_at: v0.9 milestone started — defining requirements
+status: roadmap-ready
+stopped_at: v0.9 roadmap drafted — Phase 9 ready for /gsd:plan-phase
 last_updated: "2026-04-28T00:00:00.000Z"
 last_activity: 2026-04-28
 progress:
-  total_phases: 0
+  total_phases: 2
   completed_phases: 0
   total_plans: 0
   completed_plans: 0
@@ -21,17 +21,17 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-28)
 
 **Core value:** Every AI coding tool on a developer's machine shares the same skill library without manual copying or per-tool configuration.
-**Current focus:** v0.9 — Cross-Machine Config Portability & Polish (defining requirements)
+**Current focus:** v0.9 — Cross-Machine Config Portability & Polish (Phase 9: Cross-Machine Path Overrides)
 
 ## Current Position
 
 Milestone: v0.9 — Cross-Machine Config Portability & Polish
-Phase: Not started (defining requirements)
-Plan: —
-Status: Defining requirements
-Last activity: 2026-04-28 — Milestone v0.9 started
+Phase: Phase 9 — Cross-Machine Path Overrides (not started)
+Plan: — (run `/gsd:plan-phase 9` to decompose)
+Status: Roadmap drafted; awaiting plan-phase decomposition
+Last activity: 2026-04-28 — v0.9 roadmap drafted (Phases 9 + 10)
 
-Progress: [░░░░░░░░░░] 0% (defining requirements)
+Progress: [░░░░░░░░░░] 0% (0/2 phases complete)
 
 ## Accumulated Context
 
@@ -48,6 +48,7 @@ v0.9-specific decisions (so far):
 
 - **D-1 (v0.9 scope):** Bundle #462 (test/wording/dead-code polish) and #463 (type design + TUI architecture polish) into v0.9 alongside the cross-machine portability driver. Trade-off: bigger milestone, longer cycle, but clears the v0.8 review tail in one cut and avoids a v0.8.2 patch release.
 - **D-2 (v0.9 scope):** Bare-slug `tome add` improvement (PR #471, merged 2026-04-27 to main) ships with v0.9 — no separate v0.8.2 patch release.
+- **D-3 (v0.9 phasing):** Two-phase shape — Phase 9 (PORT, 5 reqs) lands the portability epic as a coherent unit; Phase 10 (POLISH + TEST, 11 reqs) lands the entire #462/#463 review tail in one cut. Coarse granularity favours fewer phases; TEST-03 ↔ POLISH-02 coupling (both touch `ViewSource .status()` / `StatusMessage`) makes co-location natural and avoids splitting tightly-related work.
 
 ### Pending Todos / Carry-over
 
@@ -56,10 +57,10 @@ v0.9-specific decisions (so far):
 
 ### Blockers/Concerns
 
-- None for v0.9 requirements work.
+- None for v0.9 Phase 9 entry.
 
 ## Session Continuity
 
 Last session: 2026-04-28T00:00:00.000Z
-Stopped at: v0.9 milestone started — proceeding to requirements definition
+Stopped at: v0.9 roadmap drafted (Phases 9 + 10) — ready for `/gsd:plan-phase 9`
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,11 +1,11 @@
 ---
 gsd_state_version: 1.0
-milestone: null
-milestone_name: null
-status: between-milestones
-stopped_at: v0.8 milestone shipped (v0.8.1 — 2026-04-27); ready to plan v0.9
-last_updated: "2026-04-27T00:00:00.000Z"
-last_activity: 2026-04-27
+milestone: v0.9
+milestone_name: Cross-Machine Config Portability & Polish
+status: defining-requirements
+stopped_at: v0.9 milestone started — defining requirements
+last_updated: "2026-04-28T00:00:00.000Z"
+last_activity: 2026-04-28
 progress:
   total_phases: 0
   completed_phases: 0
@@ -18,18 +18,20 @@ progress:
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-04-27)
+See: .planning/PROJECT.md (updated 2026-04-28)
 
 **Core value:** Every AI coding tool on a developer's machine shares the same skill library without manual copying or per-tool configuration.
-**Current focus:** Between milestones — v0.8 shipped, v0.9 not yet planned
+**Current focus:** v0.9 — Cross-Machine Config Portability & Polish (defining requirements)
 
 ## Current Position
 
-Milestone: (none — between milestones)
-Last shipped: v0.8.1 (2026-04-27)
-Next: v0.9 — Cross-Machine Config Portability (epic [#458](https://github.com/MartinP7r/tome/issues/458)) — not yet planned
+Milestone: v0.9 — Cross-Machine Config Portability & Polish
+Phase: Not started (defining requirements)
+Plan: —
+Status: Defining requirements
+Last activity: 2026-04-28 — Milestone v0.9 started
 
-Run `/gsd:new-milestone` to plan v0.9.
+Progress: [░░░░░░░░░░] 0% (defining requirements)
 
 ## Accumulated Context
 
@@ -42,19 +44,22 @@ Historical decisions are archived in:
 - `.planning/milestones/v0.7-ROADMAP.md` — per-phase decisions for v0.7
 - `.planning/milestones/v0.6-ROADMAP.md` — per-phase decisions for v0.6
 
+v0.9-specific decisions (so far):
+
+- **D-1 (v0.9 scope):** Bundle #462 (test/wording/dead-code polish) and #463 (type design + TUI architecture polish) into v0.9 alongside the cross-machine portability driver. Trade-off: bigger milestone, longer cycle, but clears the v0.8 review tail in one cut and avoids a v0.8.2 patch release.
+- **D-2 (v0.9 scope):** Bare-slug `tome add` improvement (PR #471, merged 2026-04-27 to main) ships with v0.9 — no separate v0.8.2 patch release.
+
 ### Pending Todos / Carry-over
 
 - **Linux UAT (v0.8 carry-over):** 2 pending items in `.planning/phases/08-*/08-HUMAN-UAT.md` — clipboard runtime + xdg-open runtime tests on a Linux desktop. Pending hardware. Run `/gsd:verify-work 08` when on Linux.
-- **v0.8.x polish (#462):** 5 items from Phase 8 post-merge review (success-banner-absence assertion, retry end-to-end test, ViewSource .status() middle-branch coverage, regen-warning ordering, dead `source_path` field). Could ship as a v0.8.x patch.
-- **v0.9 polish (#463):** 6 type design + TUI architecture items from Phase 8 review — natural fit for v0.9 scope.
 - **Pre-existing flake:** `backup::tests::push_and_pull_roundtrip` — passes in isolation, intermittent in full suite. Worth a separate investigation pass.
 
 ### Blockers/Concerns
 
-- None for v0.9 planning.
+- None for v0.9 requirements work.
 
 ## Session Continuity
 
-Last session: 2026-04-27T00:00:00.000Z
-Stopped at: v0.8 milestone archived to milestones/v0.8-ROADMAP.md and milestones/v0.8-REQUIREMENTS.md
+Last session: 2026-04-28T00:00:00.000Z
+Stopped at: v0.9 milestone started — proceeding to requirements definition
 Resume file: None


### PR DESCRIPTION
## Summary

Starts the v0.9 milestone — Cross-Machine Config Portability & Polish. Bundles the cross-machine portability epic (#458) with the v0.8 post-merge review tail (#462 type-design/TUI polish + #463 test/wording/dead-code) into one cut.

**16 requirements across 3 categories:**
- **PORT-01..05** — \`[directory_overrides.<name>]\` in \`machine.toml\` for per-machine path remapping, override-apply timing in load pipeline, validation error class, typo-target warnings, status/doctor surfacing
- **POLISH-01..06** — D1-D6 from #463: TUI block UX, StatusMessage redesign, ClipboardOccupied retry, FailureKind::ALL compile-enforcement, RemoveFailure::new disposition, arboard drift hygiene
- **TEST-01..05** — P1-P5 from #462: success-banner-absence assertion, retry e2e test, ViewSource helper extraction + test, regen-warning ordering, dead source_path field

## 2 phases, sequential

| Phase | Goal | Requirements |
|-------|------|--------------|
| 9 | Cross-Machine Path Overrides | PORT-01..05 |
| 10 | Phase 8 Review Tail — Type Design, TUI Polish & Test Coverage | POLISH-01..06 + TEST-01..05 |

**Phasing rationale:**
- Phase 9 keeps the PORT epic atomic — all 5 requirements ship as a coherent unit (mechanism + timing + validation + surfacing).
- Phase 10 bundles POLISH + TEST because TEST-03 (factor \`status_message_from_open_result\` helper) naturally pairs with POLISH-02 (StatusMessage redesign).
- Sequential dependency keeps PORT delivery clean and avoids interleaving review-tail churn with the portability epic.

## Files changed

- \`.planning/PROJECT.md\` — current milestone v0.9 scope, key decisions extended (D-1/D-2/D-3 v0.9 phasing rationale), Last updated footer
- \`.planning/REQUIREMENTS.md\` — 16 requirements across PORT/POLISH/TEST, traceability table mapped to phases
- \`.planning/ROADMAP.md\` — v0.8 collapsed to \`<details>\`, v0.9 active section + phase details + progress rows added, v1.0 forward-plan reference
- \`.planning/STATE.md\` — between-milestones → roadmap-ready, current focus = Phase 9 entry

## Out of scope (intentionally untracked)

- \`.planning/milestones/v1.0-{REQUIREMENTS,ROADMAP}.md\` — v1.0 Tauri GUI forward-planning artifacts you authored separately. Referenced from this PR's ROADMAP.md (markdown link will appear broken on GitHub until you commit those separately).
- \`docs/migration/rust-to-typescript-feature-inventory.md\` — same separate-session forward-planning work.

Both can land in their own PR or be folded into a future v1.0 kickoff.

## Carry-over from v0.8

- 2 Linux-runtime UAT items in \`08-HUMAN-UAT.md\` (clipboard runtime + xdg-open runtime) — pending Linux desktop hardware. Tracked in STATE.md "Pending Todos".
- Pre-existing \`backup::tests::push_and_pull_roundtrip\` flake — investigation deferred.

## Test plan

- [x] No code changes; planning docs only — no \`make ci\` impact
- [x] All 16 requirements have phase mappings in the traceability table
- [x] Phase numbering continues from v0.8 (Phase 8.1 → Phase 9, Phase 10)

Refs #458 #462 #463