### PR TITLE
feat(phase-09): plan cross-machine path overrides (3 plans, 2 waves)

### DIFF
--- a/.planning/phases/09-cross-machine-path-overrides/09-01-machine-overrides-schema-and-apply-PLAN.md
+++ b/.planning/phases/09-cross-machine-path-overrides/09-01-machine-overrides-schema-and-apply-PLAN.md
@@ -1,0 +1,667 @@
+---
+phase: 09-cross-machine-path-overrides
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - crates/tome/src/machine.rs
+  - crates/tome/src/config.rs
+  - crates/tome/src/lib.rs
+autonomous: true
+requirements: [PORT-01, PORT-02]
+issue: "https://github.com/MartinP7r/tome/issues/458"
+
+must_haves:
+  truths:
+    - "User can declare `[directory_overrides.<name>] path = \"...\"` blocks in `~/.config/tome/machine.toml` and the resulting `MachinePrefs` parses without error"
+    - "After config load, every `Config::directories[name].path` matches the override (when one was declared), with `~` already expanded — `tome sync` / `tome status` / `tome doctor` / `lockfile::generate` all see the merged result"
+    - "Override application happens exactly once, after `Config::expand_tildes()` and before `Config::validate()` — no second code path can observe pre-override paths"
+    - "When no overrides are declared in `machine.toml`, behavior is byte-identical to v0.8.1 (zero-cost path)"
+  artifacts:
+    - path: "crates/tome/src/machine.rs"
+      provides: "`DirectoryOverride` struct (with `path: PathBuf`) and `MachinePrefs.directory_overrides: BTreeMap<DirectoryName, DirectoryOverride>` field, deserialized from `[directory_overrides.<name>]` TOML blocks"
+      contains: "directory_overrides"
+    - path: "crates/tome/src/config.rs"
+      provides: "`Config::apply_machine_overrides(&mut self, prefs: &MachinePrefs)` method that mutates `self.directories[name].path` for each matching override and sets `override_applied = true` on each touched entry. `DirectoryConfig` gains a `#[serde(skip)] pub(crate) override_applied: bool` field. New `Config::load_with_overrides(path: &Path, prefs: &MachinePrefs) -> Result<Self>` that runs `expand_tildes → apply_machine_overrides → validate` in that order."
+      contains: "apply_machine_overrides"
+    - path: "crates/tome/src/lib.rs"
+      provides: "Single canonical load path used by all non-Init commands: load `MachinePrefs` BEFORE `Config`, then call `Config::load_with_overrides(&effective_config_path, &machine_prefs)` instead of `Config::load_or_default`. Sync handler reuses the already-loaded `machine_prefs` instead of re-loading inside `sync()`."
+      contains: "load_with_overrides"
+  key_links:
+    - from: "crates/tome/src/lib.rs run() (line ~282, the post-Init load block)"
+      to: "config::Config::load_with_overrides"
+      via: "called once per command invocation, with machine_prefs loaded immediately above it"
+      pattern: "Config::load_with_overrides"
+    - from: "crates/tome/src/config.rs Config::load_with_overrides"
+      to: "Config::apply_machine_overrides"
+      via: "invoked between expand_tildes() and validate()"
+      pattern: "self\\.expand_tildes.*apply_machine_overrides.*self\\.validate"
+    - from: "crates/tome/src/machine.rs MachinePrefs"
+      to: "[directory_overrides.<name>] TOML table"
+      via: "serde derive with #[serde(default)]"
+      pattern: "directory_overrides"
+---
+
+<objective>
+Add `[directory_overrides.<name>]` schema to `machine.toml` and thread it through the canonical config load path so every downstream command (`sync`, `status`, `doctor`, `lockfile::generate`) operates on the merged result. Override application happens exactly once, between `Config::expand_tildes()` and `Config::validate()`.
+
+This is the foundation plan for Phase 9 — Plans 02 (validation surfacing) and 03 (status/doctor markers) build on the schema + `override_applied` flag introduced here.
+
+**Closes:** PORT-01 (schema), PORT-02 (apply timing in load pipeline).
+
+Purpose: Lets a single `tome.toml` checked into dotfiles be applied across machines with different filesystem layouts. The user adds machine-local path overrides to `~/.config/tome/machine.toml` (which is already excluded from dotfiles sync) without touching `tome.toml`.
+
+Output: New schema in `machine.rs`, two new methods on `Config`, and a single-call-site rewrite in `lib.rs::run()` that swaps `Config::load_or_default` for the override-aware path.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/REQUIREMENTS.md
+
+@crates/tome/src/machine.rs
+@crates/tome/src/config.rs
+@crates/tome/src/lib.rs
+@crates/tome/src/paths.rs
+@crates/tome/src/lockfile.rs
+@crates/tome/src/status.rs
+@crates/tome/src/doctor.rs
+@crates/tome/tests/cli.rs
+
+<interfaces>
+<!-- Key types and contracts the executor needs. Extracted from codebase. -->
+
+From `crates/tome/src/machine.rs` (current shape — extend, do not break):
+```rust
+pub struct MachinePrefs {
+    #[serde(default)] pub(crate) disabled: BTreeSet<SkillName>,
+    #[serde(default)] pub(crate) disabled_directories: BTreeSet<DirectoryName>,
+    #[serde(default)] pub(crate) directory: BTreeMap<DirectoryName, DirectoryPrefs>,
+    // <-- add: pub(crate) directory_overrides: BTreeMap<DirectoryName, DirectoryOverride>,
+}
+pub fn load(path: &Path) -> Result<MachinePrefs>;       // already exists, reuse
+pub fn default_machine_path() -> Result<PathBuf>;       // already exists
+```
+
+From `crates/tome/src/config.rs` (current shape — extend, do not break):
+```rust
+pub struct DirectoryConfig {
+    pub path: PathBuf,
+    #[serde(rename = "type", default)] pub directory_type: DirectoryType,
+    #[serde(default)] pub(crate) role: Option<DirectoryRole>,
+    #[serde(default, skip_serializing_if = "Option::is_none")] pub branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")] pub tag: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")] pub rev: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")] pub subdir: Option<String>,
+    // <-- add: #[serde(skip)] pub(crate) override_applied: bool,
+}
+
+impl Config {
+    pub fn load(path: &Path) -> Result<Self> { /* expand_tildes() then validate() */ }
+    pub fn load_or_default(cli_path: Option<&Path>) -> Result<Self> { /* wraps load */ }
+    pub(crate) fn expand_tildes(&mut self) -> Result<()>;
+    pub fn validate(&self) -> Result<()>;
+    pub fn save_checked(&self, path: &Path) -> Result<()>;  // expand → validate → roundtrip
+}
+```
+
+From `crates/tome/src/lib.rs::run` (line 282, post-Init):
+```rust
+let config = Config::load_or_default(effective_config.as_deref())?;
+config.validate()?;                                          // redundant — load already did this
+let tome_home = resolve_tome_home(cli.tome_home.as_deref(), cli.config.as_deref())?;
+let paths = TomePaths::new(tome_home, config.library_dir.clone())?;
+```
+
+From `crates/tome/src/lib.rs::sync` (line 836):
+```rust
+fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()> {
+    // ...
+    let machine_path = resolve_machine_path(machine_override)?;  // line 889
+    let mut machine_prefs = machine::load(&machine_path)?;        // line 890
+    // ...
+}
+```
+
+After this plan, the load order in `run()` becomes:
+```text
+1. resolve_machine_path(cli.machine.as_deref())     // already exists
+2. machine::load(&machine_path)                      // moved up from sync()
+3. Config::load_with_overrides(effective_config_path, &machine_prefs)
+   -> internally: read TOML → expand_tildes() → apply_machine_overrides(&prefs) → validate()
+4. TomePaths::new(...)
+5. dispatch to subcommand handler
+```
+
+The `sync()` function continues to receive `&Config`, but now also needs `&MachinePrefs` (instead of loading it itself). Pass it through `SyncOptions` or as a separate parameter — see Task 3 for the exact shape.
+
+**Field naming:** the new MachinePrefs field is `directory_overrides` (snake_case, plural) to mirror the existing `disabled_directories` style and match the TOML key `[directory_overrides.<name>]`. Do NOT use `overrides` (too generic, could collide later).
+
+**Future-extension shape:** the issue (#458) calls out `role`, `type`, `subdir` as future override fields. v0.9 ships ONLY `path`. Do NOT add `Option<...>` placeholders for unused fields — they would be dead code and serde would happily accept them in machine.toml without ever applying them. Add them in a future phase when there's a concrete user need. (YAGNI per Pragmatic Programmer.)
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add `DirectoryOverride` struct + `directory_overrides` field to `MachinePrefs`</name>
+  <files>crates/tome/src/machine.rs</files>
+  <read_first>
+    - crates/tome/src/machine.rs (full file — 475 lines; mirror the `DirectoryPrefs` shape)
+    - crates/tome/src/config.rs lines 18–95 (DirectoryName Borrow/Display impls — needed because the override map is keyed by `DirectoryName`)
+  </read_first>
+  <behavior>
+    - Test 1 (`directory_overrides_default_empty`): `MachinePrefs::default().directory_overrides` is empty.
+    - Test 2 (`directory_overrides_parses_from_toml`): TOML `[directory_overrides.claude-skills]\npath = "/work/skills"` parses into `prefs.directory_overrides["claude-skills"].path == PathBuf::from("/work/skills")`.
+    - Test 3 (`directory_overrides_with_tilde_path_is_preserved_unexpanded`): TOML `[directory_overrides.x]\npath = "~/work/skills"` parses with `path == PathBuf::from("~/work/skills")` — tilde expansion is the responsibility of `Config::apply_machine_overrides` (Task 2), NOT of machine.rs deserialization. **The executor MUST include this comment in the test body** so the design intent is documented at the point of test:
+      ```rust
+      // serde::Deserialize for PathBuf treats `~` as a literal char; tilde
+      // expansion is delayed to Config::apply_machine_overrides so override
+      // paths follow the same expansion semantics as paths in tome.toml.
+      ```
+    - Test 4 (`directory_overrides_roundtrip`): Constructing a `MachinePrefs` with one override, serializing via `toml::to_string_pretty`, then parsing back yields equal `directory_overrides`.
+    - Test 5 (`existing_machine_toml_without_overrides_still_parses`): A TOML string with only `disabled = ["x"]` parses with `directory_overrides` defaulting to empty (`#[serde(default)]` works).
+    - Test 6 (`directory_overrides_save_skips_when_empty`): With no overrides set, `toml::to_string_pretty(&prefs)` does NOT emit a `[directory_overrides]` table heading. (Use `#[serde(skip_serializing_if = "BTreeMap::is_empty")]` so empty maps stay invisible in the on-disk file.)
+    - Test 7 (`directory_overrides_unknown_extra_field_rejected`): TOML `[directory_overrides.x]\npath = "/p"\nbogus = "y"` fails to parse. (Use `#[serde(deny_unknown_fields)]` on `DirectoryOverride` so future-renamed fields don't silently swallow typos.)
+  </behavior>
+  <action>
+Add the new struct and field to `crates/tome/src/machine.rs`. Place `DirectoryOverride` immediately above the `MachinePrefs` struct definition (around line 35) so it reads top-down: helpers → MachinePrefs → impl → load/save → tests.
+
+```rust
+/// Per-machine path override for a specific directory.
+///
+/// Allows a single `tome.toml` checked into dotfiles to be applied across
+/// machines with different filesystem layouts. The override is applied at
+/// config load time (between `Config::expand_tildes()` and `Config::validate()`)
+/// so every downstream command operates on the merged result.
+///
+/// Schema (v0.9): only `path` is supported. Future versions may add
+/// `role`/`type`/`subdir` overrides — track via #458 follow-ups.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DirectoryOverride {
+    /// Replaces `directories.<name>.path` on this machine. Tilde-expansion
+    /// happens in `Config::apply_machine_overrides`, not here.
+    pub path: PathBuf,
+}
+```
+
+Add the field to `MachinePrefs`:
+```rust
+pub struct MachinePrefs {
+    // ... existing fields ...
+
+    /// Per-machine path overrides for entries in `tome.toml::directories`.
+    /// Keyed by directory name; only the `path` field is currently supported (PORT-01).
+    /// See `Config::apply_machine_overrides` for the apply step.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) directory_overrides: BTreeMap<DirectoryName, DirectoryOverride>,
+}
+```
+
+**Implementation notes:**
+- `BTreeMap` is already imported from `std::collections` at the top of the file.
+- `PathBuf` is already imported.
+- Keep visibility `pub(crate)` to match `disabled` and `directory` — external API is via `Config::apply_machine_overrides` (Task 2), not direct field access.
+- Do NOT extend `MachinePrefs::validate()` in this task — there's no machine.toml-internal invariant to check. Cross-validation against `Config.directories` happens in `Config::apply_machine_overrides` (Task 2).
+- Do NOT add convenience methods like `is_overridden(name)` here — the only consumer is `Config::apply_machine_overrides`, which iterates the map directly.
+
+Add the 7 unit tests inside the existing `#[cfg(test)] mod tests {}` at the bottom of `machine.rs`, after the `disabled_directories_toml_format` test (~line 460). Reuse the existing test patterns: `tempfile::TempDir`, `toml::from_str`, `toml::to_string_pretty`, direct field access via `pub(crate)` (the tests are in the same module).
+
+Run: `cargo test -p tome machine::tests::directory_overrides`
+  </action>
+  <verify>
+    <automated>cargo test -p tome machine::tests::directory_overrides_ -- --exact-skip false 2>&1 | tail -20</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "pub struct DirectoryOverride" crates/tome/src/machine.rs` returns exactly 1 match.
+    - `rg -n "directory_overrides:" crates/tome/src/machine.rs` returns at least 1 match (the field declaration).
+    - `cargo test -p tome machine::tests::directory_overrides` runs ≥ 7 tests, all pass.
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+    - `rg -n "deny_unknown_fields" crates/tome/src/machine.rs` returns at least 1 match (on `DirectoryOverride`).
+    - `rg -n "skip_serializing_if = \"BTreeMap::is_empty\"" crates/tome/src/machine.rs` returns at least 1 match.
+  </acceptance_criteria>
+  <done>
+    `DirectoryOverride` struct exists, `MachinePrefs.directory_overrides` field exists with `#[serde(default)]` + `#[serde(skip_serializing_if = "BTreeMap::is_empty")]`, 7 unit tests pass, clippy is clean.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Add `Config::apply_machine_overrides` + `Config::load_with_overrides` + `override_applied` field</name>
+  <files>crates/tome/src/config.rs</files>
+  <read_first>
+    - crates/tome/src/config.rs lines 196–235 (DirectoryConfig struct — add the new field here)
+    - crates/tome/src/config.rs lines 273–520 (Config impl — load, expand_tildes, validate, save_checked)
+    - crates/tome/src/config.rs lines 580–620 (`expand_tilde` free function — reused for override path expansion)
+    - crates/tome/src/machine.rs (the new `DirectoryOverride` + `directory_overrides` field from Task 1)
+  </read_first>
+  <behavior>
+    - Test 1 (`apply_machine_overrides_no_overrides_is_noop`): Config with one directory, MachinePrefs with empty `directory_overrides` → after apply, `directories[name].path` is unchanged AND `directories[name].override_applied == false`.
+    - Test 2 (`apply_machine_overrides_replaces_path`): Config with `directories.x.path = /old`, MachinePrefs with `directory_overrides.x.path = /new` → after apply, `directories.x.path == /new` AND `directories.x.override_applied == true`.
+    - Test 3 (`apply_machine_overrides_expands_tilde_in_override_path`): Config with `directories.x.path = /old`, MachinePrefs with `directory_overrides.x.path = ~/work` → after apply, `directories.x.path` starts with the resolved home dir (no leading `~`) AND `override_applied == true`.
+    - Test 4 (`apply_machine_overrides_unknown_target_does_not_panic`): Config with `directories.x`, MachinePrefs with `directory_overrides.bogus.path = /p` (no matching directory) → apply returns `Ok(())`, `directories.x` is unchanged, `directories.x.override_applied == false`. (PORT-03 will add the warning emission in Plan 02; in this task, it's a silent no-op for unknown targets — verify via behavior, no warning string check.)
+    - Test 5 (`apply_machine_overrides_idempotent`): Calling `apply_machine_overrides` twice in a row produces the same result as calling it once (no double-expansion of tilde, no flag flip).
+    - Test 6 (`load_with_overrides_runs_in_order_expand_apply_validate`): Write a `tome.toml` with `directories.x.path = "~/old"` and a fake MachinePrefs with `directory_overrides.x.path = "~/new"`. `Config::load_with_overrides(path, &prefs)` returns Ok with `directories.x.path` resolved to `<home>/new` and `override_applied == true`. (Verifies the I2 invariant: override happens AFTER expand_tildes — `~` in the override path is expanded — and BEFORE validate.)
+    - Test 7 (`load_with_overrides_validate_failure_propagates`): Config has `directories.x.role = "managed"` with `type = "directory"` (an invalid combo) — `load_with_overrides` returns Err with the existing role/type conflict message. (Verifies validate still runs after override apply.)
+    - Test 8 (`save_checked_does_not_serialize_override_applied`): Build a Config in-memory with one directory whose `override_applied = true`, call `save_checked`, then read the resulting TOML — `override_applied` MUST NOT appear in the file. (Verifies `#[serde(skip)]` on the new field.)
+    - Test 9 (`override_applied_field_starts_false_after_load`): Config with one directory, MachinePrefs with empty overrides — `load_with_overrides` produces `directories[x].override_applied == false`. (Default-initialized via `#[serde(skip)] + Default`.)
+  </behavior>
+  <action>
+**Step 1 — Add `override_applied` field to `DirectoryConfig`** (line ~196 in `config.rs`):
+
+```rust
+pub struct DirectoryConfig {
+    pub path: PathBuf,
+    #[serde(rename = "type", default)] pub directory_type: DirectoryType,
+    #[serde(default)] pub(crate) role: Option<DirectoryRole>,
+    #[serde(default, skip_serializing_if = "Option::is_none")] pub branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")] pub tag: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")] pub rev: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")] pub subdir: Option<String>,
+
+    /// True iff this directory's `path` was rewritten by a `[directory_overrides.<name>]`
+    /// entry in `machine.toml` during config load. Set in `Config::apply_machine_overrides`.
+    /// `#[serde(skip)]` ensures this never appears in `tome.toml` (it's machine-local state,
+    /// not portable config). Default = `false`.
+    #[serde(skip)]
+    pub(crate) override_applied: bool,
+}
+```
+
+**`Default` derive:** `DirectoryConfig` does NOT currently derive `Default` — bool defaults to false naturally via `#[serde(skip)]` (serde calls `Default::default()` to populate skipped fields). Verify the existing struct has `#[derive(...)]` line; if `Default` is not in the list, serde's `#[serde(skip)]` requires it. Add it. If adding `Default` triggers cascading requirements (e.g., `DirectoryType` must derive `Default` — check whether it already does at line 92), follow the chain. The existing `DirectoryType` already has a `#[derive(..., Default)]` (verify at line ~92) and defaults to `Directory`; if not, fix that too. The existing `DirectoryRole` is `Option<>` so its default is `None` automatically.
+
+**Alternative path** (cleaner if the Default chain explodes): use `#[serde(skip, default)]` so serde uses `bool::default()` directly — this works without requiring `DirectoryConfig: Default`. Prefer this if available.
+
+**Step 1.5 — Update all `DirectoryConfig` struct literal sites to include `override_applied: false`.**
+
+Adding the new field (even with `#[serde(skip, default)]`) requires every direct struct-literal construction across the crate to set the field explicitly. Find them:
+
+```bash
+rg -n "DirectoryConfig \{" crates/tome/src/
+```
+
+Expected ~17 sites across `eject.rs`, `wizard.rs` (×5), `relocate.rs`, `status.rs` (×3), `doctor.rs` (×3), `distribute.rs`, `reassign.rs`. The two `lockfile.rs` constructors use `toml::from_str` and are immune. Update each by adding `override_applied: false,` as the last field. Run `cargo build -p tome` to verify all sites are updated before proceeding to Step 2.
+
+**Step 2 — Add `apply_machine_overrides` method to `impl Config`** (place after `expand_tildes`, around line 522):
+
+```rust
+/// Apply per-machine path overrides from `[directory_overrides.<name>]` entries
+/// in `machine.toml`. Mutates `self.directories[name].path` and sets
+/// `override_applied = true` on each matched entry.
+///
+/// **Order constraint (I2 invariant):** Call this AFTER `expand_tildes()` and
+/// BEFORE `validate()`. The single canonical caller is `Config::load_with_overrides`.
+///
+/// **Override path expansion:** the override's own `path` is tilde-expanded here
+/// (mirrors what `expand_tildes` did to the original path), so `~/...` works in
+/// `machine.toml` exactly as it does in `tome.toml`.
+///
+/// **Unknown override targets:** silently ignored at this layer. The Plan 02
+/// follow-up (`Config::warn_unknown_overrides`) emits stderr warnings; we keep
+/// them separate so this method stays infallible and side-effect-free apart
+/// from mutating `self`.
+///
+/// **Idempotent:** safe to call multiple times — the override path is read
+/// from `prefs`, not from `self`, and tilde expansion is itself idempotent
+/// (already-absolute paths pass through unchanged).
+pub(crate) fn apply_machine_overrides(
+    &mut self,
+    prefs: &crate::machine::MachinePrefs,
+) -> Result<()> {
+    for (name, override_) in &prefs.directory_overrides {
+        if let Some(dir) = self.directories.get_mut(name.as_str()) {
+            dir.path = expand_tilde(&override_.path)?;
+            dir.override_applied = true;
+        }
+        // Unknown override targets: no-op here. PORT-03 (Plan 02) handles warnings.
+    }
+    Ok(())
+}
+```
+
+**Step 3 — Add `Config::load_with_overrides`** (place immediately after `load_or_default`, around line 316):
+
+```rust
+/// Load config and apply per-machine path overrides in one shot.
+///
+/// **Order (I2 invariant — must not change):**
+///   1. Read TOML from `path` (or build defaults if missing — same as `Config::load`)
+///   2. `expand_tildes()` on the raw config
+///   3. `apply_machine_overrides(prefs)` — rewrites paths per `[directory_overrides.<name>]`
+///   4. `validate()` — sees the merged result, so any override that produces an
+///      invalid config (e.g., overridden path overlaps `library_dir`) surfaces here
+///
+/// Plan 02 (PORT-04) wraps the validate step in a distinct error class so the
+/// user knows to fix `machine.toml`, not `tome.toml`. This method intentionally
+/// returns the raw `validate()` error for now — Plan 02 introduces the wrapping.
+///
+/// Used by `lib.rs::run()` for every non-Init command. `tome init` does NOT use
+/// this path — the wizard runs against the bare `tome.toml` that the user is
+/// about to write.
+pub fn load_with_overrides(
+    path: &Path,
+    prefs: &crate::machine::MachinePrefs,
+) -> Result<Self> {
+    let mut config = if path.exists() {
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let config: Config = toml::from_str(&content).map_err(|e| {
+            let mut msg = format!("failed to parse {}: {e}", path.display());
+            if content.contains("[[sources]]") || content.contains("[targets.") {
+                msg.push_str("\nhint: tome v0.6 replaced [[sources]] and [targets.*] with [directories.*]. See CHANGELOG.md for migration instructions.");
+            }
+            anyhow::anyhow!("{msg}")
+        })?;
+        config
+    } else {
+        Self::default()
+    };
+
+    config.expand_tildes()?;
+    config.apply_machine_overrides(prefs)?;
+    config.validate()?;
+    Ok(config)
+}
+```
+
+**Step 4 — Add a `load_or_default_with_overrides` wrapper for the `cli_path: Option<&Path>` shape** (mirroring `load_or_default`, placed immediately after the new `load_with_overrides`):
+
+```rust
+/// CLI-aware variant of `load_with_overrides`. See `load_or_default` for the
+/// missing-file vs. missing-parent-dir semantics.
+pub fn load_or_default_with_overrides(
+    cli_path: Option<&Path>,
+    prefs: &crate::machine::MachinePrefs,
+) -> Result<Self> {
+    let path = match cli_path {
+        Some(p) => {
+            if !p.exists() {
+                let parent_exists = p.parent().is_some_and(|d| d.exists());
+                anyhow::ensure!(parent_exists, "config file not found: {}", p.display());
+            }
+            p.to_path_buf()
+        }
+        None => default_config_path()?,
+    };
+    Self::load_with_overrides(&path, prefs)
+}
+```
+
+**Implementation notes:**
+- DO NOT modify `Config::load` or `Config::load_or_default`. Tests + the Init wizard still use them. Adding two new methods (additive) is the minimum-blast-radius path.
+- `expand_tilde` (the free function at line ~580) is the same one used by `expand_tildes` — reuse it.
+- The `DirectoryName` keys in `prefs.directory_overrides` are `DirectoryName`s; the keys in `self.directories` are also `DirectoryName`s; use `.get_mut(name.as_str())` because `BTreeMap` lookup borrows. (Verify against existing code patterns at lines ~360 and ~445.)
+- `save_checked` (line ~533) currently does TOML round-trip equality. Adding `#[serde(skip)] override_applied` to `DirectoryConfig` MUST NOT break this — the field is invisible to serde, so the round-trip stays identical. Verify by running `cargo test -p tome --lib config::tests::save_checked_writes_valid_config_and_reloads_unchanged` (existing test, line 1752) after the change.
+
+Add the 9 tests inside the existing `#[cfg(test)] mod tests` block of `config.rs`. Reuse existing test helpers (`make_*`, `TempDir`, etc.). For tests that need a `MachinePrefs`, build it directly:
+```rust
+use crate::machine::{DirectoryOverride, MachinePrefs};
+let mut prefs = MachinePrefs::default();
+prefs.directory_overrides.insert(
+    DirectoryName::new("x").unwrap(),
+    DirectoryOverride { path: PathBuf::from("/new") },
+);
+```
+
+Run: `cargo test -p tome config::tests::apply_machine_overrides config::tests::load_with_overrides config::tests::override_applied`
+  </action>
+  <verify>
+    <automated>cargo test -p tome --lib config::tests 2>&1 | tail -30 && cargo clippy -p tome --all-targets -- -D warnings 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "pub\\(crate\\) fn apply_machine_overrides" crates/tome/src/config.rs` returns exactly 1 match.
+    - `rg -n "pub fn load_with_overrides" crates/tome/src/config.rs` returns exactly 1 match.
+    - `rg -n "pub fn load_or_default_with_overrides" crates/tome/src/config.rs` returns exactly 1 match.
+    - `rg -n "override_applied" crates/tome/src/config.rs` returns at least 4 matches (field decl + apply method + at least 2 tests).
+    - `rg -n "#\\[serde\\(skip" crates/tome/src/config.rs | rg "override_applied"` matches the field annotation. (Use either `#[serde(skip)]` or `#[serde(skip, default)]` per the action's "Alternative path" note.)
+    - `cargo test -p tome --lib config::tests::apply_machine_overrides_` runs ≥ 5 tests, all pass.
+    - `cargo test -p tome --lib config::tests::load_with_overrides_` runs ≥ 2 tests, all pass.
+    - `cargo test -p tome --lib config::tests::save_checked_writes_valid_config_and_reloads_unchanged` still passes (regression — `#[serde(skip)]` must not break the round-trip).
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+    - After all sites are updated (Step 1.5), `cargo build -p tome` is clean (zero "missing field `override_applied`" errors).
+    - `rg -c "DirectoryConfig \{" crates/tome/src/` matches the count taken before the change (i.e., no struct-literal construction sites were accidentally rewritten or removed during Step 1.5).
+  </acceptance_criteria>
+  <done>
+    `DirectoryConfig.override_applied` field exists with `#[serde(skip)]`, `Config::apply_machine_overrides` mutates path + flag in one pass, `Config::load_with_overrides` chains expand → apply → validate, and `Config::load_or_default_with_overrides` wraps the CLI-path shape. 9 unit tests pass, save_checked round-trip regression test still passes.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Wire `load_with_overrides` into the canonical load path in `lib.rs::run`</name>
+  <files>crates/tome/src/lib.rs</files>
+  <read_first>
+    - crates/tome/src/lib.rs lines 90–100 (`resolve_machine_path` helper — already exists, reuse)
+    - crates/tome/src/lib.rs lines 154–290 (`run()` — the load block that needs editing is at line ~282)
+    - crates/tome/src/lib.rs lines 690–700 (`SyncOptions` struct definition)
+    - crates/tome/src/lib.rs lines 836–895 (`sync()` — currently loads MachinePrefs internally at line 889; it'll receive prefs from caller now)
+    - crates/tome/src/config.rs (the new `load_or_default_with_overrides` method from Task 2)
+  </read_first>
+  <action>
+**Step 1 — Replace the post-Init load block in `run()`** (`lib.rs` line 282–285):
+
+Find this block:
+```rust
+let config = Config::load_or_default(effective_config.as_deref())?;
+config.validate()?;
+let tome_home = resolve_tome_home(cli.tome_home.as_deref(), cli.config.as_deref())?;
+let paths = TomePaths::new(tome_home, config.library_dir.clone())?;
+```
+
+Replace with:
+```rust
+// Load per-machine preferences first — they may rewrite directory paths via
+// `[directory_overrides.<name>]` entries, which `Config::load_with_overrides`
+// applies between `expand_tildes()` and `validate()` (PORT-02 / I2 invariant).
+let machine_path = resolve_machine_path(cli.machine.as_deref())?;
+let machine_prefs = machine::load(&machine_path)?;
+
+let config =
+    Config::load_or_default_with_overrides(effective_config.as_deref(), &machine_prefs)?;
+// Note: `load_or_default_with_overrides` already runs `validate()` internally —
+// no separate `config.validate()?` call here (was redundant in the old code too,
+// since `Config::load` also called `validate`).
+let tome_home = resolve_tome_home(cli.tome_home.as_deref(), cli.config.as_deref())?;
+let paths = TomePaths::new(tome_home, config.library_dir.clone())?;
+```
+
+**Step 2 — Update `SyncOptions` to carry both the path and the loaded prefs.**
+
+`run()` loads `MachinePrefs` once at the top, so `sync()` no longer needs to re-load. Both fields are required: `machine_prefs` for read-only usage during sync, `machine_path` for the `machine::save(&machine_prefs, &machine_path)?` call at the end of the triage block (line ~966).
+
+In `SyncOptions` (line ~691), replace `machine_override: Option<&'a Path>` with two fields:
+
+```rust
+struct SyncOptions<'a> {
+    dry_run: bool,
+    force: bool,
+    no_triage: bool,
+    no_input: bool,
+    verbose: bool,
+    quiet: bool,
+    machine_path: &'a Path,
+    machine_prefs: &'a machine::MachinePrefs,
+}
+```
+
+In `sync()` (line ~836), update the destructure and remove the inline `resolve_machine_path` + `machine::load` calls (currently at lines ~889–890):
+
+```rust
+let SyncOptions {
+    dry_run, force, no_triage, no_input, verbose, quiet,
+    machine_path, machine_prefs: prefs_in,
+} = opts;
+let mut machine_prefs = prefs_in.clone();   // clone so triage can mutate locally
+```
+
+Update the two `SyncOptions { ... }` constructors at lines ~268 and ~313 to pass `machine_path: &machine_path, machine_prefs: &machine_prefs` instead of `machine_override`.
+
+**Why both fields:** The `machine_path` is needed for `machine::save` after triage; the `machine_prefs` (already loaded at `run()` entry) avoids a redundant `machine::load` inside `sync()`. Loading once at the top guarantees the override-apply step in `Config::load_with_overrides` and the disabled-skill filtering inside `sync()` see identical prefs.
+
+**Step 3 — Init handler**. The `Command::Init` branch (line ~247) calls `sync(...)` after wizard run. It currently passes `machine_override: cli.machine.as_deref()`. Update it to load `machine_prefs` once at the top of the Init branch:
+```rust
+// Inside `if matches!(cli.command, Command::Init)` block, before the sync call:
+let machine_path = resolve_machine_path(cli.machine.as_deref())?;
+let machine_prefs = machine::load(&machine_path)?;
+
+// ... existing wizard code ...
+
+if !cli.dry_run {
+    // ... existing expanded config setup ...
+    sync(
+        &expanded,
+        &paths,
+        SyncOptions {
+            dry_run: cli.dry_run,
+            force: false,
+            no_triage: true,
+            no_input: cli.no_input,
+            verbose: cli.verbose,
+            quiet: cli.quiet,
+            machine_path: &machine_path,
+            machine_prefs: &machine_prefs,
+        },
+    )?;
+}
+```
+
+**Important — the Init pre-load probe at line 163:**
+```rust
+if let Err(e) = Config::load_or_default(effective_config.as_deref()) {
+    eprintln!("warning: existing config is malformed (...)", e);
+}
+```
+Leave this unchanged. It probes whether the existing file parses; overrides aren't relevant to malformed-detection, and applying them would mask schema errors the wizard wants to surface.
+
+**Step 4 — Backup command path** (line ~610): `let new_config = Config::load(&config_path)?;`. This is read inside backup-restore for a snapshot path. Leave it on plain `Config::load` — backup snapshots are restored verbatim and overrides are a runtime concern, not a snapshot concern. Add a one-line code comment noting why:
+```rust
+// Use plain Config::load (no overrides) — backup restore reads a snapshot exactly as written.
+let new_config = Config::load(&config_path)?;
+```
+
+**Step 5 — Run the existing CLI integration test suite** to confirm nothing regressed:
+```bash
+cargo build -p tome
+cargo test -p tome --lib
+cargo test -p tome --test cli
+```
+
+Known fragile integration tests to watch: any test that constructs `SyncOptions` directly (search with `rg -n "machine_override:" crates/tome/`). After this change, those tests must use `machine_path` + `machine_prefs` instead. Update mechanically — there should be zero non-`lib.rs` `SyncOptions` constructions because `SyncOptions` is `struct` (not `pub`) with `pub(crate)`-or-tighter visibility (verify before starting).
+
+**Add a smoke test** in `crates/tome/tests/cli.rs` that proves the wiring works end-to-end:
+
+```rust
+#[cfg(unix)]
+#[test]
+fn machine_override_rewrites_directory_path_for_status() {
+    // PORT-01 + PORT-02 smoke: declare an override in machine.toml and
+    // confirm `tome status --json` reports the OVERRIDDEN path, proving
+    // the load pipeline applied the override before status::gather ran.
+    let tmp = TempDir::new().unwrap();
+    let real_skills = tmp.path().join("real-skills");
+    create_skill(&real_skills, "x");
+
+    // tome.toml points at a path that does NOT exist.
+    let tome_toml = format!(
+        "library_dir = \"{}/library\"\n\
+         \n\
+         [directories.work]\n\
+         path = \"{}/does-not-exist\"\n\
+         type = \"directory\"\n\
+         role = \"source\"\n",
+        tmp.path().display(),
+        tmp.path().display(),
+    );
+    std::fs::write(tmp.path().join("tome.toml"), tome_toml).unwrap();
+
+    // machine.toml overrides directories.work.path to the real path.
+    let machine_toml = format!(
+        "[directory_overrides.work]\npath = \"{}\"\n",
+        real_skills.display(),
+    );
+    let machine_path = tmp.path().join("machine.toml");
+    std::fs::write(&machine_path, machine_toml).unwrap();
+
+    let assert = tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "--machine",
+            machine_path.to_str().unwrap(),
+            "status",
+            "--json",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let report: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let dirs = report["directories"].as_array().unwrap();
+    let work = dirs.iter().find(|d| d["name"] == "work").unwrap();
+    let path = work["path"].as_str().unwrap();
+    assert!(
+        path.contains("real-skills"),
+        "expected status to report overridden path, got: {path}"
+    );
+}
+```
+
+Run: `cargo test -p tome --test cli machine_override_rewrites_directory_path_for_status`
+  </action>
+  <verify>
+    <automated>cargo build -p tome 2>&1 | tail -10 && cargo test -p tome --lib 2>&1 | tail -5 && cargo test -p tome --test cli machine_override_rewrites_directory_path_for_status</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "Config::load_or_default_with_overrides" crates/tome/src/lib.rs` returns at least 1 match.
+    - `rg -n "Config::load_or_default\\(" crates/tome/src/lib.rs` returns exactly 1 match (the Init pre-load probe at line ~163; the post-Init call site at line ~282 is gone).
+    - `rg -n "machine_override:" crates/tome/src/lib.rs` returns 0 matches (replaced by `machine_path` + `machine_prefs`).
+    - `rg -n "machine_path:|machine_prefs:" crates/tome/src/lib.rs` returns at least 4 matches (struct decl + 2 sync call sites + sync body destructure).
+    - `cargo build -p tome` is clean.
+    - `cargo test -p tome --lib` passes (existing 464+ unit tests; no regressions).
+    - `cargo test -p tome --test cli` passes (existing integration tests + the new smoke test).
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+    - `make ci` passes.
+  </acceptance_criteria>
+  <done>
+    `run()` loads `MachinePrefs` once, threads it through `Config::load_or_default_with_overrides` and `SyncOptions` to `sync()`. The Init handler also loads prefs at the top of its branch. The `machine_override` field on `SyncOptions` is gone. The new smoke integration test proves end-to-end that an override declared in `machine.toml` reaches `tome status --json` output.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- `cargo test -p tome machine::tests::directory_overrides` — ≥ 7 tests pass.
+- `cargo test -p tome --lib config::tests::apply_machine_overrides_` — ≥ 5 tests pass.
+- `cargo test -p tome --lib config::tests::load_with_overrides_` — ≥ 2 tests pass.
+- `cargo test -p tome --lib config::tests::save_checked_writes_valid_config_and_reloads_unchanged` — passes (regression guard for `#[serde(skip)]`).
+- `cargo test -p tome --test cli machine_override_rewrites_directory_path_for_status` — passes (end-to-end I2 smoke test).
+- `make ci` — clean.
+- `rg -n "Config::load_or_default\\(" crates/tome/src/lib.rs` — exactly 1 match (Init malformed-config probe only).
+- `rg -n "machine_override:" crates/tome/src/lib.rs` — 0 matches.
+</verification>
+
+<success_criteria>
+- `DirectoryOverride` struct + `MachinePrefs.directory_overrides` parsed from `[directory_overrides.<name>]` TOML blocks (PORT-01).
+- `Config::apply_machine_overrides` mutates `directories[name].path` + sets `override_applied = true`, called between `expand_tildes()` and `validate()` (PORT-02 / I2 invariant).
+- A single canonical load path (`Config::load_or_default_with_overrides`) is used by every non-Init command via `lib.rs::run()`. Sync, status, doctor, lockfile::generate all see the merged result without re-loading prefs.
+- The Init pre-load probe (line ~163) and Init wizard run unchanged — overrides do not interfere with malformed-config detection or wizard prompts.
+- `#[serde(skip)] override_applied` is invisible to `tome.toml` round-trips — `save_checked` byte-equality is preserved.
+- End-to-end smoke test proves `tome status --json` reports the overridden path.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/09-cross-machine-path-overrides/09-01-SUMMARY.md` recording:
+- New `DirectoryOverride` struct + `MachinePrefs.directory_overrides` field signatures.
+- New `Config::apply_machine_overrides` + `Config::load_with_overrides` + `Config::load_or_default_with_overrides` signatures.
+- New `DirectoryConfig.override_applied` field (with `#[serde(skip)]`).
+- The exact `lib.rs::run()` line range that was rewritten.
+- Test names added (machine.rs ≥ 7, config.rs ≥ 9, tests/cli.rs = 1).
+- One-line confirmation: PORT-01 + PORT-02 closed.
+- Any deviations from the plan (e.g., if `Default` chain expansion was needed on `DirectoryType`).
+</output>

--- a/.planning/phases/09-cross-machine-path-overrides/09-02-validation-surfacing-PLAN.md
+++ b/.planning/phases/09-cross-machine-path-overrides/09-02-validation-surfacing-PLAN.md
@@ -1,0 +1,624 @@
+---
+phase: 09-cross-machine-path-overrides
+plan: 02
+type: execute
+wave: 2
+depends_on: [09-01]
+files_modified:
+  - crates/tome/src/config.rs
+  - crates/tome/src/lib.rs
+  - crates/tome/tests/cli.rs
+autonomous: true
+requirements: [PORT-03, PORT-04]
+issue: "https://github.com/MartinP7r/tome/issues/458"
+
+must_haves:
+  truths:
+    - "An override targeting a directory name not present in `tome.toml` produces a single stderr `warning:` line naming the typo target and continues loading — does not abort"
+    - "When `apply_machine_overrides` produces a path that fails `Config::validate()` (e.g., overlaps `library_dir`), the user sees a distinct error class that names `machine.toml` as the file to edit, not `tome.toml`"
+    - "Validation errors NOT caused by an override (i.e., the underlying `tome.toml` was already invalid) continue to surface as before — only override-induced failures get the new wrapper"
+  artifacts:
+    - path: "crates/tome/src/config.rs"
+      provides: "`Config::warn_unknown_overrides(prefs: &MachinePrefs, mut warn: impl FnMut(String))` helper that walks `prefs.directory_overrides` and emits a `warning:` string for any key not present in `self.directories`. `Config::load_with_overrides` is updated to: (1) call `warn_unknown_overrides` before `apply_machine_overrides`, emitting via `eprintln!`, (2) snapshot a pre-override clone, (3) wrap the post-override `validate()` Err into a new `OverrideValidationError` shape that names `machine.toml` and contrasts pre-override vs post-override paths."
+      contains: "warn_unknown_overrides"
+    - path: "crates/tome/src/lib.rs"
+      provides: "No structural changes — `run()` already calls `Config::load_or_default_with_overrides` from Plan 01. The new warnings + error class flow through automatically."
+      contains: "load_or_default_with_overrides"
+    - path: "crates/tome/tests/cli.rs"
+      provides: "Two integration tests: (1) override with unknown target name produces stderr warning, command still succeeds; (2) override that creates a library/distribution overlap produces a distinct error message naming `machine.toml`."
+      contains: "machine_override_unknown_target_warns"
+  key_links:
+    - from: "crates/tome/src/config.rs Config::load_with_overrides"
+      to: "Config::warn_unknown_overrides"
+      via: "called once before apply_machine_overrides; emits via eprintln! closure"
+      pattern: "warn_unknown_overrides"
+    - from: "crates/tome/src/config.rs Config::load_with_overrides"
+      to: "OverrideValidationError wrapper"
+      via: "validate() Err branch wrapped only when at least one override was applied AND the same validate() succeeds on the pre-override snapshot"
+      pattern: "OverrideValidationError|machine\\.toml"
+---
+
+<objective>
+Surface override-related issues with the right level of noise:
+
+- **PORT-03 (typo guard):** A `[directory_overrides.<name>]` block whose `<name>` doesn't match any directory in `tome.toml` emits a single stderr `warning:` line and load continues. Without this, a user who misspells `claude` as `claud` silently loses their override and wonders why their path didn't change.
+
+- **PORT-04 (validation blame attribution):** When `apply_machine_overrides` rewrites a path that ends up making `validate()` fail (e.g., the new path overlaps `library_dir`), the resulting error names `machine.toml` as the file to edit — NOT `tome.toml`. Without this, the user sees "library_dir overlaps distribution directory 'work'" and wastes time editing `tome.toml`, where everything is fine.
+
+Plan 01 left `apply_machine_overrides` as a silent infallible mutation and `load_with_overrides` returning the raw `validate()` error. This plan adds the surfacing layer on top.
+
+**Closes:** PORT-03 (typo warning), PORT-04 (override-induced validation error class).
+
+Purpose: Make the override mechanism a tool the user can debug, not a black box.
+Output: `Config::warn_unknown_overrides` helper, `OverrideValidationError` wrapper, two integration tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/REQUIREMENTS.md
+
+@.planning/phases/09-cross-machine-path-overrides/09-01-SUMMARY.md
+
+@crates/tome/src/config.rs
+@crates/tome/src/machine.rs
+@crates/tome/src/lib.rs
+@crates/tome/tests/cli.rs
+
+<interfaces>
+<!-- Key types and contracts the executor needs. After Plan 01. -->
+
+From `crates/tome/src/config.rs` (after Plan 01):
+```rust
+pub fn load_with_overrides(path: &Path, prefs: &MachinePrefs) -> Result<Self> {
+    let mut config = /* parse TOML or default */;
+    config.expand_tildes()?;
+    config.apply_machine_overrides(prefs)?;   // <-- silent for unknown targets
+    config.validate()?;                        // <-- raw validate() error
+    Ok(config)
+}
+
+pub(crate) fn apply_machine_overrides(&mut self, prefs: &MachinePrefs) -> Result<()>;
+```
+
+From `crates/tome/src/config.rs::validate()` — error message style template (already established by D-10 Conflict+Why+Suggestion):
+```text
+library_dir overlaps distribution directory 'work'
+Conflict: library_dir (/foo) is the same path as directory 'work' (/foo)
+Why: this directory has role <X>; tome would try to distribute the library into itself...
+hint: choose a library_dir outside any distribution directory, such as '~/.tome/skills'.
+```
+
+The Plan 02 wrapper PRESERVES the original error text and PREPENDS a header that names `machine.toml`:
+```text
+override-induced config error from machine.toml
+
+The following directory paths come from `[directory_overrides.<name>]` overrides:
+  - work: /foo  (was: /old, in tome.toml)
+
+These overrides made an otherwise-valid `tome.toml` fail validation:
+
+<original validate() error here, indented 2 spaces>
+
+To fix: edit `<machine_toml_path>` (NOT tome.toml). Either remove the override
+or change it to a path that doesn't overlap library_dir.
+```
+
+From `crates/tome/src/lib.rs::run` (after Plan 01):
+```rust
+let machine_path = resolve_machine_path(cli.machine.as_deref())?;
+let machine_prefs = machine::load(&machine_path)?;
+let config = Config::load_or_default_with_overrides(effective_config.as_deref(), &machine_prefs)?;
+```
+
+The new error wrapper needs to know `machine_path` to put it in the message. Two options:
+- (a) Pass `machine_path: &Path` into `load_with_overrides` as a third arg.
+- (b) Resolve `machine::default_machine_path()` at error-construction time inside `load_with_overrides`.
+
+**Choose (a)** — explicit threading is clearer than reaching for a default that may not match `cli.machine.as_deref()`. The `lib.rs::run` already has `machine_path` in scope; passing it costs one more parameter.
+
+**Existing pattern to mirror:** `lib.rs::warn_unknown_disabled_directories` (line ~679) handles the typo case for `disabled_directories`. The same shape works here: take `(prefs: &MachinePrefs, config: &Config)`, walk the relevant map, `eprintln!` for each miss. Keep the warning string parallel:
+
+```text
+warning: directory_overrides target 'claud' in machine.toml does not match any configured directory
+```
+
+Note: `warn_unknown_disabled_directories` uses an `eprintln!` directly. We have two choices for `warn_unknown_overrides`:
+- Match that pattern (write `eprintln!` inline), OR
+- Take an `impl FnMut(String)` so it's testable without capturing stderr.
+
+**Choose the FnMut shape** — matching the existing pattern is fine, but `warn_unknown_disabled_directories` doesn't have unit tests; we want `warn_unknown_overrides` to be unit-testable so the warning string format is locked in. The caller in `Config::load_with_overrides` adapts via `|s| eprintln!("warning: {}", s)`.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add `Config::warn_unknown_overrides` helper</name>
+  <files>crates/tome/src/config.rs</files>
+  <read_first>
+    - crates/tome/src/lib.rs lines 677–688 (`warn_unknown_disabled_directories` — mirror this shape)
+    - crates/tome/src/config.rs (the `apply_machine_overrides` method added in Plan 01)
+    - crates/tome/src/machine.rs (the `directory_overrides` field added in Plan 01)
+  </read_first>
+  <behavior>
+    - Test 1 (`warn_unknown_overrides_no_overrides_emits_nothing`): Empty `directory_overrides` → `warn` closure called 0 times.
+    - Test 2 (`warn_unknown_overrides_known_target_emits_nothing`): Override target `x` exists in `config.directories` → `warn` called 0 times.
+    - Test 3 (`warn_unknown_overrides_unknown_target_emits_one_warning`): Override target `claud` (typo) does NOT exist in `config.directories` → `warn` called exactly once with a message containing `"claud"`, `"machine.toml"`, AND either `"directory_overrides"` or `"override"`. (Verifies user can grep stderr for any of the three keywords.)
+    - Test 4 (`warn_unknown_overrides_multiple_unknowns_emit_one_each`): Two unknown targets `a` and `b` → `warn` called exactly twice (once per target). Order is alphabetical (`BTreeMap` iteration).
+    - Test 5 (`warn_unknown_overrides_does_not_mutate_config`): Calling the helper does not mutate `self` — it's `&self`, not `&mut self`.
+  </behavior>
+  <action>
+Add to `impl Config` in `crates/tome/src/config.rs`, immediately after `apply_machine_overrides` (the method added in Plan 01):
+
+```rust
+/// Emit a warning for each `[directory_overrides.<name>]` entry whose `<name>`
+/// does not match any key in `self.directories`. Caller-supplied `warn` closure
+/// receives the formatted message body (without the `warning:` prefix), so the
+/// caller decides whether to `eprintln!`, push to a Vec, or do something else.
+///
+/// Used by `Config::load_with_overrides` to surface PORT-03 typo guards.
+/// Mirrors `lib.rs::warn_unknown_disabled_directories` (which handles the same
+/// typo case for `disabled_directories`).
+///
+/// **Order:** call this BEFORE `apply_machine_overrides` so the user sees
+/// warnings about typos even if the apply step never touches them. (Apply is
+/// silent for unknown targets — see Plan 01.)
+pub(crate) fn warn_unknown_overrides(
+    &self,
+    prefs: &crate::machine::MachinePrefs,
+    mut warn: impl FnMut(String),
+) {
+    for name in prefs.directory_overrides.keys() {
+        if !self.directories.contains_key(name.as_str()) {
+            warn(format!(
+                "directory_overrides target '{name}' in machine.toml does not match any configured directory"
+            ));
+        }
+    }
+}
+```
+
+**Implementation notes:**
+- `prefs.directory_overrides` is `BTreeMap<DirectoryName, DirectoryOverride>` (Plan 01 exact shape) — iteration is alphabetical and deterministic.
+- The warning string format MUST contain `"directory_overrides target '<name>' in machine.toml"` so it's structurally similar to (but distinguishable from) the existing `warn_unknown_disabled_directories` line `"disabled directory '<name>' in machine.toml does not match any configured directory"`. Tests assert on the keyword set, not exact wording — this gives us room to tweak phrasing later.
+- Visibility: `pub(crate)` — only `load_with_overrides` (same module) needs to call it.
+
+Add the 5 unit tests inside the existing `#[cfg(test)] mod tests` block of `config.rs`. Test pattern (use a captured `Vec<String>` for assertions):
+```rust
+#[test]
+fn warn_unknown_overrides_unknown_target_emits_one_warning() {
+    let mut config = Config::default();
+    config.directories.insert(
+        DirectoryName::new("real").unwrap(),
+        DirectoryConfig { /* ... minimal */ },
+    );
+    let mut prefs = crate::machine::MachinePrefs::default();
+    prefs.directory_overrides.insert(
+        DirectoryName::new("claud").unwrap(),
+        crate::machine::DirectoryOverride { path: PathBuf::from("/p") },
+    );
+    let mut warnings: Vec<String> = Vec::new();
+    config.warn_unknown_overrides(&prefs, |w| warnings.push(w));
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].contains("claud"));
+    assert!(warnings[0].contains("machine.toml"));
+    assert!(warnings[0].contains("directory_overrides") || warnings[0].contains("override"));
+}
+```
+
+Run: `cargo test -p tome --lib config::tests::warn_unknown_overrides`
+  </action>
+  <verify>
+    <automated>cargo test -p tome --lib config::tests::warn_unknown_overrides 2>&1 | tail -15</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "pub\\(crate\\) fn warn_unknown_overrides" crates/tome/src/config.rs` returns exactly 1 match.
+    - `cargo test -p tome --lib config::tests::warn_unknown_overrides` runs ≥ 5 tests, all pass.
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+    - The helper does NOT mutate `self` (`rg -n "fn warn_unknown_overrides\\(\\s*&mut self" crates/tome/src/config.rs` returns 0 matches).
+  </acceptance_criteria>
+  <done>
+    `Config::warn_unknown_overrides` exists with `&self` + `impl FnMut(String)` callback, 5 unit tests cover empty/known/unknown/multiple/no-mutation cases, clippy is clean.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Wrap override-induced validation failures with `OverrideValidationError` shape</name>
+  <files>crates/tome/src/config.rs</files>
+  <read_first>
+    - crates/tome/src/config.rs lines 277–300 (existing `Config::load`)
+    - crates/tome/src/config.rs (the `load_with_overrides` method added in Plan 01)
+    - crates/tome/src/config.rs lines 351–492 (`Config::validate` — the bail messages we're wrapping)
+  </read_first>
+  <behavior>
+    - Test 1 (`load_with_overrides_pre_override_invalid_returns_raw_error`): `tome.toml` has `library_dir = /foo`, `directories.work.path = /foo` (overlap, invalid in v0.8.1). MachinePrefs has empty `directory_overrides`. `load_with_overrides` returns Err whose message contains the existing `library_dir overlaps distribution directory 'work'` text — NOT wrapped. (Pre-override invalid stays raw.)
+    - Test 2 (`load_with_overrides_override_induces_invalid_returns_wrapped_error`): `tome.toml` has `library_dir = /lib`, `directories.work.path = /work` (valid). MachinePrefs has `directory_overrides.work.path = /lib` (overrides into the library). `load_with_overrides` returns Err whose message contains: (a) `"machine.toml"`, (b) `"directory_overrides"` or the literal override path `/lib`, (c) the original `library_dir overlaps` text from `validate()`, AND (d) does NOT direct the user to edit `tome.toml`. Specifically: assert message contains `"machine.toml"` AND does not contain `"edit tome.toml"`.
+    - Test 3 (`load_with_overrides_override_unrelated_to_failure_returns_raw_error`): `tome.toml` has `library_dir = /lib`, `directories.work.path = /lib` (overlap, invalid). MachinePrefs has `directory_overrides.unrelated.path = /elsewhere` (an override that doesn't exist as a target — typo). `load_with_overrides`: warns about unknown override target `unrelated`, then returns Err with the RAW `library_dir overlaps` error (no machine.toml wrapper), because removing the override would NOT fix the underlying tome.toml problem. (Discriminator: the wrapper applies only when the pre-override config validates AND the post-override config does not.)
+    - Test 4 (`load_with_overrides_path_appears_in_wrapper_message`): The wrapped error message includes the override target name (`work`), the new path (`/lib`), AND the old (pre-override) path. Reason: the user needs to see what changed to debug.
+  </behavior>
+  <action>
+**Step 1 — Update `Config::load_with_overrides` to take `machine_path: &Path`:**
+
+Change the signature from Plan 01:
+```rust
+pub fn load_with_overrides(path: &Path, prefs: &MachinePrefs) -> Result<Self>
+```
+to:
+```rust
+pub fn load_with_overrides(
+    path: &Path,
+    machine_path: &Path,
+    prefs: &MachinePrefs,
+) -> Result<Self>
+```
+
+And update `load_or_default_with_overrides` similarly:
+```rust
+pub fn load_or_default_with_overrides(
+    cli_path: Option<&Path>,
+    machine_path: &Path,
+    prefs: &MachinePrefs,
+) -> Result<Self>
+```
+
+Then update the single call site in `lib.rs::run` (added by Plan 01) to pass `&machine_path`:
+```rust
+let config = Config::load_or_default_with_overrides(
+    effective_config.as_deref(),
+    &machine_path,
+    &machine_prefs,
+)?;
+```
+
+**Step 2 — Rewrite the body of `load_with_overrides` to add warnings + the wrapping branch:**
+
+```rust
+pub fn load_with_overrides(
+    path: &Path,
+    machine_path: &Path,
+    prefs: &crate::machine::MachinePrefs,
+) -> Result<Self> {
+    // Parse TOML (or default if missing) — same as Config::load.
+    let mut config = if path.exists() {
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        toml::from_str::<Config>(&content).map_err(|e| {
+            let mut msg = format!("failed to parse {}: {e}", path.display());
+            if content.contains("[[sources]]") || content.contains("[targets.") {
+                msg.push_str("\nhint: tome v0.6 replaced [[sources]] and [targets.*] with [directories.*]. See CHANGELOG.md for migration instructions.");
+            }
+            anyhow::anyhow!("{msg}")
+        })?
+    } else {
+        Self::default()
+    };
+
+    config.expand_tildes()?;
+
+    // PORT-03: warn about typos before applying.
+    config.warn_unknown_overrides(prefs, |w| eprintln!("warning: {w}"));
+
+    // Snapshot pre-override paths for the PORT-04 wrapper.
+    // Only the directory paths matter for the diff; clone is fine for v0.9.
+    let pre_override_paths: std::collections::BTreeMap<String, std::path::PathBuf> = config
+        .directories
+        .iter()
+        .map(|(name, dir)| (name.as_str().to_string(), dir.path.clone()))
+        .collect();
+
+    config.apply_machine_overrides(prefs)?;
+
+    // PORT-04: if validation fails, attribute the failure to machine.toml
+    // ONLY when removing the overrides would have produced a valid config.
+    // Otherwise, the underlying tome.toml is what's broken — pass the raw
+    // error through.
+    if let Err(post_err) = config.validate() {
+        // Reconstruct the pre-override config (cheap — only paths changed).
+        let mut pre_override_config = config.clone();
+        for (name, dir) in pre_override_config.directories.iter_mut() {
+            if let Some(orig) = pre_override_paths.get(name.as_str()) {
+                dir.path = orig.clone();
+                dir.override_applied = false;
+            }
+        }
+        let pre_override_valid = pre_override_config.validate().is_ok();
+
+        if pre_override_valid && config.directories.values().any(|d| d.override_applied) {
+            return Err(format_override_validation_error(
+                &post_err,
+                &pre_override_paths,
+                &config,
+                machine_path,
+            ));
+        }
+        return Err(post_err);
+    }
+    Ok(config)
+}
+```
+
+**Step 3 — Add the formatter as a free function** (place above `load_with_overrides`, or after it — your choice):
+
+```rust
+/// Wrap a `Config::validate()` error that was caused by `[directory_overrides.*]`
+/// rewriting paths into something invalid. Names `machine.toml` as the file to
+/// edit (NOT `tome.toml`) and shows the pre-override vs post-override paths so
+/// the user can see what changed.
+///
+/// Only called when:
+///   - pre-override config validates,
+///   - at least one override was applied,
+///   - post-override config fails validation.
+fn format_override_validation_error(
+    post_err: &anyhow::Error,
+    pre_override_paths: &std::collections::BTreeMap<String, std::path::PathBuf>,
+    config: &Config,
+    machine_path: &std::path::Path,
+) -> anyhow::Error {
+    let mut diff_lines = Vec::new();
+    for (name, dir) in &config.directories {
+        if dir.override_applied {
+            let was = pre_override_paths
+                .get(name.as_str())
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "<unknown>".to_string());
+            diff_lines.push(format!(
+                "  - {}: {} (was: {}, in tome.toml)",
+                name,
+                dir.path.display(),
+                was,
+            ));
+        }
+    }
+
+    // Indent the original validate() error by 2 spaces so it visually nests
+    // under our wrapper text. Multi-line errors stay readable.
+    let indented = format!("{post_err:#}")
+        .lines()
+        .map(|l| format!("  {l}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    anyhow::anyhow!(
+        "override-induced config error from machine.toml\n\
+         \n\
+         The following directory paths come from `[directory_overrides.<name>]` overrides:\n\
+         {}\n\
+         \n\
+         These overrides made an otherwise-valid `tome.toml` fail validation:\n\
+         \n\
+         {}\n\
+         \n\
+         To fix: edit `{}` (NOT tome.toml). Either remove the override(s) above \
+         or change them to paths that don't conflict.",
+        diff_lines.join("\n"),
+        indented,
+        machine_path.display(),
+    )
+}
+```
+
+**Implementation notes:**
+- The wrapper does NOT change the `Result` type of `load_with_overrides` — it stays `Result<Self>` (anyhow::Error). The "distinct error class" PORT-04 calls for is achieved by **message content + structure** rather than a typed error variant. This matches the existing tome convention (everything is `anyhow::Result` with grep-able message conventions like "Conflict: ... Why: ... hint: ..."). If a future caller needs to programmatically detect override errors, we can add a marker line like `class: override-induced` or migrate to a typed error then. **Track this as a v1.0 follow-up issue if it comes up; do not introduce a typed error class in v0.9.**
+- The discriminator (`pre_override_valid && any override_applied`) intentionally allows both conditions: if no overrides were applied, the wrapper isn't relevant. If pre-override config is also invalid, blaming machine.toml would be wrong.
+- Indentation by `format!("{post_err:#}")` — using the `:#` formatter so anyhow's chained context shows up. Verify by writing one test that constructs a multi-line validate error and checks both lines appear in the wrapped message.
+- The test in `Test 3` exercises the discriminator: pre-override invalid + override that doesn't fix it → raw error.
+
+Add the 4 unit tests inside the `#[cfg(test)] mod tests` block. Use the existing `make_*` helpers and `tempfile::TempDir`. The library_dir/distribution-dir overlap is the cleanest validate failure to trigger; reuse the patterns from existing `validate_rejects_library_equals_distribution` test (~line 1536).
+
+Run: `cargo test -p tome --lib config::tests::load_with_overrides`
+  </action>
+  <verify>
+    <automated>cargo test -p tome --lib config::tests::load_with_overrides 2>&1 | tail -20 && cargo clippy -p tome --all-targets -- -D warnings 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "fn format_override_validation_error" crates/tome/src/config.rs` returns exactly 1 match.
+    - `rg -n "override-induced config error from machine.toml" crates/tome/src/config.rs` returns exactly 1 match.
+    - `rg -n "load_or_default_with_overrides" crates/tome/src/lib.rs` shows the call site passing 3 args (path + machine_path + prefs).
+    - `cargo test -p tome --lib config::tests::load_with_overrides_pre_override_invalid_returns_raw_error` passes.
+    - `cargo test -p tome --lib config::tests::load_with_overrides_override_induces_invalid_returns_wrapped_error` passes.
+    - `cargo test -p tome --lib config::tests::load_with_overrides_override_unrelated_to_failure_returns_raw_error` passes.
+    - `cargo test -p tome --lib config::tests::load_with_overrides_path_appears_in_wrapper_message` passes.
+    - `cargo test -p tome --lib config::tests::load_with_overrides_runs_in_order_expand_apply_validate` (from Plan 01) STILL passes — wrapper changes did not regress the order test.
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+  </acceptance_criteria>
+  <done>
+    `load_with_overrides` and `load_or_default_with_overrides` take `machine_path: &Path`, run `warn_unknown_overrides` before apply, snapshot pre-override paths, and wrap post-override `validate()` errors with `format_override_validation_error` only when (pre-override valid AND override applied). 4 unit tests cover the matrix.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Integration tests — typo warning + override-induced validation error end-to-end</name>
+  <files>crates/tome/tests/cli.rs</files>
+  <read_first>
+    - crates/tome/tests/cli.rs lines 1–80 (test infrastructure: `tome()` builder, `create_skill`, `TempDir`)
+    - crates/tome/tests/cli.rs lines 300–340 (existing `--machine` flag tests for shape reference)
+    - The smoke test `machine_override_rewrites_directory_path_for_status` (added in Plan 01, Task 3) — match its style
+  </read_first>
+  <action>
+Add two integration tests to `crates/tome/tests/cli.rs`, immediately after `machine_override_rewrites_directory_path_for_status` (added in Plan 01).
+
+**Test 1 — PORT-03 unknown target warning:**
+
+```rust
+#[cfg(unix)]
+#[test]
+fn machine_override_unknown_target_warns_and_continues() {
+    // PORT-03: an override targeting a directory name not present in tome.toml
+    // produces a stderr `warning:` line (typo guard) without aborting load.
+    let tmp = TempDir::new().unwrap();
+    let real_skills = tmp.path().join("real-skills");
+    create_skill(&real_skills, "x");
+
+    let tome_toml = format!(
+        "library_dir = \"{}/library\"\n\
+         \n\
+         [directories.work]\n\
+         path = \"{}\"\n\
+         type = \"directory\"\n\
+         role = \"source\"\n",
+        tmp.path().display(),
+        real_skills.display(),
+    );
+    std::fs::write(tmp.path().join("tome.toml"), tome_toml).unwrap();
+
+    // Override target `claud` is a typo — `claude` doesn't exist either, but
+    // that's fine: the warning fires for any unknown name.
+    let machine_toml = format!(
+        "[directory_overrides.claud]\npath = \"{}/elsewhere\"\n",
+        tmp.path().display(),
+    );
+    let machine_path = tmp.path().join("machine.toml");
+    std::fs::write(&machine_path, machine_toml).unwrap();
+
+    let assert = tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "--machine",
+            machine_path.to_str().unwrap(),
+            "status",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();   // <-- does NOT abort, only warns
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("warning:") && stderr.contains("claud") && stderr.contains("machine.toml"),
+        "expected stderr warning naming 'claud' and 'machine.toml', got:\n{stderr}"
+    );
+}
+```
+
+**Test 2 — PORT-04 override-induced validation error:**
+
+```rust
+#[cfg(unix)]
+#[test]
+fn machine_override_validation_failure_blames_machine_toml() {
+    // PORT-04: validation failures triggered by an override surface as a
+    // distinct error class that names machine.toml (not tome.toml) as the
+    // file to edit.
+    let tmp = TempDir::new().unwrap();
+    let library_dir = tmp.path().join("library");
+    std::fs::create_dir_all(&library_dir).unwrap();
+
+    // tome.toml is valid: library_dir and directories.work.path are disjoint.
+    let work_dir = tmp.path().join("work-skills");
+    std::fs::create_dir_all(&work_dir).unwrap();
+    let tome_toml = format!(
+        "library_dir = \"{}\"\n\
+         \n\
+         [directories.work]\n\
+         path = \"{}\"\n\
+         type = \"directory\"\n\
+         role = \"synced\"\n",
+        library_dir.display(),
+        work_dir.display(),
+    );
+    std::fs::write(tmp.path().join("tome.toml"), tome_toml).unwrap();
+
+    // machine.toml override forces directories.work.path == library_dir.
+    // After apply_machine_overrides, validate() will fail with the existing
+    // "library_dir overlaps distribution directory 'work'" error.
+    let machine_toml = format!(
+        "[directory_overrides.work]\npath = \"{}\"\n",
+        library_dir.display(),
+    );
+    let machine_path = tmp.path().join("machine.toml");
+    std::fs::write(&machine_path, machine_toml).unwrap();
+
+    let assert = tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "--machine",
+            machine_path.to_str().unwrap(),
+            "status",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+
+    // The wrapped error MUST mention machine.toml (so the user knows where to look)
+    assert!(
+        stderr.contains("machine.toml"),
+        "expected stderr to name machine.toml, got:\n{stderr}"
+    );
+    // And include the original validate() error text (preserved inside the wrapper)
+    assert!(
+        stderr.contains("library_dir") && stderr.contains("overlaps"),
+        "expected wrapped error to preserve the original validate() text, got:\n{stderr}"
+    );
+    // And reference the override-induced classification
+    assert!(
+        stderr.contains("override-induced") || stderr.contains("directory_overrides"),
+        "expected wrapped error to identify itself as override-induced, got:\n{stderr}"
+    );
+    // And NOT direct the user to edit tome.toml (negative assertion — discriminator)
+    assert!(
+        !stderr.contains("edit tome.toml") && !stderr.contains("Edit tome.toml"),
+        "wrapped error must NOT direct the user to edit tome.toml, got:\n{stderr}"
+    );
+}
+```
+
+**Implementation notes:**
+- These tests share the `--tome-home` + `--machine` flag pattern with the Plan 01 smoke test. If `--machine` is not yet a direct CLI flag (it is — see `cli.rs:39 pub machine: Option<PathBuf>`), no plumbing changes needed.
+- Both tests run `tome status` (read-only) — no skill consolidation, no symlink writes — so they're fast and don't need the full sync pipeline.
+- The assertion in Test 2 about `"override-induced" || "directory_overrides"` matches the wrapper text from Task 2: `"override-induced config error from machine.toml"` and `"[directory_overrides.<name>]"` both appear. The `||` allows future wording tweaks without test churn.
+
+Run: `cargo test -p tome --test cli machine_override_unknown_target machine_override_validation_failure`
+  </action>
+  <verify>
+    <automated>cargo test -p tome --test cli machine_override_unknown_target_warns_and_continues machine_override_validation_failure_blames_machine_toml</automated>
+  </verify>
+  <acceptance_criteria>
+    - `cargo test -p tome --test cli machine_override_unknown_target_warns_and_continues` passes.
+    - `cargo test -p tome --test cli machine_override_validation_failure_blames_machine_toml` passes.
+    - `make ci` passes (no regressions to existing 590+ tests).
+  </acceptance_criteria>
+  <done>
+    Both PORT-03 and PORT-04 are pinned end-to-end by integration tests that exercise the full CLI binary against a real `tome.toml` + `machine.toml` fixture pair.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- `cargo test -p tome --lib config::tests::warn_unknown_overrides` — ≥ 5 tests pass.
+- `cargo test -p tome --lib config::tests::load_with_overrides_pre_override_invalid_returns_raw_error` — passes.
+- `cargo test -p tome --lib config::tests::load_with_overrides_override_induces_invalid_returns_wrapped_error` — passes.
+- `cargo test -p tome --lib config::tests::load_with_overrides_override_unrelated_to_failure_returns_raw_error` — passes.
+- `cargo test -p tome --lib config::tests::load_with_overrides_path_appears_in_wrapper_message` — passes.
+- `cargo test -p tome --test cli machine_override_unknown_target_warns_and_continues` — passes.
+- `cargo test -p tome --test cli machine_override_validation_failure_blames_machine_toml` — passes.
+- `make ci` — clean (no regressions to existing test suite).
+</verification>
+
+<success_criteria>
+- An override targeting an unknown directory name produces a stderr `warning:` line and load continues (PORT-03).
+- An override that makes `Config::validate()` fail surfaces with a wrapper that names `machine.toml`, preserves the original validate text, shows pre/post override paths, and explicitly discourages editing `tome.toml` (PORT-04).
+- The wrapper applies ONLY when pre-override config validates AND ≥ 1 override was applied — otherwise the raw `validate()` error passes through unchanged (correct discrimination).
+- `Config::warn_unknown_overrides` is unit-testable via `impl FnMut(String)` callback.
+- Integration tests pin both PORT-03 and PORT-04 end-to-end through the real CLI binary.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/09-cross-machine-path-overrides/09-02-SUMMARY.md` recording:
+- New `Config::warn_unknown_overrides(&self, prefs, warn)` signature.
+- Updated `Config::load_with_overrides` and `Config::load_or_default_with_overrides` signatures (now take `machine_path`).
+- New `format_override_validation_error` formatter signature + the wrapper text template.
+- Discriminator logic summary: wrapper applies iff (pre-override valid) && (≥ 1 override applied).
+- Test names added (config.rs ≥ 5 + 4 = 9, tests/cli.rs = 2).
+- One-line confirmation: PORT-03 + PORT-04 closed.
+- A note for v1.0: if a future caller needs to programmatically detect override errors, consider migrating to a typed error variant (`OverrideValidationError` enum). For v0.9, the message-content approach is sufficient and matches existing anyhow conventions.
+</output>

--- a/.planning/phases/09-cross-machine-path-overrides/09-03-status-doctor-surfacing-PLAN.md
+++ b/.planning/phases/09-cross-machine-path-overrides/09-03-status-doctor-surfacing-PLAN.md
@@ -1,0 +1,745 @@
+---
+phase: 09-cross-machine-path-overrides
+plan: 03
+type: execute
+wave: 2
+depends_on: [09-01]
+files_modified:
+  - crates/tome/src/status.rs
+  - crates/tome/src/doctor.rs
+  - crates/tome/tests/cli.rs
+autonomous: true
+requirements: [PORT-05]
+issue: "https://github.com/MartinP7r/tome/issues/458"
+
+must_haves:
+  truths:
+    - "`tome status` (text mode) marks each directory whose `path` was rewritten by a machine.toml override with an `(override)` annotation in the directory table"
+    - "`tome status --json` includes a per-directory boolean `override_applied: true|false` field so machine-readable consumers (future tome-desktop GUI, scripts) can render the same information"
+    - "`tome doctor` (text mode) marks override-affected directories in the per-directory section so the user sees the same context when running `tome doctor`"
+    - "`tome doctor --json` includes the same per-directory `override_applied` boolean for consistency with status"
+    - "When NO overrides are applied, behavior is byte-identical to v0.8.1 — the `(override)` marker / `override_applied: true` field never appears spuriously"
+  artifacts:
+    - path: "crates/tome/src/status.rs"
+      provides: "`DirectoryStatus.override_applied: bool` field (serialized via serde). `gather()` populates it from `dir_config.override_applied`. `render_status` text path appends ` (override)` to the `PATH` column for entries where `override_applied == true`."
+      contains: "override_applied"
+    - path: "crates/tome/src/doctor.rs"
+      provides: "`DiagnosticIssue` is unchanged (per-issue, not per-directory). The `DoctorReport.directory_issues: Vec<(String, Vec<DiagnosticIssue>)>` is replaced or augmented with `Vec<DirectoryDiagnostic>` carrying `name`, `override_applied`, and `issues`. `render_issues_for_directory` includes the override marker when present. `--json` output includes `override_applied` per directory."
+      contains: "override_applied"
+    - path: "crates/tome/tests/cli.rs"
+      provides: "End-to-end integration test covering the full I2 invariant: tome.toml + machine.toml override → `tome sync` succeeds → `tome status --json` reports `override_applied: true` AND text mode shows `(override)` AND `tome doctor --json` reports `override_applied: true`."
+      contains: "machine_override_appears_in_status_and_doctor"
+  key_links:
+    - from: "crates/tome/src/status.rs DirectoryStatus"
+      to: "crates/tome/src/config.rs DirectoryConfig.override_applied"
+      via: "gather() reads dir_config.override_applied during the directory iteration loop"
+      pattern: "override_applied"
+    - from: "crates/tome/src/doctor.rs DoctorReport per-directory entries"
+      to: "crates/tome/src/config.rs DirectoryConfig.override_applied"
+      via: "check() reads dir_config.override_applied when building the per-directory diagnostic shape"
+      pattern: "override_applied"
+    - from: "crates/tome/src/status.rs render_status (text mode)"
+      to: "DirectoryStatus.override_applied"
+      via: "PATH column gets ` (override)` suffix when the flag is true"
+      pattern: "\\(override\\)"
+---
+
+<objective>
+Surface `[directory_overrides.<name>]` activations in the two read-only commands a user reaches for when asking "why is this path different on this machine?": `tome status` and `tome doctor`. Both commands already render per-directory information; this plan adds the `override_applied` signal to their data structures (so `--json` consumers see it too) and adds an `(override)` annotation to the text output paths.
+
+Plan 01 set the `DirectoryConfig.override_applied: bool` flag during config load. This plan reads that flag in `status::gather()` and `doctor::check()` and renders it.
+
+**Closes:** PORT-05.
+
+**Design choice (option a — `override_applied` flag on DirectoryConfig vs option b — diff against pre-override snapshot):** I picked option (a) in Plan 01 and use it here. Justification:
+
+1. **Single source of truth.** The flag is set once in `Config::apply_machine_overrides` (Plan 01) — the same place that owns the I2 invariant. status/doctor never re-resolve overrides; they read the same merged config every other consumer reads.
+2. **No second snapshot.** Option (b) would require status/doctor to load `MachinePrefs` themselves, build a pre-override `Config` snapshot, and diff paths — duplicating logic from `apply_machine_overrides` in two more places. That's exactly the kind of "second code path that observes pre-override paths" the I2 invariant forbids (success criterion 2).
+3. **`#[serde(skip)]` keeps tome.toml clean.** The flag is invisible to TOML serialization (verified in Plan 01 Task 2), so no existing round-trip test breaks and no spurious field appears in user configs.
+4. **Costs one bool per DirectoryConfig.** Effectively zero memory overhead.
+
+The trade-off: any future code that constructs a `Config` in-memory (e.g., the wizard, tests) needs the field default-initialized to `false`. That's already handled by `#[serde(skip, default)]` in Plan 01.
+
+Output: per-directory `override_applied` field in `DirectoryStatus` and the doctor report, text-mode `(override)` annotations in both commands' rendering, and one end-to-end integration test that pins the full PORT-05 contract.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/REQUIREMENTS.md
+
+@.planning/phases/09-cross-machine-path-overrides/09-01-SUMMARY.md
+
+@crates/tome/src/status.rs
+@crates/tome/src/doctor.rs
+@crates/tome/src/config.rs
+@crates/tome/src/lib.rs
+@crates/tome/tests/cli.rs
+
+<interfaces>
+<!-- Key types and contracts the executor needs. After Plan 01. -->
+
+From `crates/tome/src/config.rs` (after Plan 01):
+```rust
+pub struct DirectoryConfig {
+    pub path: PathBuf,
+    pub directory_type: DirectoryType,
+    pub(crate) role: Option<DirectoryRole>,
+    pub branch: Option<String>,
+    pub tag: Option<String>,
+    pub rev: Option<String>,
+    pub subdir: Option<String>,
+    #[serde(skip, default)]
+    pub(crate) override_applied: bool,   // <-- added by Plan 01
+}
+```
+
+The `override_applied` field is `pub(crate)` — accessible from `status.rs` and `doctor.rs` since both live in the same crate.
+
+From `crates/tome/src/status.rs::DirectoryStatus`:
+```rust
+pub struct DirectoryStatus {
+    pub name: String,
+    pub directory_type: String,
+    pub role: String,
+    pub path: String,
+    pub skill_count: CountOrError,
+    pub warnings: Vec<String>,
+    // <-- add: pub override_applied: bool,
+}
+```
+
+From `crates/tome/src/status.rs::gather` (line ~75):
+```rust
+let directories: Vec<DirectoryStatus> = config
+    .directories
+    .iter()
+    .map(|(name, dir_config)| {
+        // ...
+        DirectoryStatus {
+            name: name.as_str().to_string(),
+            directory_type: dir_config.directory_type.to_string(),
+            role: role.description().to_string(),
+            path: dir_config.path.display().to_string(),
+            skill_count: skill_count.into(),
+            warnings,
+            // <-- add: override_applied: dir_config.override_applied,
+        }
+    })
+    .collect();
+```
+
+From `crates/tome/src/status.rs::render_status` (line ~127, text-mode rendering — the table builder):
+```rust
+for dir in &report.directories {
+    let count = match (&dir.skill_count.count, &dir.skill_count.error) {
+        // ...
+    };
+    rows.push([
+        dir.name.clone(),
+        dir.directory_type.clone(),
+        dir.role.clone(),
+        crate::paths::collapse_home(std::path::Path::new(&dir.path)),  // <-- modify this column
+        count,
+    ]);
+}
+```
+
+From `crates/tome/src/doctor.rs::DoctorReport`:
+```rust
+pub struct DoctorReport {
+    pub configured: bool,
+    pub library_issues: Vec<DiagnosticIssue>,
+    pub directory_issues: Vec<(String, Vec<DiagnosticIssue>)>,   // <-- replace with new shape
+    pub config_issues: Vec<DiagnosticIssue>,
+}
+```
+
+The `(String, Vec<DiagnosticIssue>)` tuple is just `(name, issues)`. To carry `override_applied` we have two options:
+- (a) Replace with `Vec<DirectoryDiagnostic>` where `DirectoryDiagnostic { name, override_applied, issues }`. Cleaner shape; minor JSON-schema break.
+- (b) Add a parallel `Vec<String> override_applied_directory_names` next to `directory_issues`. Avoids the schema break but creates a second-source-of-truth lookup.
+
+**Choose (a)** — `tome doctor --json` is consumed only by humans grep-ing JSON or by the future tome-desktop GUI (drafted but not yet implemented). The schema break is acceptable in v0.9, and the wrapped shape is what we'd want for the GUI anyway. Document the JSON shape change in the v0.9 CHANGELOG entry (out of scope for this plan; track via the existing changelog convention).
+
+From `crates/tome/src/doctor.rs::check` (line ~57):
+```rust
+pub fn check(config: &Config, paths: &TomePaths) -> Result<DoctorReport> {
+    // ...
+    let mut directory_issues = Vec::new();
+    for (name, dir_config) in config.distribution_dirs() {
+        let issues = check_distribution_dir(name.as_str(), &dir_config.path, paths.library_dir())?;
+        directory_issues.push((name.as_str().to_string(), issues));
+        // <-- becomes: directory_issues.push(DirectoryDiagnostic {
+        //                  name: name.as_str().to_string(),
+        //                  override_applied: dir_config.override_applied,
+        //                  issues,
+        //              });
+    }
+    // ...
+}
+```
+
+From `crates/tome/src/doctor.rs::render_issues_for_directory` (line ~383):
+```rust
+fn render_issues_for_directory(name: &str, issues: &[DiagnosticIssue]) {
+    if issues.is_empty() {
+        println!("  {} {}: OK", style("ok").green(), name);
+    } else {
+        for issue in issues {
+            // ...
+            println!("  {} {}: {}", marker, name, issue.message);
+        }
+    }
+}
+```
+This signature stays; pass `override_applied: bool` as a third argument and append `" (override)"` to the name string when true.
+
+**Annotation format:** `(override)` (lowercase, parens, no color in JSON, optional dim styling in text). Picked over alternatives:
+- `[override]` — visually heavier
+- `*` suffix — too cryptic
+- A separate column — overkill for one bit; the table is already 5 cols wide
+
+Apply the dim/cyan styling pattern that's already used elsewhere (`style("...").dim()` or `style("...").cyan()`). Match the existing console::style use in the file (status.rs uses `.cyan()` for paths; doctor.rs uses `.dim()` for "skip" text). Use `style("(override)").cyan()` to match status.rs convention.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add `override_applied` to `DirectoryStatus` + render `(override)` in `tome status`</name>
+  <files>crates/tome/src/status.rs</files>
+  <read_first>
+    - crates/tome/src/status.rs full file (673 lines — small enough to absorb)
+    - crates/tome/src/config.rs lines 196–235 (DirectoryConfig.override_applied — verify field visibility is `pub(crate)`)
+    - crates/tome/src/paths.rs (`collapse_home` — used in the PATH column)
+  </read_first>
+  <behavior>
+    - Test 1 (`gather_with_no_overrides_sets_flag_false`): Config with one directory, `override_applied = false` → `gather()` produces `report.directories[0].override_applied == false`.
+    - Test 2 (`gather_with_override_applied_sets_flag_true`): Config with one directory, `override_applied = true` (set manually in test) → `report.directories[0].override_applied == true`.
+    - Test 3 (`render_status_appends_override_marker_to_path`): Build a `StatusReport` with one directory, `override_applied = true`, `path = "/foo"`. Capture the output of `render_status` (or test the column composition logic in isolation) and assert the PATH column contains `(override)` AND `/foo`. (If `render_status` writes directly to stdout, factor the per-row formatting into a small helper `format_dir_path_column(path: &str, override_applied: bool) -> String` and unit-test that.)
+    - Test 4 (`render_status_no_override_omits_marker`): Same as Test 3 but `override_applied = false` → output does NOT contain `(override)`.
+    - Test 5 (`status_json_includes_override_applied_field`): Serialize a `DirectoryStatus` with `override_applied = true` to JSON via `serde_json::to_string` → resulting string contains `"override_applied":true`. (Confirms the field is exposed in machine-readable output.)
+  </behavior>
+  <action>
+**Step 1 — Add field to `DirectoryStatus`:**
+
+In `crates/tome/src/status.rs` lines 38–49, add the new field:
+```rust
+#[derive(serde::Serialize)]
+pub struct DirectoryStatus {
+    pub name: String,
+    pub directory_type: String,
+    pub role: String,
+    pub path: String,
+    pub skill_count: CountOrError,
+    pub warnings: Vec<String>,
+    /// True iff `directories.<name>.path` was rewritten by a machine.toml
+    /// `[directory_overrides.<name>]` entry during config load (PORT-05).
+    /// JSON consumers can use this to render the same context that text-mode
+    /// `tome status` shows via the `(override)` annotation.
+    pub override_applied: bool,
+}
+```
+
+**Step 2 — Populate field in `gather()`:**
+
+In the existing `gather()` function (line ~75), inside the `.map(|(name, dir_config)| { ... })` closure, add `override_applied` to the struct literal:
+```rust
+DirectoryStatus {
+    name: name.as_str().to_string(),
+    directory_type: dir_config.directory_type.to_string(),
+    role: role.description().to_string(),
+    path: dir_config.path.display().to_string(),
+    skill_count: skill_count.into(),
+    warnings,
+    override_applied: dir_config.override_applied,
+}
+```
+
+**Step 3 — Render `(override)` in text mode:**
+
+Extract a small helper near the top of the file (above `render_status`):
+```rust
+/// Format the PATH column for the directories table. When `override_applied`
+/// is true, append a styled ` (override)` annotation so the user can see
+/// which entries were rewritten by a machine.toml override (PORT-05).
+fn format_dir_path_column(path: &str, override_applied: bool) -> String {
+    let collapsed = crate::paths::collapse_home(std::path::Path::new(path));
+    if override_applied {
+        format!("{} {}", collapsed, style("(override)").cyan())
+    } else {
+        collapsed
+    }
+}
+```
+
+Then update the table-building loop in `render_status` (~line 168):
+```rust
+for dir in &report.directories {
+    let count = match (&dir.skill_count.count, &dir.skill_count.error) {
+        // ... unchanged ...
+    };
+    rows.push([
+        dir.name.clone(),
+        dir.directory_type.clone(),
+        dir.role.clone(),
+        format_dir_path_column(&dir.path, dir.override_applied),  // <-- changed line
+        count,
+    ]);
+}
+```
+
+**Implementation notes:**
+- `style` is already imported at the top of `status.rs` (`use console::style;` — verify at line 4).
+- The helper `collapse_home` is reused inside `format_dir_path_column`; do NOT call it twice in the table loop.
+- The annotation uses `.cyan()` to match the existing `style(... ).cyan()` pattern in `render_status` (e.g., the library count line at line 151). Avoid `.bold()` — it would dominate the row visually.
+- The annotation is appended AFTER the path with one space separator (no parentheses around the path itself).
+- For the JSON schema, `override_applied` is a public field of a `pub struct` with `#[derive(serde::Serialize)]` — no extra attributes needed; it'll appear in `tome status --json`.
+- Since `DirectoryStatus` does NOT derive `Default`, all existing test code that builds a `DirectoryStatus` literal must add the new field. Find these with `rg -n "DirectoryStatus \\{" crates/tome/`. Update each to set `override_applied: false`.
+
+Add the 5 unit tests in the existing `#[cfg(test)] mod tests` of `status.rs`. Reuse existing config-builder patterns from the file's existing tests (`gather_with_directories_marks_configured`, etc.).
+
+For Test 3/4, test the `format_dir_path_column` helper directly. To avoid stripping ANSI codes, set `console::set_colors_enabled(false)` at the start of the test, OR strip codes via a regex/substring check. Match the file's existing approach: search for `set_colors_enabled` in `status.rs`; if not used, prefer a substring assertion that doesn't depend on ANSI:
+```rust
+let s = format_dir_path_column("/foo", true);
+assert!(s.contains("/foo"));
+assert!(s.contains("(override)"));
+```
+The `console::style` produces strings that contain the literal `(override)` even with ANSI escapes — substring assertion works either way.
+
+Run: `cargo test -p tome --lib status::tests`
+  </action>
+  <verify>
+    <automated>cargo test -p tome --lib status::tests 2>&1 | tail -20 && cargo clippy -p tome --all-targets -- -D warnings 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "pub override_applied: bool" crates/tome/src/status.rs` returns exactly 1 match.
+    - `rg -n "fn format_dir_path_column" crates/tome/src/status.rs` returns exactly 1 match.
+    - `rg -n "override_applied: dir_config\\.override_applied" crates/tome/src/status.rs` returns exactly 1 match (the `gather()` populator).
+    - `cargo test -p tome --lib status::tests::gather_with_no_overrides_sets_flag_false` passes.
+    - `cargo test -p tome --lib status::tests::gather_with_override_applied_sets_flag_true` passes.
+    - `cargo test -p tome --lib status::tests::render_status_appends_override_marker_to_path` passes.
+    - `cargo test -p tome --lib status::tests::render_status_no_override_omits_marker` passes.
+    - `cargo test -p tome --lib status::tests::status_json_includes_override_applied_field` passes.
+    - All pre-existing status::tests still pass (regression — `DirectoryStatus { ... }` literals updated everywhere).
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+  </acceptance_criteria>
+  <done>
+    `DirectoryStatus.override_applied` field exists, `gather()` populates it from `DirectoryConfig.override_applied`, `format_dir_path_column` helper appends ` (override)` when true, and 5 unit tests pin the contract.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Add `override_applied` to `DoctorReport` per-directory entries + render annotation</name>
+  <files>crates/tome/src/doctor.rs</files>
+  <read_first>
+    - crates/tome/src/doctor.rs lines 26–85 (DiagnosticIssue, DoctorReport, check())
+    - crates/tome/src/doctor.rs lines 116–127 (the per-directory render loop in `diagnose()`)
+    - crates/tome/src/doctor.rs lines 383–395 (render_issues_for_directory)
+    - crates/tome/src/doctor.rs lines 335–365 (render_repair_plan_auto — also iterates directory_issues)
+    - status.rs Task 1 result (mirror the field naming and styling)
+  </read_first>
+  <behavior>
+    - Test 1 (`check_with_no_overrides_sets_flags_false`): Config with one distribution directory, `override_applied = false` → `report.directory_issues[0].override_applied == false`.
+    - Test 2 (`check_with_override_applied_sets_flag_true`): Config with one distribution directory, `override_applied = true` → `report.directory_issues[0].override_applied == true`.
+    - Test 3 (`render_issues_for_directory_appends_override_marker_when_set`): Capture `render_issues_for_directory("work", &[issue], true)` output → contains `(override)` in the line that names `work`.
+    - Test 4 (`render_issues_for_directory_omits_marker_when_unset`): Same as Test 3 but `override_applied = false` → output does NOT contain `(override)`.
+    - Test 5 (`doctor_json_includes_override_applied_per_directory`): Serialize a `DoctorReport` (with one entry, `override_applied = true`) → JSON contains `"override_applied":true` inside the directory entry.
+    - Test 6 (`total_issues_unchanged_by_directory_diagnostic_shape`): The existing `total_issues()` accounting still works after the shape change — count is correct regardless of how many directories have overrides.
+  </behavior>
+  <action>
+**Step 1 — Replace `(String, Vec<DiagnosticIssue>)` tuple with `DirectoryDiagnostic` struct:**
+
+In `crates/tome/src/doctor.rs` line ~26 (above `DoctorReport`):
+```rust
+/// Per-directory diagnostic entry. Aggregates issues for one configured
+/// directory and notes whether its `path` was rewritten by a machine.toml
+/// `[directory_overrides.<name>]` entry (PORT-05).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DirectoryDiagnostic {
+    pub name: String,
+    pub issues: Vec<DiagnosticIssue>,
+    /// True iff `directories.<name>.path` was rewritten by a machine.toml
+    /// override during config load. Renders as ` (override)` after the
+    /// directory name in text mode; appears as `override_applied: true` in
+    /// `tome doctor --json`.
+    pub override_applied: bool,
+}
+```
+
+Update `DoctorReport` (line ~35):
+```rust
+#[derive(Debug, serde::Serialize)]
+pub struct DoctorReport {
+    pub configured: bool,
+    pub library_issues: Vec<DiagnosticIssue>,
+    pub directory_issues: Vec<DirectoryDiagnostic>,   // <-- was Vec<(String, Vec<DiagnosticIssue>)>
+    pub config_issues: Vec<DiagnosticIssue>,
+}
+```
+
+Update `total_issues()` (line ~42):
+```rust
+impl DoctorReport {
+    pub fn total_issues(&self) -> usize {
+        self.library_issues.len()
+            + self
+                .directory_issues
+                .iter()
+                .map(|d| d.issues.len())   // <-- was .map(|(_, v)| v.len())
+                .sum::<usize>()
+            + self.config_issues.len()
+    }
+}
+```
+
+**Step 2 — Update `check()` (line ~57) to populate the new field:**
+
+```rust
+let mut directory_issues = Vec::new();
+for (name, dir_config) in config.distribution_dirs() {
+    let issues = check_distribution_dir(name.as_str(), &dir_config.path, paths.library_dir())?;
+    directory_issues.push(DirectoryDiagnostic {
+        name: name.as_str().to_string(),
+        issues,
+        override_applied: dir_config.override_applied,
+    });
+}
+```
+
+**Step 3 — Update all consumers of `directory_issues`:**
+
+Find them with `rg -n "directory_issues" crates/tome/src/doctor.rs`. Expected sites:
+- Line ~121 (in `diagnose()`): change `for (name, issues) in &report.directory_issues` → `for d in &report.directory_issues` and update body to `render_issues_for_directory(&d.name, &d.issues, d.override_applied)`.
+- Line ~350 (in `render_repair_plan_auto`): change `for (name, issues) in &report.directory_issues` → `for d in &report.directory_issues` and update body to use `&d.name` / `&d.issues`.
+
+**Step 4 — Update `render_issues_for_directory` signature** (line ~383) to accept `override_applied`:
+
+```rust
+fn render_issues_for_directory(name: &str, issues: &[DiagnosticIssue], override_applied: bool) {
+    let display_name = if override_applied {
+        format!("{} {}", name, style("(override)").cyan())
+    } else {
+        name.to_string()
+    };
+    if issues.is_empty() {
+        println!("  {} {}: OK", style("ok").green(), display_name);
+    } else {
+        for issue in issues {
+            let marker = match issue.severity {
+                IssueSeverity::Error => style("x").red(),
+                IssueSeverity::Warning => style("!").yellow(),
+            };
+            println!("  {} {}: {}", marker, display_name, issue.message);
+        }
+    }
+}
+```
+
+**Implementation notes:**
+- `console::style` is already imported in `doctor.rs` (`use console::style;` — verify at line 4 or thereabouts).
+- The `(override)` annotation uses `.cyan()` to match the status.rs Task 1 styling exactly. (Consistency — not a strong requirement, but good for the user.)
+- ALL existing tests in `doctor.rs` that reference `directory_issues` (search with `rg -n "directory_issues" crates/tome/src/doctor.rs`) need updating to use the new shape:
+  - Construction: `directory_issues: vec![DirectoryDiagnostic { name: "...".to_string(), issues: vec![...], override_applied: false }]` instead of `vec![("...".to_string(), vec![...])]`.
+  - Field access: `report.directory_issues[0].name` / `.issues` instead of `.0` / `.1` tuple access.
+- Add the 6 new tests at the end of the existing `#[cfg(test)] mod tests` block.
+- Test 3/4 capture stdout. The existing `doctor.rs` tests do not capture stdout (verify with grep). Two options:
+  - (a) Refactor `render_issues_for_directory` to take an `&mut impl std::io::Write` instead of `println!` — bigger change but enables clean unit testing.
+  - (b) Use `cargo test --captured` reliance + a substring check on the test thread's stdout via the `gag` crate (NOT in the deps).
+  - (c) Just exercise the helper indirectly: call it (it prints to stdout — `cargo test` swallows that), and instead test the **string-building** logic by extracting `format_dir_diagnostic_header(name: &str, override_applied: bool) -> String` and testing that helper directly. Use the same pattern as Task 1's `format_dir_path_column`.
+  
+  **Choose (c)** — minimum invasion, parallel to Task 1, avoids a captured-stdout dependency. Refactor `render_issues_for_directory` to call:
+  ```rust
+  fn format_dir_diagnostic_header(name: &str, override_applied: bool) -> String {
+      if override_applied {
+          format!("{} {}", name, style("(override)").cyan())
+      } else {
+          name.to_string()
+      }
+  }
+  ```
+  And test that helper directly:
+  ```rust
+  let s = format_dir_diagnostic_header("work", true);
+  assert!(s.contains("work") && s.contains("(override)"));
+  let s = format_dir_diagnostic_header("work", false);
+  assert!(s.contains("work") && !s.contains("(override)"));
+  ```
+
+Run: `cargo test -p tome --lib doctor::tests`
+  </action>
+  <verify>
+    <automated>cargo test -p tome --lib doctor::tests 2>&1 | tail -25 && cargo clippy -p tome --all-targets -- -D warnings 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "pub struct DirectoryDiagnostic" crates/tome/src/doctor.rs` returns exactly 1 match.
+    - `rg -n "pub override_applied: bool" crates/tome/src/doctor.rs` returns exactly 1 match.
+    - `rg -n "Vec<DirectoryDiagnostic>" crates/tome/src/doctor.rs` returns at least 1 match (the `DoctorReport.directory_issues` field).
+    - `rg -n "Vec<\\(String, Vec<DiagnosticIssue>\\)>" crates/tome/src/doctor.rs` returns 0 matches (old tuple shape gone).
+    - `rg -n "fn format_dir_diagnostic_header" crates/tome/src/doctor.rs` returns exactly 1 match.
+    - `cargo test -p tome --lib doctor::tests::check_with_no_overrides_sets_flags_false` passes.
+    - `cargo test -p tome --lib doctor::tests::check_with_override_applied_sets_flag_true` passes.
+    - `cargo test -p tome --lib doctor::tests::render_issues_for_directory_appends_override_marker_when_set` passes.
+    - `cargo test -p tome --lib doctor::tests::render_issues_for_directory_omits_marker_when_unset` passes.
+    - `cargo test -p tome --lib doctor::tests::doctor_json_includes_override_applied_per_directory` passes.
+    - `cargo test -p tome --lib doctor::tests::total_issues_unchanged_by_directory_diagnostic_shape` passes.
+    - All pre-existing doctor::tests still pass (regression — tuple → struct migration didn't break anything).
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+  </acceptance_criteria>
+  <done>
+    `DoctorReport.directory_issues: Vec<DirectoryDiagnostic>` carries `override_applied`, `check()` populates it, `render_issues_for_directory` accepts the flag and renders `(override)`, and 6 unit tests cover the matrix.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: End-to-end integration test — full PORT-05 contract</name>
+  <files>crates/tome/tests/cli.rs</files>
+  <read_first>
+    - crates/tome/tests/cli.rs lines 1–80 (test infrastructure)
+    - The smoke test `machine_override_rewrites_directory_path_for_status` (added in Plan 01)
+    - The two PORT-03/04 tests (added in Plan 02)
+  </read_first>
+  <action>
+Add one comprehensive integration test in `crates/tome/tests/cli.rs`, after the Plan 02 tests. This test exercises the full I2 invariant + PORT-05 contract end-to-end through the real CLI:
+
+1. Set up `tome.toml` with one synced directory.
+2. Set up `machine.toml` with `[directory_overrides.<name>]` rewriting that directory's path.
+3. Run `tome sync` — must succeed (covers I2: sync sees the merged result).
+4. Run `tome status` (text) — must succeed AND stdout must contain `(override)`.
+5. Run `tome status --json` — must include `"override_applied":true` for the overridden directory AND `"override_applied":false` for any non-overridden directory.
+6. Run `tome doctor --json` — must include `"override_applied":true` for the overridden directory.
+
+```rust
+#[cfg(unix)]
+#[test]
+fn machine_override_appears_in_status_and_doctor() {
+    // PORT-05 (and end-to-end PORT-01/02 confirmation): an override declared
+    // in machine.toml causes:
+    //   - `tome sync` to operate on the overridden path,
+    //   - `tome status` text mode to show `(override)` on the affected row,
+    //   - `tome status --json` to include `override_applied: true`,
+    //   - `tome doctor --json` to include `override_applied: true` for the overridden directory.
+    //
+    // The overridden directory `work` uses role = "synced" so it appears in BOTH
+    // discovery (skill-a from real_path is consolidated into the library) AND
+    // distribution (`tome doctor` diagnoses it). This pins the full PORT-05
+    // contract end-to-end on an actually-overridden directory.
+    let tmp = TempDir::new().unwrap();
+    let library_dir = tmp.path().join("library");
+    std::fs::create_dir_all(&library_dir).unwrap();
+
+    // Two directories. `work` is synced (discovery + distribution); `other` is
+    // a plain source for the negative-case check in status JSON.
+    let dotfiles_path = tmp.path().join("dotfiles-says-here");
+    let real_path = tmp.path().join("real-skills");
+    create_skill(&real_path, "skill-a");
+    // The synced directory must EXIST on disk pre-sync — distribute writes
+    // symlinks into it. Create the real path's parent (already done by
+    // `create_skill`) and ensure `real_path` itself is a directory.
+    assert!(real_path.is_dir(), "real_path must exist for sync to succeed");
+
+    let other_path = tmp.path().join("other-skills");
+    create_skill(&other_path, "skill-b");
+
+    let tome_toml = format!(
+        "library_dir = \"{}\"\n\
+         \n\
+         [directories.work]\n\
+         path = \"{}\"\n\
+         type = \"directory\"\n\
+         role = \"synced\"\n\
+         \n\
+         [directories.other]\n\
+         path = \"{}\"\n\
+         type = \"directory\"\n\
+         role = \"source\"\n",
+        library_dir.display(),
+        dotfiles_path.display(),
+        other_path.display(),
+    );
+    std::fs::write(tmp.path().join("tome.toml"), tome_toml).unwrap();
+
+    let machine_toml = format!(
+        "[directory_overrides.work]\npath = \"{}\"\n",
+        real_path.display(),
+    );
+    let machine_path = tmp.path().join("machine.toml");
+    std::fs::write(&machine_path, machine_toml).unwrap();
+
+    // 1. `tome sync` must succeed — sync sees the overridden path.
+    let sync_assert = tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "--machine",
+            machine_path.to_str().unwrap(),
+            "sync",
+            "--no-triage",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+    let sync_stdout = String::from_utf8(sync_assert.get_output().stdout.clone()).unwrap();
+    let skill_a_in_lib = library_dir.join("skill-a").exists();
+    assert!(
+        skill_a_in_lib,
+        "expected skill-a from overridden path to be consolidated, got sync stdout:\n{sync_stdout}",
+    );
+
+    // 2. `tome status` text mode — stdout contains `(override)` exactly once.
+    let status_assert = tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "--machine",
+            machine_path.to_str().unwrap(),
+            "status",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+    let status_stdout = String::from_utf8(status_assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        status_stdout.contains("(override)"),
+        "expected `tome status` text output to contain `(override)`, got:\n{status_stdout}"
+    );
+    let override_marker_count = status_stdout.matches("(override)").count();
+    assert_eq!(
+        override_marker_count, 1,
+        "expected exactly one `(override)` marker (for `work`), got {override_marker_count} in:\n{status_stdout}"
+    );
+
+    // 3. `tome status --json` — `work` has `override_applied: true`, `other` has false.
+    let status_json_assert = tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "--machine",
+            machine_path.to_str().unwrap(),
+            "status",
+            "--json",
+        ])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+    let status_json: serde_json::Value =
+        serde_json::from_slice(&status_json_assert.get_output().stdout)
+            .expect("status --json output must be valid JSON");
+    let dirs = status_json["directories"].as_array().unwrap();
+    let work = dirs.iter().find(|d| d["name"] == "work").unwrap();
+    let other = dirs.iter().find(|d| d["name"] == "other").unwrap();
+    assert_eq!(
+        work["override_applied"], serde_json::Value::Bool(true),
+        "expected work.override_applied == true, got: {work}"
+    );
+    assert_eq!(
+        other["override_applied"], serde_json::Value::Bool(false),
+        "expected other.override_applied == false, got: {other}"
+    );
+
+    // 4. `tome doctor --json` — `work` (now synced/distribution) appears in
+    // `directory_issues` and carries `override_applied: true`. This is the
+    // strongest end-to-end PORT-05 doctor assertion.
+    let doctor_json_assert = tome()
+        .args([
+            "--tome-home",
+            tmp.path().to_str().unwrap(),
+            "--machine",
+            machine_path.to_str().unwrap(),
+            "doctor",
+            "--json",
+        ])
+        .env("NO_COLOR", "1")
+        .assert();
+    // doctor exit may be 0 or non-0 depending on issues found — accept either.
+    let doctor_json: serde_json::Value =
+        serde_json::from_slice(&doctor_json_assert.get_output().stdout)
+            .expect("doctor --json output must be valid JSON");
+
+    let doctor_dirs = doctor_json["directory_issues"]
+        .as_array()
+        .expect("doctor --json must include directory_issues array");
+    let work_entry = doctor_dirs
+        .iter()
+        .find(|d| d["name"] == "work")
+        .expect("work must appear in doctor directory_issues (it has role = synced)");
+    assert_eq!(
+        work_entry["override_applied"],
+        serde_json::Value::Bool(true),
+        "expected work.override_applied == true in doctor JSON, got: {work_entry}"
+    );
+
+    // Sanity: every entry in directory_issues uses the new DirectoryDiagnostic
+    // shape (has `name`, `issues`, and `override_applied`).
+    for entry in doctor_dirs {
+        assert!(
+            entry.get("name").is_some()
+                && entry.get("issues").is_some()
+                && entry.get("override_applied").is_some(),
+            "expected DirectoryDiagnostic shape (name + issues + override_applied), got: {entry}"
+        );
+    }
+}
+```
+
+**Implementation notes:**
+- `serde_json` is already a workspace dependency (used by other tests). Verify with `rg "serde_json" crates/tome/Cargo.toml`.
+- The `role = "synced"` choice for `work` makes it both a discovery dir (skill-a from `real_path` is consolidated) AND a distribution dir (so `tome doctor` will diagnose it and emit a `directory_issues` entry). This pins PORT-05 end-to-end on an actually-overridden directory.
+- `real_path` (the override target) MUST exist on disk pre-sync because synced directories receive symlink writes during distribute. `create_skill(&real_path, "skill-a")` ensures both the directory and a SKILL.md exist.
+- The `override_marker_count == 1` assertion guards against rendering bugs that would put `(override)` on every row.
+
+Run: `cargo test -p tome --test cli machine_override_appears_in_status_and_doctor`
+  </action>
+  <verify>
+    <automated>cargo test -p tome --test cli machine_override_appears_in_status_and_doctor</automated>
+  </verify>
+  <acceptance_criteria>
+    - `cargo test -p tome --test cli machine_override_appears_in_status_and_doctor` passes.
+    - `make ci` passes (no regressions).
+    - The test exercises the full chain: sync respects override → status text shows `(override)` exactly once → status JSON has correct booleans for both dirs → doctor JSON's `work` entry exists AND has `override_applied: true`.
+    - The `work` entry in `doctor_json["directory_issues"]` is asserted by name (`.find(|d| d["name"] == "work")` returns Some) — pinning the full PORT-05 doctor contract on an actually-overridden distribution directory.
+    - Every entry in `doctor_json["directory_issues"]` is asserted to use the new `DirectoryDiagnostic` JSON shape (object with `name`, `issues`, `override_applied`) — guarding against tuple-shape regressions.
+  </acceptance_criteria>
+  <done>
+    PORT-05 is pinned end-to-end by an integration test that covers all four user-visible surfaces (`tome sync`, `tome status` text, `tome status --json`, `tome doctor --json`). The full I2 invariant from PORT-02 is also implicitly verified — sync, status, and doctor all see the same merged config.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- `cargo test -p tome --lib status::tests` — all status tests pass (5 new + existing).
+- `cargo test -p tome --lib doctor::tests` — all doctor tests pass (6 new + existing tuple → struct migration).
+- `cargo test -p tome --test cli machine_override_appears_in_status_and_doctor` — passes.
+- `make ci` — clean.
+- `rg -n "Vec<\\(String, Vec<DiagnosticIssue>\\)>" crates/tome/src/doctor.rs` — 0 matches (old tuple shape removed).
+- `rg -n "DirectoryDiagnostic" crates/tome/src/doctor.rs` — at least 4 matches (struct, field decl, check populator, ≥ 1 test).
+</verification>
+
+<success_criteria>
+- `DirectoryStatus.override_applied: bool` field is populated from `DirectoryConfig.override_applied` in `status::gather` (PORT-05).
+- `tome status` text mode appends ` (override)` to the PATH column for affected directories; non-affected rows show no marker.
+- `tome status --json` includes `"override_applied":true|false"` per directory entry.
+- `DoctorReport.directory_issues: Vec<DirectoryDiagnostic>` carries `override_applied: bool`; `check()` populates from config; `tome doctor` text and JSON both surface it.
+- The annotation marker uses a consistent `(override)` form styled `cyan` in both commands.
+- An end-to-end integration test pins all four user-visible surfaces (sync, status text, status JSON, doctor JSON) against a real `tome.toml` + `machine.toml` fixture pair.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/09-cross-machine-path-overrides/09-03-SUMMARY.md` recording:
+- New `DirectoryStatus.override_applied: bool` field signature.
+- New `format_dir_path_column` helper signature.
+- New `DirectoryDiagnostic` struct + the schema break: `DoctorReport.directory_issues: Vec<DirectoryDiagnostic>` (was `Vec<(String, Vec<DiagnosticIssue>)>`).
+- Updated `render_issues_for_directory` signature (now takes `override_applied: bool`).
+- New `format_dir_diagnostic_header` helper signature.
+- Test names added (status.rs ≥ 5, doctor.rs ≥ 6, tests/cli.rs = 1).
+- One-line confirmation: PORT-05 closed.
+- A note for the v0.9 CHANGELOG entry: `tome doctor --json` schema break — `directory_issues` items are now objects with `name`/`issues`/`override_applied` instead of `[name, issues]` tuples.
+- Phase 9 wrap: all 5 PORT requirements (01..05) shipped across plans 01–03.
+</output>


### PR DESCRIPTION
## Summary

Re-introduces the Phase 9 plans (3 PLAN.md files) via proper PR review — recovering from the direct-to-main commit reverted by #474. **Merge #474 first**, then this PR retargets to \`main\` automatically and lands the plans cleanly.

## Phase 9 — Cross-Machine Path Overrides

3 plans organized into 2 waves, covering all 5 PORT requirements (PORT-01..05).

| Plan | Wave | Requirements | Builds |
|------|------|--------------|--------|
| 09-01 | 1 | PORT-01, PORT-02 | \`[directory_overrides.<name>]\` schema in \`MachinePrefs\`, \`Config::apply_machine_overrides\` + \`load_with_overrides\`, single canonical load path through sync/status/doctor/init, \`override_applied: bool\` flag on \`DirectoryConfig\` |
| 09-02 | 2 | PORT-03, PORT-04 | Typo-target stderr warning for unknown override names, distinct error wrapper that names \`machine.toml\` on override-induced validation failures |
| 09-03 | 2 | PORT-05 | \`(override)\` annotation in \`tome status\` and \`tome doctor\` text + \`--json\` output |

Plan-checker verified across 8 dimensions over 2 iterations:
- **Iter 1:** 1 BLOCKER (DirectoryConfig struct-literal cascade) + 2 IMPORTANT + 1 SUGGESTION applied; 1 design SUGGESTION accepted as-is.
- **Iter 2:** PLANS APPROVED with one minor non-blocking caveat (struct-literal site enumeration is slightly conservative — \`rg\`-based discovery + \`cargo build\` safety net catches the remainder).

## Notable design decisions captured in plan bodies

- **Schema future-extension shape:** \`path\` only in v0.9; \`role\`/\`type\`/\`subdir\` override fields deferred per YAGNI.
- **Error class via message-content wrapping** (not typed enum) — matches existing tome convention; typed-enum migration noted as v1.0 follow-up if a programmatic consumer needs it.
- **\`DirectoryConfig.override_applied: bool\`** with \`#[serde(skip)]\` keeps \`tome.toml\` round-trip byte-equality intact while giving status/doctor a single source of truth (vs. recomputing via snapshot diff).
- **\`SyncOptions\` shape change:** replaces \`machine_override: Option<&Path>\` with explicit \`machine_path\` + \`machine_prefs\` to ensure sync sees the same prefs the load path saw.

## Why this PR exists separately from #474

Original commit \`b8d7ac8\` landed directly on main due to a subagent-introduced branch state I didn't catch. PR #474 reverts it; this PR re-adds the plans through normal review. Net diff after both merge: identical to the mistaken commit, plus full review history.

## Test plan

- [x] No code changes; planning docs only
- [x] PORT-01..05 each appear in exactly one plan's \`requirements\` field
- [x] Plan-checker passes 8/8 dimensions

Refs #458