### PR TITLE
docs(phase-10): plan phase 8 review tail bundle (3 plans, 1 wave)

### DIFF
--- a/.planning/phases/10-phase-8-review-tail/10-01-tui-status-message-redesign-PLAN.md
+++ b/.planning/phases/10-phase-8-review-tail/10-01-tui-status-message-redesign-PLAN.md
@@ -1,0 +1,882 @@
+---
+phase: 10-phase-8-review-tail
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - crates/tome/src/browse/app.rs
+  - crates/tome/src/browse/ui.rs
+  - crates/tome/src/browse/mod.rs
+autonomous: true
+requirements: [POLISH-01, POLISH-02, POLISH-03, TEST-03]
+issue: "https://github.com/MartinP7r/tome/issues/463 + https://github.com/MartinP7r/tome/issues/462"
+
+must_haves:
+  truths:
+    - "User pressing Enter on the `Open source directory` action sees an `⏳ Opening: <collapsed-path>...` status message rendered BEFORE the `xdg-open`/`open` blocking call returns; the message is visible during the block."
+    - "Any keystrokes typed into the tty during the `xdg-open`/`open` block are drained from the crossterm event queue afterwards and do NOT replay as DetailAction inputs."
+    - "`StatusMessage` is a single enum (`Success(String) | Warning(String) | Pending(String)`) with `body() -> &str`, `glyph() -> char`, and `severity() -> StatusSeverity` accessors. The struct form (`pub struct StatusMessage { severity, text }`) and the `text` field with pre-formatted glyph are GONE."
+    - "UI rendering composes `format!(\"{glyph} {body}\", ...)` at render time in both `render_status_bar` and the Detail-mode status branch — neither call site reaches into a pre-formatted `text` field."
+    - "`StatusMessage` and `StatusSeverity` are both `pub(super)` (browse-module-internal) — not `pub`."
+    - "`arboard::Error::ClipboardOccupied` triggers exactly one retry after a 100ms `std::thread::sleep` before a Warning ever reaches `app.status_message`. A successful retry produces a Success message; a still-occupied retry produces the existing `⚠ Clipboard busy ...` Warning."
+    - "`ViewSource` `.status()` arms (Ok+success, Ok+non-zero exit, Err) are factored into `status_message_from_open_result(binary: &str, path: &Path, raw: std::io::Result<std::process::ExitStatus>) -> StatusMessage` with unit tests for all three arms using `std::os::unix::process::ExitStatusExt::from_raw`."
+    - "The `Pending`-message visibility is achieved by threading a redraw closure (`&mut dyn FnMut(&App)`) through `App::handle_key` → `handle_detail_key` → a new `App::execute_action_with_redraw` method. Production `run_loop` passes a closure that calls `terminal.draw(|f| ui::render(f, app))`; tests pass a no-op closure. `App` itself remains independent of `ratatui::DefaultTerminal` (preserving unit-test isolation)."
+  artifacts:
+    - path: "crates/tome/src/browse/app.rs"
+      provides: "Refactored `StatusMessage` enum (`Success(String) | Warning(String) | Pending(String)`) with `pub(super)` visibility, `body()`/`glyph()`/`severity()` accessors. Free function `status_message_from_open_result(binary, path, raw)` returning a `StatusMessage`. New method `execute_action_with_redraw(&mut self, action, redraw: &mut dyn FnMut(&App))` that handles ViewSource (sets Pending → calls redraw → calls .status() → drains events) and delegates other actions to `execute_action`. `handle_key` and `handle_detail_key` gain the redraw-closure parameter. `try_clipboard_set_text_with_retry` retries `ClipboardOccupied` once after a 100ms backoff."
+      contains: "status_message_from_open_result"
+    - path: "crates/tome/src/browse/ui.rs"
+      provides: "`render_status_bar` and the Detail-mode status branch in `render_detail` both compose the rendered string via `format!(\"{} {}\", msg.glyph(), msg.body())` and dispatch fg color via `match msg.severity()` — no `msg.text` access remains. Both call sites gain a `StatusSeverity::Pending` arm using `theme.muted`."
+      contains: "msg.severity()"
+    - path: "crates/tome/src/browse/mod.rs"
+      provides: "`run_loop` constructs a real redraw closure `|a: &App| { let _ = terminal.draw(|f| ui::render(f, a)); }` and passes it to `app.handle_key(key, &mut redraw)`. The redraw closure is what enables the Pending-message visibility before `.status()` blocks (POLISH-01)."
+      contains: "handle_key"
+  key_links:
+    - from: "crates/tome/src/browse/app.rs::execute_action_with_redraw ViewSource branch"
+      to: "crates/tome/src/browse/app.rs::status_message_from_open_result"
+      via: "called with the `.status()` Result to convert to a StatusMessage"
+      pattern: "status_message_from_open_result"
+    - from: "crates/tome/src/browse/app.rs::execute_action_with_redraw ViewSource branch"
+      to: "redraw + drain"
+      via: "set Pending message → call redraw(self) → run `.status()` → call drain_pending_events()"
+      pattern: "Pending\\("
+    - from: "crates/tome/src/browse/app.rs::execute_action CopyPath arm"
+      to: "ClipboardOccupied retry"
+      via: "match arboard::Error::ClipboardOccupied → sleep 100ms → retry once (in `try_clipboard_set_text_with_retry`)"
+      pattern: "ClipboardOccupied"
+    - from: "crates/tome/src/browse/ui.rs::render_status_bar + render_detail status branch"
+      to: "StatusMessage accessors"
+      via: "msg.glyph() + msg.body() + msg.severity()"
+      pattern: "msg\\.severity\\(\\)"
+    - from: "crates/tome/src/browse/mod.rs::run_loop"
+      to: "App::handle_key redraw closure"
+      via: "&mut |a: &App| { let _ = terminal.draw(|f| ui::render(f, a)); }"
+      pattern: "handle_key.*&mut redraw"
+---
+
+<objective>
+Redesign `StatusMessage` from a struct-with-pre-formatted-text to a single enum with semantic constructors and accessors. Route the `ViewSource` `.status()` dispatch through a testable free helper. Add an `Opening: <path>...` Pending status BEFORE the `xdg-open`/`open` block, drain the crossterm event queue after the block to swallow keystrokes typed during it, and auto-retry `ClipboardOccupied` once with a 100ms backoff before any Warning reaches the status bar.
+
+This is the TUI bundle from the Phase 8 review tail — closes 4 of the 11 review-tail items in one cut, all centred on `crates/tome/src/browse/app.rs`, `crates/tome/src/browse/ui.rs`, and `crates/tome/src/browse/mod.rs`.
+
+**Closes:** POLISH-01 (D1, blocking-open UX), POLISH-02 (D2, StatusMessage type redesign), POLISH-03 (D3, ClipboardOccupied auto-retry), TEST-03 (P3, status_message_from_open_result helper + unit tests).
+
+**Decision pinned (POLISH-01 redraw threading):** Use the **redraw-closure** approach — `App::handle_key` gains a `redraw: &mut dyn FnMut(&App)` parameter, threaded down to a new `App::execute_action_with_redraw` method. Production `run_loop` passes a closure that calls `terminal.draw(...)`; tests pass a no-op closure. This keeps `App` independent of `ratatui::DefaultTerminal` (preserving unit-test isolation) and allows the redraw to fire BEFORE `.status()` blocks. Rejected alternatives: (a) a `pending_redraw: bool` flag on `App` — only redraws AFTER `.status()` returns, which is too late; (b) threading `&mut ratatui::DefaultTerminal` directly through `handle_key` — couples `App` to the ratatui type and breaks unit-test isolation.
+
+Purpose: Make the `tome browse` `open`/`copy` paths feel responsive (Pending message before block, no replayed keystrokes), eliminate the stringly-typed glyph-prefix in `StatusMessage::text`, and make the three `.status()` arms unit-testable on synthetic exit codes.
+
+Output: Refactored `StatusMessage` enum + accessors, new `status_message_from_open_result` helper, redraw-closure threading through `handle_key`, drain-after-block in ViewSource, retry-once in CopyPath, ui.rs callsites updated.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/REQUIREMENTS.md
+
+@crates/tome/src/browse/app.rs
+@crates/tome/src/browse/ui.rs
+@crates/tome/src/browse/mod.rs
+@crates/tome/src/browse/theme.rs
+
+<interfaces>
+<!-- Key types and contracts the executor needs. Extracted from codebase. -->
+
+Current shape of `StatusMessage` in `crates/tome/src/browse/app.rs` (lines 19–54):
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusSeverity {
+    Success,
+    Warning,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusMessage {
+    pub severity: StatusSeverity,
+    pub text: String,   // <-- pre-formatted with leading glyph "✓ " / "⚠ "
+}
+
+impl StatusMessage {
+    pub fn success(body: impl Into<String>) -> Self { /* prefixes "✓ " */ }
+    pub fn warning(body: impl Into<String>) -> Self { /* prefixes "⚠ " */ }
+}
+```
+
+Target shape after this plan:
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StatusSeverity { Success, Warning, Pending }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum StatusMessage {
+    Success(String),
+    Warning(String),
+    Pending(String),
+}
+
+impl StatusMessage {
+    pub(super) fn body(&self) -> &str;       // returns inner String slice
+    pub(super) fn glyph(&self) -> char;      // '✓' / '⚠' / '⏳'
+    pub(super) fn severity(&self) -> StatusSeverity;
+}
+```
+
+Current `ViewSource` arm in `execute_action` (`crates/tome/src/browse/app.rs` lines 252–293):
+```rust
+match std::process::Command::new(binary).arg(&path).status() {
+    Ok(status) if status.success() => self.status_message = Some(StatusMessage::success(format!("Opened: {}", ...))),
+    Ok(status) => self.status_message = Some(StatusMessage::warning(format!("{binary} exited {exit} for: {path}"))),
+    Err(e)   => self.status_message = Some(StatusMessage::warning(format!("Could not launch {binary}: {e}"))),
+}
+```
+
+Target shape — the ViewSource branch lives in a new `App::handle_view_source(&mut self, redraw: &mut dyn FnMut(&App))` helper called only from `App::execute_action_with_redraw`. Set Pending → call redraw(self) → call `.status()` → set result message → drain events:
+
+```rust
+fn handle_view_source(&mut self, redraw: &mut dyn FnMut(&App)) {
+    if let Some((_, _, path)) = self.selected_row_meta() {
+        let binary = if cfg!(target_os = "macos") { "open" } else { "xdg-open" };
+        let path_buf = std::path::PathBuf::from(&path);
+
+        // POLISH-01: surface "Opening: ..." BEFORE blocking on .status()
+        self.status_message = Some(StatusMessage::Pending(format!(
+            "Opening: {}...",
+            crate::paths::collapse_home(&path_buf)
+        )));
+        redraw(self);   // user sees "Opening: ..." before the block
+
+        let raw = std::process::Command::new(binary).arg(&path).status();
+        self.status_message = Some(status_message_from_open_result(binary, &path_buf, raw));
+
+        // POLISH-01: drain queued events typed during the block
+        self.drain_pending_events();
+    }
+}
+```
+
+Free function (new, sibling of `App` impl, `pub(super)` so unit tests in the same module see it):
+```rust
+pub(super) fn status_message_from_open_result(
+    binary: &str,
+    path: &std::path::Path,
+    raw: std::io::Result<std::process::ExitStatus>,
+) -> StatusMessage {
+    match raw {
+        Ok(status) if status.success() => StatusMessage::Success(format!(
+            "Opened: {}",
+            crate::paths::collapse_home(path)
+        )),
+        Ok(status) => {
+            let exit = status.code().map(|c| c.to_string()).unwrap_or_else(|| "signal".into());
+            StatusMessage::Warning(format!("{binary} exited {exit} for: {}", path.display()))
+        }
+        Err(e) => StatusMessage::Warning(format!("Could not launch {binary}: {e}")),
+    }
+}
+```
+
+Current `CopyPath` arm (`crates/tome/src/browse/app.rs` lines 294–337) returns either Ok or Err; on Err the match maps `ClipboardOccupied` → `"Clipboard busy ..."`. After this plan, the call to `arboard::Clipboard::new().and_then(...)` is replaced by `try_clipboard_set_text_with_retry(&path)`, which retries `ClipboardOccupied` once after a 100ms `std::thread::sleep`.
+
+`render_status_bar` (`crates/tome/src/browse/ui.rs` line ~370) and the Detail-mode status branch (line ~315) currently access `msg.text` and `msg.severity` directly. After this plan, they call `msg.body()`, `msg.glyph()`, `msg.severity()` and compose the rendered span via `format!(" {} {} ", msg.glyph(), msg.body())`.
+
+`Pending` rendering: use `theme.muted` foreground (no `theme.warning` is needed; `Pending` is informational, not alarming).
+
+**Drain semantics:** `crossterm::event::poll(Duration::ZERO)` returns true if at least one event is available without blocking. Looping until it returns false drains the queue. Drop everything (don't dispatch) — keystrokes typed during the block were aimed at "the open dialog" not "the TUI."
+
+**Redraw closure threading depth (the chosen design):**
+```text
+run_loop (browse/mod.rs)
+   └── builds `let mut redraw = |a: &App| { let _ = terminal.draw(|f| ui::render(f, a)); };`
+       └── calls `app.handle_key(key, &mut redraw)`
+              └── `App::handle_key` matches mode, dispatches to:
+                     ├── `handle_normal_key(key)` (unchanged — no redraw needed)
+                     ├── `handle_search_key(key)` (unchanged)
+                     ├── `handle_detail_key(key, redraw)` (gains redraw param)
+                     │      └── on Enter+ViewSource: `self.execute_action_with_redraw(action, redraw)`
+                     │      └── on other actions:    `self.execute_action(action)` (legacy path)
+                     └── Help mode (unchanged)
+```
+
+Test sites: every `app.handle_key(key)` call in `#[cfg(test)] mod tests` becomes `app.handle_key(key, &mut |_| {})`. Mechanical update; ~25-30 call sites in `app.rs::tests`.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Redesign `StatusMessage` as an enum with accessors (POLISH-02)</name>
+  <files>crates/tome/src/browse/app.rs, crates/tome/src/browse/ui.rs</files>
+  <read_first>
+    - crates/tome/src/browse/app.rs lines 17–54 (current StatusMessage struct + StatusSeverity enum)
+    - crates/tome/src/browse/app.rs lines 252–337 (execute_action — call sites for StatusMessage::success/warning)
+    - crates/tome/src/browse/app.rs lines 853–956 (existing test coverage that asserts on `.text`, `.severity`)
+    - crates/tome/src/browse/ui.rs lines 313–353 (render_detail status branch — accesses msg.text + msg.severity)
+    - crates/tome/src/browse/ui.rs lines 355–386 (render_status_bar — accesses msg.text + msg.severity)
+    - crates/tome/src/browse/theme.rs (theme.accent / theme.alert / theme.muted — Pending uses muted)
+  </read_first>
+  <behavior>
+    - Test 1 (`status_message_success_constructor`): `StatusMessage::Success("Copied: /tmp/x".into())` matches `Success(_)` arm; `.body()` returns `"Copied: /tmp/x"`; `.glyph()` returns `'✓'`; `.severity()` returns `StatusSeverity::Success`.
+    - Test 2 (`status_message_warning_constructor`): `StatusMessage::Warning("Could not copy: permission denied".into())`; `.glyph()` returns `'⚠'`; `.severity()` returns `StatusSeverity::Warning`.
+    - Test 3 (`status_message_pending_constructor`): `StatusMessage::Pending("Opening: ~/foo...".into())`; `.body()` returns `"Opening: ~/foo..."`; `.glyph()` returns `'⏳'`; `.severity()` returns `StatusSeverity::Pending`.
+    - Test 4 (`status_message_body_does_not_contain_glyph`): For all three variants, `body()` returns the raw inner string with NO leading glyph or space. Assert via `assert!(!msg.body().starts_with('✓') && !msg.body().starts_with('⚠') && !msg.body().starts_with('⏳'))` and `assert!(!msg.body().starts_with(' '))`.
+    - Test 5 (`status_message_lifecycle_unchanged`): The existing `status_message_set_by_copy_path_and_cleared_by_any_key` and `status_message_set_by_view_source_and_cleared_by_any_key` tests are MIGRATED (not duplicated): assertions like `msg.text.starts_with('✓')` become `msg.glyph() == '✓'`; assertions on `msg.severity` become `msg.severity()`. Behavior under test (set on action / cleared by any key) is unchanged.
+  </behavior>
+  <action>
+**Step 1 — Replace the type declaration in `crates/tome/src/browse/app.rs`** (lines 17–54).
+
+Replace the existing `StatusSeverity` and `StatusMessage` declarations with:
+
+```rust
+/// Severity for ephemeral status-bar messages surfaced by DetailAction
+/// handlers. The variant set is closed — adding a new variant requires
+/// updates to `glyph()`, `severity()`, the ui.rs color dispatch, and any
+/// tests that exhaustively match on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StatusSeverity {
+    Success,
+    Warning,
+    /// Informational "operation in progress" message. Used for the
+    /// `Opening: <path>...` status surfaced before blocking on
+    /// `xdg-open` / `open` (POLISH-01). Rendered with `theme.muted`.
+    Pending,
+}
+
+/// A one-shot toast rendered in the status bar until the next keypress.
+///
+/// Stored as `Option<StatusMessage>` on `App`. The variant carries the raw
+/// body string only — the glyph (`✓` / `⚠` / `⏳`) is composed at render
+/// time in `ui.rs` via `msg.glyph()`. This eliminates the stringly-typed
+/// pre-formatted-text design that made the type fragile to refactor and
+/// duplicated the severity signal between `severity` and the leading
+/// glyph in `text`.
+// Derives note: Clone + PartialEq + Eq are kept for the existing assert_eq!-based
+// test surface (handle_key / execute_action lifecycle). Debug is for {:?} in test
+// failure messages. NO Hash / Ord / Default — this type has no key/sort/empty
+// semantics. Audited 2026 (POLISH-02).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum StatusMessage {
+    Success(String),
+    Warning(String),
+    Pending(String),
+}
+
+impl StatusMessage {
+    /// Raw body without any glyph prefix.
+    pub(super) fn body(&self) -> &str {
+        match self {
+            StatusMessage::Success(s) | StatusMessage::Warning(s) | StatusMessage::Pending(s) => {
+                s.as_str()
+            }
+        }
+    }
+
+    /// Severity glyph rendered before the body. UI composes
+    /// `format!("{} {}", msg.glyph(), msg.body())` at render time.
+    pub(super) fn glyph(&self) -> char {
+        match self {
+            StatusMessage::Success(_) => '✓',
+            StatusMessage::Warning(_) => '⚠',
+            StatusMessage::Pending(_) => '⏳',
+        }
+    }
+
+    pub(super) fn severity(&self) -> StatusSeverity {
+        match self {
+            StatusMessage::Success(_) => StatusSeverity::Success,
+            StatusMessage::Warning(_) => StatusSeverity::Warning,
+            StatusMessage::Pending(_) => StatusSeverity::Pending,
+        }
+    }
+}
+```
+
+**Visibility:** the previous `pub` is narrowed to `pub(super)` so consumers outside the `browse` module cannot reach into the type. Confirm `App.status_message: Option<StatusMessage>` field stays pub-or-pub(super) per the existing visibility — but `StatusMessage` itself does NOT need to be visible outside the module. (`browse/mod.rs` is the only external entry point and it doesn't construct StatusMessages.)
+
+**Step 2 — Update construction sites in `execute_action`** (lines 272, 282, 287, 311, 320–334):
+
+Replace `StatusMessage::success(format!("Opened: {}", ...))` with
+`StatusMessage::Success(format!("Opened: {}", ...))`. Same swap for `::warning(...)` → `::Warning(...)`. The body strings are identical to the current code (no leading glyph, no leading space). The `Self::success`/`::warning` constructors themselves are removed in this step — direct variant construction replaces them.
+
+**Step 3 — Update `crates/tome/src/browse/ui.rs` consumers** (lines 313–353 for `render_detail`'s status branch; lines 370–386 for `render_status_bar`):
+
+Wherever the code reads `msg.text` or `msg.severity`, swap to:
+- `msg.text` → `format!("{} {}", msg.glyph(), msg.body())`
+- `msg.severity` → `msg.severity()`
+
+The match-on-severity block in both call sites GAINS a `StatusSeverity::Pending` arm. Color dispatch:
+
+```rust
+let msg_style = match msg.severity() {
+    super::app::StatusSeverity::Warning => Style::default().fg(theme.alert).bg(theme.status_bar_bg),
+    super::app::StatusSeverity::Success => Style::default().fg(theme.accent).bg(theme.status_bar_bg),
+    super::app::StatusSeverity::Pending => Style::default().fg(theme.muted).bg(theme.status_bar_bg),
+};
+```
+
+In both `render_detail` (line ~315) and `render_status_bar` (line ~370), the `Span::styled(format!(" {} ", msg.text), ...)` becomes `Span::styled(format!(" {} {} ", msg.glyph(), msg.body()), ...)`.
+
+**Step 4 — Migrate the 3 existing StatusMessage tests in `app.rs`** (lines 853–956):
+- `status_message_set_by_copy_path_and_cleared_by_any_key`: change `msg.severity` → `msg.severity()`, change `msg.text.starts_with('✓')` → `msg.glyph() == '✓'`. Add the no-leading-glyph-in-body assertion: `assert!(!msg.body().starts_with('✓') && !msg.body().starts_with('⚠'))`.
+- `status_message_success_and_warning_constructors_apply_glyph_prefix`: rename to `status_message_glyph_dispatch_for_each_variant`. Replace constructors with direct variants:
+  ```rust
+  let ok = StatusMessage::Success("Copied: /tmp/foo".into());
+  assert_eq!(ok.severity(), StatusSeverity::Success);
+  assert_eq!(ok.glyph(), '✓');
+  assert_eq!(ok.body(), "Copied: /tmp/foo");
+
+  let warn = StatusMessage::Warning("Could not copy: permission denied".into());
+  assert_eq!(warn.severity(), StatusSeverity::Warning);
+  assert_eq!(warn.glyph(), '⚠');
+  assert_eq!(warn.body(), "Could not copy: permission denied");
+
+  let pending = StatusMessage::Pending("Opening: ~/foo...".into());
+  assert_eq!(pending.severity(), StatusSeverity::Pending);
+  assert_eq!(pending.glyph(), '⏳');
+  assert_eq!(pending.body(), "Opening: ~/foo...");
+  ```
+- `status_message_set_by_view_source_and_cleared_by_any_key`: same `severity` → `severity()` and `text.starts_with` → `glyph() ==` migration. The `match msg.severity { Success => ..., Warning => ... }` block GAINS a `Pending` arm (assert `msg.glyph() == '⏳'`); behavior is now: ViewSource may emit Success, Warning, OR Pending (Pending here would be transient — the test calls `execute_action(ViewSource)` synchronously; the Pending message is set BEFORE the `.status()` call but overwritten by the result before `execute_action` returns, so in practice the test sees Success or Warning. The Pending arm is included for exhaustiveness — if a future refactor leaves the message as Pending, the test will assert the correct glyph instead of panicking on a non-exhaustive match).
+
+**Step 5 — Add 4 new tests** for the pure type behavior (Tests 1–4 above). Place after `status_message_set_by_view_source_and_cleared_by_any_key` (~line 956).
+
+**Step 6 — Audit derives** (already documented in the comment above the `StatusMessage` derive line in Step 1). Verify the `Copy` derive on `StatusSeverity` is still warranted — it is (used in `match` dispatch and across the `app.rs` ↔ `ui.rs` boundary as a value). No `Hash` / `Ord` / `Default` derives are added.
+
+Run: `cargo test -p tome browse::app::tests::status_message`
+  </action>
+  <verify>
+    <automated>cd /Users/martin/dev/opensource/tome && cargo test -p tome browse::app::tests::status_message 2>&1 | tail -20 && cargo clippy -p tome --all-targets -- -D warnings 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "pub\(super\) enum StatusMessage" crates/tome/src/browse/app.rs` returns exactly 1 match.
+    - `rg -n "Success\(String\)|Warning\(String\)|Pending\(String\)" crates/tome/src/browse/app.rs` returns at least 3 matches (the variant declarations).
+    - `rg -n "fn glyph\(&self\)|fn body\(&self\)|fn severity\(&self\)" crates/tome/src/browse/app.rs` returns exactly 3 matches.
+    - `rg -n "msg\.text" crates/tome/src/browse/ui.rs` returns 0 matches (the `.text` field is gone — every consumer composes via `glyph()` + `body()`).
+    - `rg -n "msg\.text" crates/tome/src/browse/app.rs` returns 0 matches.
+    - `rg -n "msg\.severity\b" crates/tome/src/browse/ui.rs` returns 0 matches (must be the method call `msg.severity()` with parens).
+    - `rg -n "msg\.severity\(\)" crates/tome/src/browse/ui.rs` returns at least 2 matches (one per call site).
+    - `rg -n "StatusSeverity::Pending" crates/tome/src/browse/ui.rs` returns at least 2 matches (Pending arm in both render_detail status branch and render_status_bar).
+    - `rg -n "StatusMessage::success\(|StatusMessage::warning\(" crates/tome/src/browse/app.rs` returns 0 matches (legacy constructors removed).
+    - `rg -n "pub StatusMessage|pub fn success|pub fn warning" crates/tome/src/browse/app.rs` returns 0 matches (visibility narrowed).
+    - `cargo test -p tome browse::app::tests::status_message` runs ≥ 7 tests, all pass.
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+  </acceptance_criteria>
+  <done>
+    `StatusMessage` is a `pub(super) enum { Success(String) | Warning(String) | Pending(String) }` with `body()`/`glyph()`/`severity()` accessors. ui.rs composes the rendered string via `format!("{} {}", msg.glyph(), msg.body())` and dispatches color via `msg.severity()` with a Pending arm using `theme.muted`. Tests migrated, derives audited.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Factor `status_message_from_open_result` + add Pending status + drain keystrokes (POLISH-01, TEST-03)</name>
+  <files>crates/tome/src/browse/app.rs, crates/tome/src/browse/mod.rs</files>
+  <read_first>
+    - crates/tome/src/browse/app.rs lines 161–212 (`handle_key` and `handle_normal_key` — `handle_key` signature change required)
+    - crates/tome/src/browse/app.rs lines 213–250 (`handle_detail_key` — needs the redraw param)
+    - crates/tome/src/browse/app.rs lines 252–293 (current ViewSource arm — being refactored into `handle_view_source`)
+    - crates/tome/src/browse/app.rs lines 478–957 (entire `#[cfg(test)] mod tests` block — every `app.handle_key(key, ...)` call site must be updated mechanically)
+    - crates/tome/src/browse/mod.rs lines 1–60 (`run_loop` — needs to construct and pass the redraw closure)
+    - crates/tome/src/paths.rs (`collapse_home` — already used elsewhere)
+  </read_first>
+  <behavior>
+    - Test 1 (`status_message_from_open_result_ok_success`): synthetic `ExitStatus::from_raw(0)` (status 0 = success on Unix) → returns `StatusMessage::Success(s)` where `s.contains("Opened:")` and the body includes `crate::paths::collapse_home(path)` rendering of the path. Use `std::os::unix::process::ExitStatusExt::from_raw` (gated on `#[cfg(unix)]`).
+    - Test 2 (`status_message_from_open_result_ok_nonzero_exit`): synthetic `ExitStatus::from_raw(0x100)` (exit code 1 in the high byte on Linux/macOS) → returns `StatusMessage::Warning(s)` where `s.starts_with("xdg-open exited 1 for: ")`. Test with `binary = "xdg-open"` and a path; assert the body contains the path's `Display` form.
+    - Test 3 (`status_message_from_open_result_err`): synthetic `std::io::Error::new(std::io::ErrorKind::NotFound, "not found")` → returns `StatusMessage::Warning(s)` where `s == "Could not launch xdg-open: not found"`.
+    - Test 4 (`view_source_invokes_redraw_callback_for_pending_status`): drives `App::execute_action_with_redraw(DetailAction::ViewSource, &mut redraw_cb)` with a counting closure; asserts `redraw_calls >= 1`. Proves the redraw is invoked at least once per ViewSource (which is the Pending-message render trip).
+    - Test 5 (`drain_pending_events_returns_when_queue_empty`): calls `app.drain_pending_events()` and asserts it returns within ~100ms via `Instant::now()` before/after. Proves the drain loop terminates on an empty queue (no hangs).
+  </behavior>
+  <action>
+**Step 1 — Add `status_message_from_open_result` free function** (after `impl StatusMessage` block in `app.rs`, ~line 95):
+
+```rust
+/// Convert the result of `Command::new(opener).arg(path).status()` into the
+/// matching `StatusMessage`. Factored out of `App::execute_action` so the
+/// three arms (Ok+success, Ok+non-zero exit, Err) are unit-testable with
+/// synthetic `ExitStatus` values via `ExitStatusExt::from_raw` — engineering
+/// a real opener failure on a CI runner is racy (depends on whether
+/// `xdg-open`/`open` is installed and what the OS does on missing MIME
+/// handlers).
+///
+/// `binary` is the opener name ("open" on macOS, "xdg-open" on Linux);
+/// `path` is the file path passed to it. Both appear in error/success
+/// messages so the user can tell which file failed and which opener tried.
+pub(super) fn status_message_from_open_result(
+    binary: &str,
+    path: &std::path::Path,
+    raw: std::io::Result<std::process::ExitStatus>,
+) -> StatusMessage {
+    match raw {
+        Ok(status) if status.success() => StatusMessage::Success(format!(
+            "Opened: {}",
+            crate::paths::collapse_home(path)
+        )),
+        Ok(status) => {
+            let exit = status
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "signal".into());
+            StatusMessage::Warning(format!("{binary} exited {exit} for: {}", path.display()))
+        }
+        Err(e) => StatusMessage::Warning(format!("Could not launch {binary}: {e}")),
+    }
+}
+```
+
+**Step 2 — Add `drain_pending_events` method on `App`** (private helper, place near `selected_row_meta` ~line 471):
+
+```rust
+/// Drain any crossterm events that accumulated in the queue without
+/// dispatching them. Called after a long-blocking operation (e.g.
+/// `xdg-open`'s `.status()`) so keystrokes typed while the operation
+/// was running don't replay as DetailAction inputs after it returns
+/// (POLISH-01).
+///
+/// Uses `event::poll(Duration::ZERO)` which returns immediately without
+/// blocking. The `unwrap_or(false)` collapses the rare poll error to
+/// "queue empty, stop draining" — losing one event under a poll error
+/// is no worse than the phantom-replay we're already avoiding.
+fn drain_pending_events(&self) {
+    while crossterm::event::poll(std::time::Duration::ZERO).unwrap_or(false) {
+        let _ = crossterm::event::read();
+    }
+}
+```
+
+`&self` (not `&mut`) — we don't store events, just discard them.
+
+**Step 3 — Refactor the ViewSource arm into a `handle_view_source` helper that accepts a redraw closure.**
+
+Remove the entire current `DetailAction::ViewSource => { ... }` arm from `execute_action` (lines 252–293). Add a new private method on `App`:
+
+```rust
+fn handle_view_source(&mut self, redraw: &mut dyn FnMut(&App)) {
+    if let Some((_, _, path)) = self.selected_row_meta() {
+        let binary = if cfg!(target_os = "macos") {
+            "open"
+        } else {
+            "xdg-open"
+        };
+        let path_buf = std::path::PathBuf::from(&path);
+
+        // POLISH-01: surface "Opening: <path>..." BEFORE the blocking
+        // `.status()` call. The redraw closure synchronously calls
+        // `terminal.draw(...)` so the user sees the Pending message
+        // BEFORE the block (in production); test sites pass a no-op
+        // closure and skip the visual side-effect.
+        self.status_message = Some(StatusMessage::Pending(format!(
+            "Opening: {}...",
+            crate::paths::collapse_home(&path_buf)
+        )));
+        redraw(self);
+
+        let raw = std::process::Command::new(binary).arg(&path).status();
+        self.status_message = Some(status_message_from_open_result(binary, &path_buf, raw));
+
+        // POLISH-01 drain step: keystrokes that arrived in the crossterm
+        // event queue while `.status()` was blocking were aimed at the
+        // GUI file opener, not the TUI — replaying them as DetailAction
+        // inputs would cause phantom navigation. Drain them.
+        self.drain_pending_events();
+    }
+}
+```
+
+The `execute_action` body retains the `CopyPath`, `Disable`, `Enable`, `Back` arms unchanged. The `ViewSource` arm of `execute_action` itself becomes:
+
+```rust
+DetailAction::ViewSource => {
+    // Production callers should use `execute_action_with_redraw` directly so the
+    // Pending status renders before `.status()` blocks. This arm is kept so
+    // tests that construct an App and call `execute_action(ViewSource)` directly
+    // continue to work — they pass through to handle_view_source with a no-op
+    // redraw, which is identical to legacy behavior.
+    self.handle_view_source(&mut |_| {});
+}
+```
+
+**Step 4 — Add a redraw-aware variant of `execute_action`** in `crates/tome/src/browse/app.rs`. Place immediately after the existing `execute_action` method:
+
+```rust
+/// Executes a detail action with the ability to redraw before any blocking
+/// operation (e.g. `xdg-open`/`open` `.status()` calls). Production callers
+/// (the run_loop in browse/mod.rs) should use this method; tests that don't
+/// need the pre-block redraw can call `execute_action(action)` directly.
+///
+/// The `redraw` closure should call `terminal.draw(...)` so the user sees
+/// `Pending` status before the block. Failures inside the closure are
+/// silently dropped — a draw error must not abort the action.
+pub(super) fn execute_action_with_redraw(
+    &mut self,
+    action: DetailAction,
+    redraw: &mut dyn FnMut(&App),
+) {
+    match action {
+        DetailAction::ViewSource => self.handle_view_source(redraw),
+        other => self.execute_action(other),
+    }
+}
+```
+
+**Step 5 — Update `App::handle_key` to accept and thread the redraw closure** (`crates/tome/src/browse/app.rs` line 161). Replace:
+
+```rust
+pub fn handle_key(&mut self, key: KeyEvent) {
+```
+
+With:
+
+```rust
+pub(super) fn handle_key(&mut self, key: KeyEvent, redraw: &mut dyn FnMut(&App)) {
+```
+
+Inside `handle_key`, the `Mode::Detail => self.handle_detail_key(key)` branch becomes `Mode::Detail => self.handle_detail_key(key, redraw)`. The `Mode::Normal`, `Mode::Search`, and `Mode::Help` branches do NOT need the closure (no blocking calls inside them).
+
+**Step 6 — Update `App::handle_detail_key`** (line 214). Replace:
+
+```rust
+fn handle_detail_key(&mut self, key: KeyEvent) {
+```
+
+With:
+
+```rust
+fn handle_detail_key(&mut self, key: KeyEvent, redraw: &mut dyn FnMut(&App)) {
+```
+
+Inside `handle_detail_key`, the Enter-action dispatch becomes:
+
+```rust
+KeyCode::Enter => {
+    if let Some(&action) = self.detail_actions.get(self.detail_selected) {
+        // ViewSource needs the redraw closure for POLISH-01; other actions
+        // do not block, so the legacy execute_action path is sufficient.
+        if matches!(action, DetailAction::ViewSource) {
+            self.execute_action_with_redraw(action, redraw);
+        } else {
+            self.execute_action(action);
+        }
+    }
+}
+```
+
+**Step 7 — Update `crates/tome/src/browse/mod.rs::run_loop`** to construct a real redraw closure and pass it. Replace the loop body:
+
+```rust
+fn run_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Result<()> {
+    loop {
+        terminal.draw(|frame| ui::render(frame, app))?;
+
+        if event::poll(Duration::from_millis(100))?
+            && let Event::Key(key) = event::read()?
+        {
+            // POLISH-01: redraw closure threaded into handle_key so the
+            // ViewSource arm can surface a `Pending("Opening: ...")` message
+            // BEFORE `.status()` blocks. The closure ignores draw errors —
+            // a draw failure must not abort the open action; the next
+            // `terminal.draw(...)` at the top of this loop will recover.
+            let mut redraw = |a: &App| {
+                let _ = terminal.draw(|frame| ui::render(frame, a));
+            };
+            app.handle_key(key, &mut redraw);
+        }
+
+        if app.should_quit {
+            break;
+        }
+    }
+    Ok(())
+}
+```
+
+**Step 8 — Update the ~25-30 test sites** that call `app.handle_key(key)` in `crates/tome/src/browse/app.rs::tests`. Find them with:
+
+```bash
+rg -c "app\.handle_key\(" crates/tome/src/browse/app.rs
+```
+
+Each becomes `app.handle_key(key, &mut |_| {})`. The closure is a no-op `|_: &App| {}` — tests don't care about the redraw side-effect (Pending messages are overwritten by the result before any test inspects `app.status_message`).
+
+**Note on borrow-checker quirk:** The closure-passing pattern `&mut |_| {}` may need a stack binding to satisfy lifetime rules in some test sites. If `app.handle_key(key, &mut |_| {})` triggers `error[E0716]: temporary value dropped while borrowed`, refactor to:
+
+```rust
+let mut nr = |_: &App| {};
+app.handle_key(key, &mut nr);
+```
+
+Run `cargo build -p tome --tests` to chase any sites that need the binding pattern.
+
+**Step 9 — Add the 5 new tests** to `app.rs::mod tests`:
+- `status_message_from_open_result_ok_success`
+- `status_message_from_open_result_ok_nonzero_exit`
+- `status_message_from_open_result_err`
+- `view_source_invokes_redraw_callback_for_pending_status`
+- `drain_pending_events_returns_when_queue_empty`
+
+For the synthetic-`ExitStatus` tests, use `std::os::unix::process::ExitStatusExt::from_raw`. Gate with `#[cfg(unix)]`:
+
+```rust
+#[cfg(unix)]
+#[test]
+fn status_message_from_open_result_ok_success() {
+    use std::os::unix::process::ExitStatusExt;
+    let status = std::process::ExitStatus::from_raw(0);
+    let path = std::path::PathBuf::from("/tmp/foo");
+    let msg = status_message_from_open_result("xdg-open", &path, Ok(status));
+    assert!(matches!(msg, StatusMessage::Success(_)));
+    assert!(msg.body().contains("Opened:"));
+}
+
+#[cfg(unix)]
+#[test]
+fn status_message_from_open_result_ok_nonzero_exit() {
+    use std::os::unix::process::ExitStatusExt;
+    let status = std::process::ExitStatus::from_raw(0x100);
+    let path = std::path::PathBuf::from("/tmp/foo");
+    let msg = status_message_from_open_result("xdg-open", &path, Ok(status));
+    assert!(matches!(msg, StatusMessage::Warning(_)));
+    assert!(msg.body().starts_with("xdg-open exited 1 for: "));
+}
+
+#[test]
+fn status_message_from_open_result_err() {
+    let err = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
+    let path = std::path::PathBuf::from("/tmp/foo");
+    let msg = status_message_from_open_result("xdg-open", &path, Err(err));
+    assert!(matches!(msg, StatusMessage::Warning(_)));
+    assert_eq!(msg.body(), "Could not launch xdg-open: not found");
+}
+
+#[test]
+fn view_source_invokes_redraw_callback_for_pending_status() {
+    let (mut app, _tmp) = make_app(3);
+    let mut redraw_calls: u32 = 0;
+    let mut redraw_cb = |_app: &App| { redraw_calls += 1; };
+    app.execute_action_with_redraw(DetailAction::ViewSource, &mut redraw_cb);
+    assert!(
+        redraw_calls >= 1,
+        "redraw must be called at least once for the Pending status (POLISH-01)"
+    );
+}
+
+#[test]
+fn drain_pending_events_returns_when_queue_empty() {
+    let (app, _tmp) = make_app(3);
+    let start = std::time::Instant::now();
+    app.drain_pending_events();
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_millis(100),
+        "drain_pending_events must return promptly on empty queue; took {:?}",
+        elapsed
+    );
+}
+```
+
+Run: `cargo build -p tome --tests && cargo test -p tome --lib browse::`
+  </action>
+  <verify>
+    <automated>cd /Users/martin/dev/opensource/tome && cargo build -p tome --tests 2>&1 | tail -10 && cargo test -p tome --lib browse:: 2>&1 | tail -20 && cargo clippy -p tome --all-targets -- -D warnings 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "pub\(super\) fn status_message_from_open_result" crates/tome/src/browse/app.rs` returns exactly 1 match.
+    - `rg -n "fn drain_pending_events" crates/tome/src/browse/app.rs` returns exactly 1 match.
+    - `rg -n "fn execute_action_with_redraw" crates/tome/src/browse/app.rs` returns exactly 1 match.
+    - `rg -n "fn handle_view_source" crates/tome/src/browse/app.rs` returns exactly 1 match.
+    - `rg -n "redraw: &mut dyn FnMut" crates/tome/src/browse/` returns at least 2 matches (handle_key + execute_action_with_redraw signatures; plus likely handle_detail_key + handle_view_source for 4 total).
+    - `rg -n "Opening: " crates/tome/src/browse/app.rs` returns at least 1 match (the Pending body format string).
+    - `rg -n "StatusMessage::Pending" crates/tome/src/browse/app.rs` returns at least 1 match (the `handle_view_source` body).
+    - `rg -n "crossterm::event::poll\(std::time::Duration::ZERO\)|crossterm::event::poll\(Duration::ZERO\)" crates/tome/src/browse/app.rs` returns at least 1 match (drain loop).
+    - `rg -n "let mut redraw = \|a: &App\|" crates/tome/src/browse/mod.rs` returns at least 1 match (the production redraw closure).
+    - `rg -n "app\.handle_key\(key, &mut" crates/tome/src/browse/app.rs` returns at least 25 matches (test sites updated).
+    - `cargo test -p tome browse::app::tests::status_message_from_open_result_ok_success` passes.
+    - `cargo test -p tome browse::app::tests::status_message_from_open_result_ok_nonzero_exit` passes.
+    - `cargo test -p tome browse::app::tests::status_message_from_open_result_err` passes.
+    - `cargo test -p tome browse::app::tests::view_source_invokes_redraw_callback_for_pending_status` passes.
+    - `cargo test -p tome browse::app::tests::drain_pending_events_returns_when_queue_empty` passes.
+    - `cargo test -p tome --lib browse::` passes (all pre-existing browse module tests still green after the test-site updates).
+    - `cargo build -p tome --tests` is clean.
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+  </acceptance_criteria>
+  <done>
+    `status_message_from_open_result` is a `pub(super)` free function with 3 unit tests covering Ok-success, Ok-nonzero-exit, and Err arms. `App::execute_action_with_redraw` and `App::handle_view_source` exist; the redraw closure threads through `handle_key` → `handle_detail_key` → `execute_action_with_redraw`. `run_loop` constructs the production redraw closure with `terminal.draw(...)`. After `.status()` returns, queued crossterm events are drained via `drain_pending_events()`. Test sites updated mechanically.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Auto-retry `ClipboardOccupied` once with 100ms backoff (POLISH-03)</name>
+  <files>crates/tome/src/browse/app.rs</files>
+  <read_first>
+    - crates/tome/src/browse/app.rs lines 294–337 (current CopyPath arm — Err mapping including ClipboardOccupied)
+    - crates/tome/src/browse/app.rs lines 853–912 (existing CopyPath lifecycle test — must continue to pass)
+  </read_first>
+  <behavior>
+    - Test 1 (`copy_path_retries_clipboard_occupied_once`): factor the retry logic into a free helper `try_clipboard_set_text_with_retry(text: &str) -> Result<(), arboard::Error>` that calls `arboard::Clipboard::new().and_then(|mut cb| cb.set_text(text))` once; on `ClipboardOccupied`, sleeps 100ms and retries once. Test the helper directly with a fake by injecting a counter or by relying on the host's actual clipboard. Since arboard uses real OS APIs (un-mockable without trait abstraction, which #463 explicitly rejects), test the SHAPE: a unit test that calls the helper and asserts it returns `Ok(())` or `Err(_)` within ~250ms (one fast attempt + one 100ms-delayed attempt). Use `std::time::Instant` to assert the wall-clock bound.
+    - Test 2 (`copy_path_retry_helper_under_250ms_on_success`): On a host where the clipboard is available (most dev machines + CI runners with a display server), the first attempt succeeds and the helper returns in <50ms. Skip the test under `#[cfg(target_os = "linux")]` if `DISPLAY`/`WAYLAND_DISPLAY` is unset (headless CI) — the helper will return `Err(ClipboardNotSupported)` immediately, which is also valid (no retry, no sleep). The bound assertion: `elapsed < Duration::from_millis(250)` covers both fast-success AND fast-fail paths; only ClipboardOccupied followed by ClipboardOccupied would push past 100ms — and CI doesn't reproduce that.
+    - Test 3 (`status_message_set_by_copy_path_and_cleared_by_any_key`) — UPDATED: existing test from Task 1's migration. Continues to pass; a host that produces `ClipboardOccupied` once now eventually emits Success or Warning depending on the second attempt.
+
+    **Note on testability:** the retry contract is not directly testable on real-OS arboard without injecting a fake. Per #463 D-17/D-19, we deliberately do NOT introduce a `trait ClipboardBackend`. The test surface is therefore: (a) the wall-clock bound, (b) the lifecycle invariant (existing test), (c) a `rg` assertion in acceptance_criteria that the retry source code is present. Manual UAT covers the actual two-attempt behavior.
+  </behavior>
+  <action>
+**Step 1 — Add the retry helper** (place near `status_message_from_open_result`, ~line 110):
+
+```rust
+/// Try `Clipboard::new().set_text(text)`. On `ClipboardOccupied`, sleep 100ms
+/// and retry exactly once before returning the error. POLISH-03 / #463 D3:
+/// `ClipboardOccupied` is the most common transient failure (another app
+/// holding the clipboard mid-paste); a single 100ms backoff resolves the
+/// vast majority of real-world cases without escalating a Warning to the
+/// user.
+///
+/// All other `arboard::Error` variants return immediately — they are NOT
+/// transient (`ClipboardNotSupported` is a session-level limitation;
+/// `ContentNotAvailable` is a programming error; etc.) so retrying would
+/// just delay the inevitable Warning.
+///
+/// Per #463 D-17/D-19, we do NOT introduce a trait abstraction here — the
+/// retry is hard-coded against the real `arboard::Clipboard` API. The
+/// retry shape is verified by source-grep + manual UAT, not by an
+/// injected fake.
+fn try_clipboard_set_text_with_retry(text: &str) -> Result<(), arboard::Error> {
+    fn attempt(text: &str) -> Result<(), arboard::Error> {
+        arboard::Clipboard::new().and_then(|mut cb| cb.set_text(text.to_owned()))
+    }
+
+    match attempt(text) {
+        Ok(()) => Ok(()),
+        Err(arboard::Error::ClipboardOccupied) => {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            attempt(text)
+        }
+        Err(other) => Err(other),
+    }
+}
+```
+
+**Step 2 — Replace the inlined `arboard::Clipboard::new().and_then(...)` in the CopyPath arm** (around line 308) with a call to the new helper:
+
+```rust
+DetailAction::CopyPath => {
+    if let Some((_, _, path)) = self.selected_row_meta() {
+        let result = try_clipboard_set_text_with_retry(&path);
+        match result {
+            Ok(()) => {
+                self.status_message = Some(StatusMessage::Success(format!(
+                    "Copied: {}",
+                    crate::paths::collapse_home(Path::new(&path))
+                )));
+            }
+            Err(e) => {
+                let msg = match &e {
+                    arboard::Error::ClipboardNotSupported => {
+                        "Clipboard unavailable (headless or unsupported session)".to_string()
+                    }
+                    arboard::Error::ClipboardOccupied => {
+                        "Clipboard busy (another app is holding it); try again".to_string()
+                    }
+                    other => format!("Could not copy: {other}"),
+                };
+                self.status_message = Some(StatusMessage::Warning(msg));
+            }
+        }
+    }
+}
+```
+
+The `ClipboardOccupied` arm in the match is RETAINED — it now fires only after the retry has also failed. The body string is unchanged so existing snapshot/UAT expectations don't drift.
+
+**Step 3 — Add the 2 new tests** to `app.rs::mod tests`:
+
+```rust
+#[test]
+fn copy_path_retry_helper_returns_within_bound() {
+    // The retry contract: at most one fast attempt + one 100ms-delayed
+    // attempt. On a host where the clipboard succeeds or fails-fast
+    // (ClipboardNotSupported), the helper returns in <50ms. On a host
+    // where the clipboard is occupied repeatedly, it returns in ~100ms.
+    // The 250ms upper bound covers both — anything longer indicates a
+    // regression (e.g., a second 100ms sleep crept in).
+    let start = std::time::Instant::now();
+    let _ = super::try_clipboard_set_text_with_retry("test-payload");
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_millis(250),
+        "retry helper must complete within 250ms (one fast + one 100ms backoff); took {:?}",
+        elapsed
+    );
+}
+
+#[test]
+fn copy_path_retry_helper_signature_compiles() {
+    // Smoke test: ensures the helper exists with the documented signature.
+    // If a future refactor changes the type, this fails to compile and
+    // the issue is surfaced before the source-grep checks run.
+    let _: fn(&str) -> Result<(), arboard::Error> = super::try_clipboard_set_text_with_retry;
+}
+```
+
+The first test depends on the host's clipboard state. On macOS dev machines and most Linux CI runners with `DISPLAY` set, the first attempt succeeds in <10ms. On headless CI, `Clipboard::new()` returns `ClipboardNotSupported` (no retry, no sleep). The 250ms upper bound is safe.
+
+**Step 4 — Run the existing `status_message_set_by_copy_path_and_cleared_by_any_key` test** (migrated in Task 1) to confirm the retry path doesn't break it. The test already accepts either Success or Warning severity; the retry adds at most 100ms latency on hosts that produce ClipboardOccupied, which doesn't affect the assertion shape.
+
+Run: `cargo test -p tome browse::app::tests::copy_path_retry browse::app::tests::status_message_set_by_copy_path`
+  </action>
+  <verify>
+    <automated>cd /Users/martin/dev/opensource/tome && cargo test -p tome browse::app::tests::copy_path 2>&1 | tail -15 && cargo clippy -p tome --all-targets -- -D warnings 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "fn try_clipboard_set_text_with_retry" crates/tome/src/browse/app.rs` returns exactly 1 match.
+    - `rg -n "ClipboardOccupied.*sleep|sleep.*ClipboardOccupied" crates/tome/src/browse/app.rs` returns at least 1 match (the retry pattern: match arm + sleep call adjacent).
+    - `rg -n "Duration::from_millis\(100\)" crates/tome/src/browse/app.rs` returns at least 1 match (the 100ms backoff).
+    - `rg -n "arboard::Clipboard::new\(\).and_then" crates/tome/src/browse/app.rs` returns 0 matches in the `execute_action` body (the inlined call is replaced by the helper). One match is allowed inside the helper itself.
+    - `cargo test -p tome browse::app::tests::copy_path_retry_helper_returns_within_bound` passes.
+    - `cargo test -p tome browse::app::tests::copy_path_retry_helper_signature_compiles` passes.
+    - `cargo test -p tome browse::app::tests::status_message_set_by_copy_path_and_cleared_by_any_key` passes (regression).
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+  </acceptance_criteria>
+  <done>
+    `try_clipboard_set_text_with_retry` exists as a free helper and is called from the CopyPath arm. ClipboardOccupied triggers exactly one 100ms-delayed retry; all other errors fall through immediately. Existing CopyPath lifecycle test still passes.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- `cargo test -p tome browse::app::tests::status_message` — ≥ 7 tests pass (variant constructors, body/glyph/severity, lifecycle migrated).
+- `cargo test -p tome browse::app::tests::status_message_from_open_result` — 3 tests pass (Ok-success, Ok-nonzero-exit, Err).
+- `cargo test -p tome browse::app::tests::view_source_invokes_redraw_callback_for_pending_status` — passes.
+- `cargo test -p tome browse::app::tests::drain_pending_events_returns_when_queue_empty` — passes.
+- `cargo test -p tome browse::app::tests::copy_path_retry_helper_returns_within_bound` — passes.
+- `cargo test -p tome browse::app::tests::copy_path_retry_helper_signature_compiles` — passes.
+- `cargo test -p tome browse::app::tests::status_message_set_by_copy_path_and_cleared_by_any_key` — passes (regression).
+- `cargo test -p tome browse::app::tests::status_message_set_by_view_source_and_cleared_by_any_key` — passes (regression, migrated).
+- `cargo test -p tome --lib browse::` — passes (all pre-existing browse module tests still green after redraw-closure threading).
+- `make ci` — clean.
+- `rg -n "msg\.text" crates/tome/src/browse/` — 0 matches.
+- `rg -n "StatusMessage::success\(|StatusMessage::warning\(" crates/tome/src/browse/app.rs` — 0 matches (legacy constructors removed).
+- `rg -n "redraw: &mut dyn FnMut" crates/tome/src/browse/` — at least 2 matches.
+</verification>
+
+<success_criteria>
+- `StatusMessage` is a `pub(super) enum` with `Success(String)` / `Warning(String)` / `Pending(String)` variants and `body()`/`glyph()`/`severity()` accessors (POLISH-02).
+- `ui.rs` composes the rendered string at render time via `format!("{} {}", msg.glyph(), msg.body())` and dispatches color via `msg.severity()` with a Pending arm using `theme.muted` (POLISH-02).
+- Redraw closure (`&mut dyn FnMut(&App)`) threads through `App::handle_key` → `handle_detail_key` → `execute_action_with_redraw` → `handle_view_source`. Production `run_loop` passes a closure that calls `terminal.draw(...)`; tests pass `&mut |_| {}`. `App` itself stays independent of `ratatui::DefaultTerminal` (POLISH-01).
+- `ViewSource` action sets `StatusMessage::Pending("Opening: <collapsed-path>...")` and invokes the redraw closure BEFORE `.status()` blocks; after the block returns, queued crossterm events are drained (POLISH-01).
+- `status_message_from_open_result(binary, path, raw)` is a unit-tested `pub(super)` free function covering Ok+success / Ok+non-zero / Err (TEST-03).
+- `try_clipboard_set_text_with_retry` retries `ClipboardOccupied` once after a 100ms backoff before any Warning reaches `app.status_message` (POLISH-03).
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/10-phase-8-review-tail/10-01-SUMMARY.md` recording:
+- New `StatusMessage` enum + accessor signatures.
+- New `status_message_from_open_result` and `try_clipboard_set_text_with_retry` signatures.
+- `App::execute_action_with_redraw` and `App::handle_view_source` signatures.
+- `App::handle_key(&mut self, key: KeyEvent, redraw: &mut dyn FnMut(&App))` new signature.
+- The exact line edited in `crates/tome/src/browse/mod.rs::run_loop`.
+- Test names added (≥ 7 in the StatusMessage cluster, 3 in the open_result cluster, 2 in the retry cluster, 1 for view_source_invokes_redraw, 1 for drain_pending_events).
+- Tests migrated (lifecycle / glyph dispatch).
+- Test sites updated mechanically: the count of `app.handle_key(...)` call sites converted from 1-arg to 2-arg.
+- One-line confirmation: POLISH-01 + POLISH-02 + POLISH-03 + TEST-03 closed.
+</output>

--- a/.planning/phases/10-phase-8-review-tail/10-02-remove-correctness-and-test-coverage-PLAN.md
+++ b/.planning/phases/10-phase-8-review-tail/10-02-remove-correctness-and-test-coverage-PLAN.md
@@ -1,0 +1,893 @@
+---
+phase: 10-phase-8-review-tail
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - crates/tome/src/remove.rs
+  - crates/tome/src/lib.rs
+  - crates/tome/tests/cli.rs
+autonomous: true
+requirements: [POLISH-04, POLISH-05, TEST-01, TEST-02, TEST-04]
+issue: "https://github.com/MartinP7r/tome/issues/463 + https://github.com/MartinP7r/tome/issues/462"
+
+must_haves:
+  truths:
+    - "`FailureKind::ALL` cannot drift from the enum: a compile-time guard (exhaustive-match sentinel function `_ensure_failure_kind_all_exhaustive`) fails to compile if a new variant is added without also being appended to `ALL`. No runtime drift detection — the check happens at `cargo build` time."
+    - "`RemoveFailure::new` carries a real invariant: `debug_assert!(path.is_absolute(), \"RemoveFailure::path must be absolute, got: {}\", path.display())` fires in debug builds when constructed with a relative path. (POLISH-05 option (a) — keep the constructor + add the invariant. Removing the constructor (option b) would touch 4 production call sites; option a is smaller blast-radius and gives the absolute-path invariant we want for collapse_home rendering.)"
+    - "`remove_partial_failure_exits_nonzero_with_warning_marker` asserts the success banner `\"✓ Removed directory\"` is ABSENT from BOTH stdout AND stderr when the partial-failure path fires."
+    - "An end-to-end retry-after-fix test (`remove_retry_succeeds_after_failure_resolved`) drives the full I2/I3 contract: chmod 0o500 → `tome remove` → expect partial failure (config + manifest preserved) → chmod 0o755 → `tome remove` again → succeeds with empty `failures`, config entry gone, manifest empty for that source, library dir for the skill gone."
+    - "On the happy `tome remove` path, the success banner `\"✓ Removed directory\"` is the LAST output line — `regen_warnings` printed via `eprintln!(\"warning: ...\")` either fire BEFORE the success banner is printed (option a, deferred) or are scoped with a `[lockfile regen]` prefix (option b). We pick option (a): defer the warning prints until after the success banner — the banner is the user's anchor and warnings should be a subordinate footnote."
+    - "The TEST-04 source-order regression test ANCHORS its `String::find()` searches to the `Command::Remove` handler region in `lib.rs` so a future reorder of unrelated regen-warnings handlers (Reassign / Fork) cannot create a false-positive failure unrelated to the Remove ordering contract."
+  artifacts:
+    - path: "crates/tome/src/remove.rs"
+      provides: "Compile-enforced `FailureKind::ALL` via `_ensure_failure_kind_all_exhaustive` const-eval sentinel that exhaustive-matches every variant. `RemoveFailure::new` gains `debug_assert!(path.is_absolute(), ...)`."
+      contains: "_ensure_failure_kind_all_exhaustive"
+    - path: "crates/tome/src/lib.rs"
+      provides: "`Command::Remove` happy-path: success banner `println!` runs BEFORE the `eprintln!(\"warning: ...\")` loop over `regen_warnings`. Code comment explains the deferred-warnings choice (option a)."
+      contains: "Removed directory"
+    - path: "crates/tome/tests/cli.rs"
+      provides: "Updated `remove_partial_failure_exits_nonzero_with_warning_marker` with success-banner-absence assertion. New `remove_retry_succeeds_after_failure_resolved` end-to-end retry test. New `lib_rs_remove_handler_prints_success_banner_before_regen_warnings` ordering regression test (anchored to the `Command::Remove` region in lib.rs)."
+      contains: "remove_retry_succeeds_after_failure_resolved"
+  key_links:
+    - from: "crates/tome/src/remove.rs::FailureKind::ALL"
+      to: "_ensure_failure_kind_all_exhaustive"
+      via: "compile-time exhaustive match — adding a variant requires updating both"
+      pattern: "_ensure_failure_kind_all_exhaustive"
+    - from: "crates/tome/src/remove.rs::RemoveFailure::new"
+      to: "debug_assert! on path.is_absolute()"
+      via: "constructor invariant"
+      pattern: "debug_assert!\\(path\\.is_absolute"
+    - from: "crates/tome/src/lib.rs::Command::Remove handler"
+      to: "success banner println before regen_warnings eprintln loop"
+      via: "deferred-warnings ordering (TEST-04 option a)"
+      pattern: "Removed directory.*\\n.*for w in.*regen_warnings"
+    - from: "crates/tome/tests/cli.rs::remove_partial_failure_exits_nonzero_with_warning_marker"
+      to: "stdout/stderr success-banner-absence assertion"
+      via: "predicate that ✓ Removed directory does NOT appear"
+      pattern: "Removed directory"
+---
+
+<objective>
+Close the Remove-module review tail: compile-enforce `FailureKind::ALL` so it cannot drift from the enum, give `RemoveFailure::new` a real `debug_assert!` invariant, fix the `regen_warnings`-before-success-banner ordering on the happy path, expand the existing partial-failure CLI test to assert the success banner is absent, and add an end-to-end retry-after-fix integration test that pins the I2/I3 retention contract.
+
+This plan owns 5 of the 11 review-tail items, all centered on `crates/tome/src/remove.rs` + `lib.rs::Command::Remove` + `tests/cli.rs`.
+
+**Closes:** POLISH-04 (D4, FailureKind::ALL drift-proofing), POLISH-05 (D5, RemoveFailure::new invariant), TEST-01 (P1, success-banner-absence), TEST-02 (P2, retry-after-fix e2e), TEST-04 (P4, regen-warnings-after-banner).
+
+**Decisions pinned:**
+- POLISH-04 option: **(c) exhaustive-match sentinel** (compile-enforced, no `strum` dependency). Smaller blast-radius than (a) `strum::EnumIter`.
+- POLISH-05 option: **(a) keep `new()` + add `debug_assert!`** invariant. Smaller blast-radius than (b) replacing 4 call sites.
+- TEST-04 option: **(a) defer warnings until after the success banner**. The banner is the user's anchor; warnings as a footnote feel more natural than the `[lockfile regen]` prefix (option b) which adds visual noise even on the happy path.
+
+Purpose: harden the partial-failure contract that v0.8 + v0.8.1 shipped, eliminate the manual-sync drift hazard on `FailureKind::ALL`, and lock the success-banner-last invariant so a future refactor cannot regress it silently.
+
+Output: 1 compile-time sentinel function in `remove.rs`, 1 debug_assert in `RemoveFailure::new`, ~10-line reorder in `lib.rs::Command::Remove`, success-banner-absence assertion added to existing test, 2 new integration tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/REQUIREMENTS.md
+
+@crates/tome/src/remove.rs
+@crates/tome/src/lib.rs
+@crates/tome/tests/cli.rs
+
+<interfaces>
+<!-- Key types and contracts the executor needs. Extracted from codebase. -->
+
+Current `FailureKind` (`crates/tome/src/remove.rs` lines 50–88):
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FailureKind {
+    DistributionSymlink,
+    LibraryDir,
+    LibrarySymlink,
+    GitCache,
+}
+
+impl FailureKind {
+    pub(crate) const ALL: [FailureKind; 4] = [
+        FailureKind::DistributionSymlink,
+        FailureKind::LibraryDir,
+        FailureKind::LibrarySymlink,
+        FailureKind::GitCache,
+    ];
+    pub(crate) fn label(self) -> &'static str { /* match */ }
+}
+```
+
+After this plan:
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FailureKind {
+    DistributionSymlink,
+    LibraryDir,
+    LibrarySymlink,
+    GitCache,
+}
+
+impl FailureKind {
+    pub(crate) const ALL: [FailureKind; 4] = [
+        FailureKind::DistributionSymlink,
+        FailureKind::LibraryDir,
+        FailureKind::LibrarySymlink,
+        FailureKind::GitCache,
+    ];
+    pub(crate) fn label(self) -> &'static str { /* unchanged */ }
+}
+
+/// Compile-time drift guard for `FailureKind::ALL`. If a new variant is
+/// added to `FailureKind` without being appended to `ALL`, this function
+/// fails to compile (the exhaustive match misses the new variant).
+///
+/// The function is dead code at runtime — `#[allow(dead_code)]` documents
+/// that it exists purely as a compile-time check. Symmetric to the
+/// 12-combo `(DirectoryType, DirectoryRole)` matrix test (WHARD-06)
+/// which compile-enforces config-shape invariants.
+#[allow(dead_code)]
+const fn _ensure_failure_kind_all_exhaustive(k: FailureKind) -> usize {
+    // Match every variant — the compiler bails if a new variant is added
+    // without being added here. Each arm returns the variant's index in
+    // `ALL`, so a const_assert on FailureKind::ALL[index] == variant
+    // could be added later if desired (currently unnecessary; the
+    // ordering is read-only — it only affects user-visible label
+    // grouping).
+    match k {
+        FailureKind::DistributionSymlink => 0,
+        FailureKind::LibraryDir => 1,
+        FailureKind::LibrarySymlink => 2,
+        FailureKind::GitCache => 3,
+    }
+}
+
+// Optionally: a const-time length assertion that pins ALL.len() == number of arms above.
+const _: () = {
+    // If this fails, FailureKind::ALL has the wrong length. The arms in
+    // _ensure_failure_kind_all_exhaustive are the source of truth for
+    // "what variants exist"; ALL must contain exactly that many entries.
+    assert!(FailureKind::ALL.len() == 4);
+};
+```
+
+Current `RemoveFailure::new` (lines 98–104):
+```rust
+pub(crate) fn new(kind: FailureKind, path: PathBuf, error: std::io::Error) -> Self {
+    RemoveFailure { kind, path, error }
+}
+```
+
+After this plan:
+```rust
+/// Construct a `RemoveFailure`. Centralizes the absolute-path invariant
+/// so downstream rendering (`paths::collapse_home(&f.path)` in lib.rs)
+/// is well-defined: collapse_home expects an absolute path; relative
+/// paths would render unmodified, leaking working-directory-relative
+/// shapes into user-facing error output. The four call sites in
+/// `execute()` all pass paths derived from config-resolved directories
+/// (always absolute), so this debug_assert never fires in normal use —
+/// it's a forward guard against a future refactor that adds a fifth
+/// call site with a relative path.
+pub(crate) fn new(kind: FailureKind, path: PathBuf, error: std::io::Error) -> Self {
+    debug_assert!(
+        path.is_absolute(),
+        "RemoveFailure::path must be absolute, got: {}",
+        path.display()
+    );
+    RemoveFailure { kind, path, error }
+}
+```
+
+Current `Command::Remove` happy-path (`crates/tome/src/lib.rs` lines 449–478):
+```rust
+// Save updated config
+config.save(&paths.config_path())?;
+// Save updated manifest
+manifest::save(&manifest, paths.config_dir())?;
+// Regenerate lockfile.
+let (resolved_paths, mut regen_warnings) =
+    lockfile::resolved_paths_from_lockfile_cache(&config, &paths);
+let skills = discover::discover_all(&config, &resolved_paths, &mut regen_warnings)?;
+for w in &regen_warnings {
+    eprintln!("warning: {}", w);            // <-- prints BEFORE success banner
+}
+let lockfile = lockfile::generate(&manifest, &skills);
+lockfile::save(&lockfile, paths.config_dir())?;
+
+// Success path — full cleanup completed with no failures.
+println!(
+    "\n{} Removed directory '{}': {} library entries, {} symlinks{}",
+    style("✓").green(), name, ...
+);
+```
+
+After this plan (TEST-04 option a — defer warnings until after the banner):
+```rust
+// Save updated config
+config.save(&paths.config_path())?;
+// Save updated manifest
+manifest::save(&manifest, paths.config_dir())?;
+// Regenerate lockfile. Recover git-skill provenance offline ...
+let (resolved_paths, mut regen_warnings) =
+    lockfile::resolved_paths_from_lockfile_cache(&config, &paths);
+let skills = discover::discover_all(&config, &resolved_paths, &mut regen_warnings)?;
+let lockfile = lockfile::generate(&manifest, &skills);
+lockfile::save(&lockfile, paths.config_dir())?;
+
+// Success banner FIRST — it's the user's anchor for "what just happened".
+// Warnings come after as a footnote (TEST-04 option a — deferred ordering).
+// Without this ordering, the success banner gets buried under stderr
+// warnings on multi-warning regen and the user has to scroll up to find
+// the green ✓ confirmation.
+println!(
+    "\n{} Removed directory '{}': {} library entries, {} symlinks{}",
+    style("✓").green(),
+    name,
+    result.library_entries_removed,
+    result.symlinks_removed,
+    if result.git_cache_removed { ", git cache" } else { "" },
+);
+for w in &regen_warnings {
+    eprintln!("warning: {}", w);
+}
+```
+
+Current `remove_partial_failure_exits_nonzero_with_warning_marker` test (`crates/tome/tests/cli.rs` lines 3375–3459) asserts:
+- exit non-success
+- stderr contains `⚠`
+- stderr contains `"operations failed"`
+- stderr contains `"remove completed with"`
+- stderr contains `"retained"` OR `"retry"`
+
+After this plan, ADD:
+- stdout does NOT contain `"✓ Removed directory"`
+- stderr does NOT contain `"✓ Removed directory"` (defense-in-depth)
+
+The reasoning: on partial failure, `lib.rs::Command::Remove` returns Err *before* reaching the success banner, so the banner never prints. The current test only asserts the warning marker IS present; a future refactor that prints the banner unconditionally (e.g., moving it before the partial-failure block) would not be caught. P1 closes this gap.
+
+`remove_test_env` and `create_skill` are existing test helpers in `tests/cli.rs` — reuse them.
+
+**`lib.rs` contains THREE `for w in &regen_warnings` loops**: one each in the `Command::Remove`, `Command::Reassign`, and `Command::Fork` handlers. Currently the Remove handler is the FIRST occurrence in source order, so a naïve `lib_rs.find("for w in &regen_warnings")` would find the right loop by coincidence. To prevent a future-refactor false-positive (e.g., reordering Reassign above Remove, or inserting a new handler with its own regen-warnings loop above Remove), the source-order test in Task 4 / Step 2 anchors all `find()` calls to the `Command::Remove` handler region first, then searches FORWARD from there for both the success banner and the warnings loop. This guarantees the test fails ONLY when the Remove handler itself regresses.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Compile-enforce `FailureKind::ALL` + add `debug_assert!` to `RemoveFailure::new` (POLISH-04, POLISH-05)</name>
+  <files>crates/tome/src/remove.rs</files>
+  <read_first>
+    - crates/tome/src/remove.rs lines 45–104 (FailureKind enum + ALL constant + RemoveFailure::new)
+    - crates/tome/src/remove.rs lines 252–321 (the four call sites of `RemoveFailure::new` in `execute`)
+    - crates/tome/src/remove.rs lines 350–625 (existing test module — extend, do not break)
+  </read_first>
+  <behavior>
+    - Test 1 (`failure_kind_all_length_matches_variant_count`): asserts `FailureKind::ALL.len() == 4` and that ALL contains every variant exactly once (using a `BTreeSet`). Pins the runtime check that complements the compile-time sentinel.
+    - Test 2 (`failure_kind_all_ordering_pinned`): asserts the order of ALL is exactly `[DistributionSymlink, LibraryDir, LibrarySymlink, GitCache]`. The order is meaningful — it's the order the `lib.rs` consumer iterates for grouped user-facing output. A reorder is a UI change and should require an explicit code edit.
+    - Test 3 (`remove_failure_new_relative_path_panics_in_debug`): drives `RemoveFailure::new(FailureKind::DistributionSymlink, PathBuf::from("relative/path"), io::Error::other("e"))` and asserts a panic via `std::panic::catch_unwind`. Gated on `cfg!(debug_assertions)` — release builds compile out the assert, so in release the test asserts construction succeeds without panicking. Use:
+      ```rust
+      #[test]
+      fn remove_failure_new_relative_path_panics_in_debug() {
+          let result = std::panic::catch_unwind(|| {
+              RemoveFailure::new(
+                  FailureKind::DistributionSymlink,
+                  PathBuf::from("relative/path"),
+                  std::io::Error::other("test"),
+              )
+          });
+          if cfg!(debug_assertions) {
+              assert!(result.is_err(), "debug build must panic on relative path");
+          } else {
+              assert!(result.is_ok(), "release build must allow construction");
+          }
+      }
+      ```
+    - Test 4 (`remove_failure_new_absolute_path_succeeds`): drives `RemoveFailure::new(...)` with `PathBuf::from("/abs/path")` and asserts construction succeeds in both debug and release. Reuses the existing `test_hash` helper if needed for io::Error.
+  </behavior>
+  <action>
+**Step 1 — Add the compile-time sentinel** (place immediately after the `impl FailureKind` block in `crates/tome/src/remove.rs`, around line 89):
+
+```rust
+/// Compile-time drift guard for `FailureKind::ALL`. If a new variant is
+/// added to `FailureKind`, this `const fn` fails to compile because the
+/// match below is exhaustive. The fix is to (a) add an arm here AND
+/// (b) append the new variant to `ALL`. Symmetric to the 12-combo
+/// `(DirectoryType, DirectoryRole)` matrix test that compile-enforces
+/// config-shape invariants (WHARD-06).
+///
+/// The function is dead-code at runtime — its sole purpose is the
+/// exhaustiveness check. The `const _: () = ...` block below additionally
+/// pins `ALL.len() == 4` at compile time.
+#[allow(dead_code)]
+const fn _ensure_failure_kind_all_exhaustive(k: FailureKind) -> usize {
+    match k {
+        FailureKind::DistributionSymlink => 0,
+        FailureKind::LibraryDir => 1,
+        FailureKind::LibrarySymlink => 2,
+        FailureKind::GitCache => 3,
+    }
+}
+
+const _: () = {
+    // If this fails: FailureKind::ALL is missing or has extra variants.
+    // The match arms in _ensure_failure_kind_all_exhaustive are the source
+    // of truth — ALL must contain exactly one entry per arm.
+    assert!(FailureKind::ALL.len() == 4);
+};
+```
+
+**Step 2 — Add `debug_assert!` to `RemoveFailure::new`** (lines 98–104):
+
+```rust
+impl RemoveFailure {
+    /// Construct a `RemoveFailure`. The path MUST be absolute — downstream
+    /// rendering uses `paths::collapse_home(&f.path)` in lib.rs, which
+    /// expects an absolute path. The four `execute()` call sites all pass
+    /// config-resolved directory paths (always absolute), so this guard
+    /// never fires in normal use; it's a forward guard against a future
+    /// refactor that adds a relative-path call site.
+    ///
+    /// Debug-only via `debug_assert!` to keep release builds zero-cost.
+    pub(crate) fn new(kind: FailureKind, path: PathBuf, error: std::io::Error) -> Self {
+        debug_assert!(
+            path.is_absolute(),
+            "RemoveFailure::path must be absolute, got: {}",
+            path.display()
+        );
+        RemoveFailure { kind, path, error }
+    }
+}
+```
+
+**Step 3 — Verify the four existing `execute()` call sites pass absolute paths.** Read `execute()` (lines 252–321) and confirm:
+- `plan.symlinks_to_remove` originates from config-directory `path` joined with `entry.path()` — both absolute. ✓
+- `plan.library_paths` originates from `paths.library_dir().join(skill)` — `library_dir` is absolute. ✓
+- `plan.git_cache_path` originates from `git::repo_cache_dir(&paths.repos_dir(), url_str)` — `repos_dir` is absolute. ✓
+
+If any site passes a relative path, the existing test `partial_failure_aggregates_symlink_error` would now panic in debug. Run it after the change to confirm.
+
+**Step 4 — Add the 4 new tests** to `mod tests` in `remove.rs` (after `partial_failure_aggregates_multiple_kinds`, ~line 624):
+
+```rust
+#[test]
+fn failure_kind_all_length_matches_variant_count() {
+    use std::collections::BTreeSet;
+    let set: BTreeSet<FailureKind> = FailureKind::ALL.iter().copied().collect();
+    assert_eq!(
+        set.len(),
+        4,
+        "FailureKind::ALL must contain every variant exactly once"
+    );
+    assert!(set.contains(&FailureKind::DistributionSymlink));
+    assert!(set.contains(&FailureKind::LibraryDir));
+    assert!(set.contains(&FailureKind::LibrarySymlink));
+    assert!(set.contains(&FailureKind::GitCache));
+}
+
+#[test]
+fn failure_kind_all_ordering_pinned() {
+    // The grouped failure-summary output in lib.rs::Command::Remove iterates
+    // FailureKind::ALL in declaration order. The user-visible grouping
+    // therefore depends on this exact order. A reorder is a UI change and
+    // must require an explicit code edit (this test fails on reorder).
+    assert_eq!(
+        FailureKind::ALL,
+        [
+            FailureKind::DistributionSymlink,
+            FailureKind::LibraryDir,
+            FailureKind::LibrarySymlink,
+            FailureKind::GitCache,
+        ],
+        "FailureKind::ALL ordering is part of the user-visible grouping contract"
+    );
+}
+
+#[test]
+fn remove_failure_new_relative_path_panics_in_debug() {
+    let result = std::panic::catch_unwind(|| {
+        RemoveFailure::new(
+            FailureKind::DistributionSymlink,
+            PathBuf::from("relative/path"),
+            std::io::Error::other("test"),
+        )
+    });
+    if cfg!(debug_assertions) {
+        assert!(result.is_err(), "debug build must panic on relative path");
+    } else {
+        assert!(result.is_ok(), "release build must allow construction (debug_assert compiled out)");
+    }
+}
+
+#[test]
+fn remove_failure_new_absolute_path_succeeds() {
+    let f = RemoveFailure::new(
+        FailureKind::DistributionSymlink,
+        PathBuf::from("/abs/path"),
+        std::io::Error::other("test"),
+    );
+    assert_eq!(f.kind, FailureKind::DistributionSymlink);
+    assert_eq!(f.path, PathBuf::from("/abs/path"));
+}
+```
+
+`std::io::Error::other` is stable since 1.74 (we're on 1.85+). Replace with `std::io::Error::new(std::io::ErrorKind::Other, "test")` if clippy complains.
+
+**Step 5 — Verify drift-guard works.** Add a temporary `FailureKind::Bogus` variant locally, run `cargo build -p tome`, observe the error pointing to `_ensure_failure_kind_all_exhaustive`, then revert. (This is a manual verification step — the executor should NOT commit the temporary variant; it's a confidence check that the sentinel actually catches drift. Document this in the SUMMARY as a one-line "drift-guard manually verified.")
+
+Run: `cargo test -p tome remove::tests::failure_kind_all remove::tests::remove_failure_new`
+  </action>
+  <verify>
+    <automated>cd /Users/martin/dev/opensource/tome && cargo build -p tome 2>&1 | tail -5 && cargo test -p tome remove::tests 2>&1 | tail -15 && cargo clippy -p tome --all-targets -- -D warnings 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "_ensure_failure_kind_all_exhaustive" crates/tome/src/remove.rs` returns at least 1 match.
+    - `rg -n "const _: \(\) = \{" crates/tome/src/remove.rs` returns at least 1 match (the const-assert block).
+    - `rg -n "FailureKind::ALL.len\(\) == 4" crates/tome/src/remove.rs` returns at least 1 match.
+    - `rg -n "debug_assert!\(path\.is_absolute" crates/tome/src/remove.rs` returns exactly 1 match.
+    - `rg -n "RemoveFailure::path must be absolute" crates/tome/src/remove.rs` returns exactly 1 match.
+    - `cargo test -p tome remove::tests::failure_kind_all_length_matches_variant_count` passes.
+    - `cargo test -p tome remove::tests::failure_kind_all_ordering_pinned` passes.
+    - `cargo test -p tome remove::tests::remove_failure_new_relative_path_panics_in_debug` passes.
+    - `cargo test -p tome remove::tests::remove_failure_new_absolute_path_succeeds` passes.
+    - `cargo test -p tome remove::tests::partial_failure_aggregates_symlink_error` still passes (existing test must not regress; would panic if any execute() call site passes a relative path).
+    - `cargo test -p tome remove::tests::partial_failure_aggregates_multiple_kinds` still passes (regression).
+    - `cargo build -p tome` is clean.
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+  </acceptance_criteria>
+  <done>
+    `_ensure_failure_kind_all_exhaustive` const fn + `const _: () = { assert!(...) };` block compile-enforce that `FailureKind::ALL` cannot drift from the enum. `RemoveFailure::new` carries `debug_assert!(path.is_absolute(), ...)`. 4 new unit tests pin the contract. Existing tests still pass.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Reorder `regen_warnings` after the success banner on the happy path (TEST-04)</name>
+  <files>crates/tome/src/lib.rs</files>
+  <read_first>
+    - crates/tome/src/lib.rs lines 449–478 (Command::Remove happy-path block)
+  </read_first>
+  <behavior>
+    Behavior is verified end-to-end via the `lib_rs_remove_handler_prints_success_banner_before_regen_warnings` source-order regression test added in Task 4. No unit test here — the call site is bare `println!`/`eprintln!` ordering which is meaningless without process-level stdout/stderr capture.
+  </behavior>
+  <action>
+**Reorder** the happy-path block in `Command::Remove` (`crates/tome/src/lib.rs` lines 449–478). Move the `for w in &regen_warnings { eprintln!(...) }` loop to AFTER the success-banner `println!`.
+
+Current:
+```rust
+// Save updated config
+config.save(&paths.config_path())?;
+manifest::save(&manifest, paths.config_dir())?;
+
+let (resolved_paths, mut regen_warnings) =
+    lockfile::resolved_paths_from_lockfile_cache(&config, &paths);
+let skills = discover::discover_all(&config, &resolved_paths, &mut regen_warnings)?;
+for w in &regen_warnings {
+    eprintln!("warning: {}", w);
+}
+let lockfile = lockfile::generate(&manifest, &skills);
+lockfile::save(&lockfile, paths.config_dir())?;
+
+// Success path — full cleanup completed with no failures.
+println!(
+    "\n{} Removed directory '{}': {} library entries, {} symlinks{}",
+    style("✓").green(), name, ...
+);
+```
+
+After (TEST-04 option a — deferred warnings):
+```rust
+// Save updated config
+config.save(&paths.config_path())?;
+manifest::save(&manifest, paths.config_dir())?;
+
+// Regenerate lockfile. Recover git-skill provenance offline from the
+// previous lockfile + on-disk cache so git-type directories are not
+// silently dropped during regen (#461 H1). Warnings collected here
+// are deferred until AFTER the success banner — see comment below.
+let (resolved_paths, mut regen_warnings) =
+    lockfile::resolved_paths_from_lockfile_cache(&config, &paths);
+let skills = discover::discover_all(&config, &resolved_paths, &mut regen_warnings)?;
+let lockfile = lockfile::generate(&manifest, &skills);
+lockfile::save(&lockfile, paths.config_dir())?;
+
+// Success banner FIRST (TEST-04 option a — deferred regen-warnings).
+// The banner is the user's anchor for "what just happened"; warnings
+// come after as a footnote. Without this ordering, multi-warning
+// regen output buries the green ✓ confirmation and the user has to
+// scroll up to find it. The deferred ordering is regression-tested by
+// `lib_rs_remove_handler_prints_success_banner_before_regen_warnings`
+// in tests/cli.rs.
+println!(
+    "\n{} Removed directory '{}': {} library entries, {} symlinks{}",
+    style("✓").green(),
+    name,
+    result.library_entries_removed,
+    result.symlinks_removed,
+    if result.git_cache_removed {
+        ", git cache"
+    } else {
+        ""
+    },
+);
+for w in &regen_warnings {
+    eprintln!("warning: {}", w);
+}
+```
+
+The reorder is purely textual — no logic change. The `regen_warnings` Vec is populated by `discover_all` BEFORE the banner prints, so the warning loop has all warnings ready when it runs.
+
+Run: `cargo build -p tome && cargo test -p tome --test cli`
+  </action>
+  <verify>
+    <automated>cd /Users/martin/dev/opensource/tome && cargo build -p tome 2>&1 | tail -5 && cargo test -p tome --test cli 2>&1 | tail -10</automated>
+  </verify>
+  <acceptance_criteria>
+    - In `crates/tome/src/lib.rs::Command::Remove` happy-path, the `println!("✓ Removed directory ...")` line MUST appear BEFORE the `for w in &regen_warnings { eprintln!("warning: {}", w); }` loop. Verify with this multi-line grep:
+      ```bash
+      rg -nU "Removed directory.*\n(.*\n){0,8}for w in &regen_warnings" crates/tome/src/lib.rs
+      ```
+      MUST return at least 1 match.
+    - `rg -nU "for w in &regen_warnings.*\n(.*\n){0,8}Removed directory" crates/tome/src/lib.rs` MUST return 0 matches (no instance of warnings BEFORE banner).
+    - `rg -n "TEST-04 option a" crates/tome/src/lib.rs` returns at least 1 match (decision documented in code).
+    - `cargo build -p tome` is clean.
+    - All existing `remove_*` integration tests in `tests/cli.rs` still pass.
+  </acceptance_criteria>
+  <done>
+    Happy-path success banner prints BEFORE regen_warnings on `tome remove`. Code comment in lib.rs cites TEST-04 option a. Existing test suite still green.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Update `remove_partial_failure_exits_nonzero_with_warning_marker` to assert success-banner-absence (TEST-01)</name>
+  <files>crates/tome/tests/cli.rs</files>
+  <read_first>
+    - crates/tome/tests/cli.rs lines 3375–3459 (existing test)
+  </read_first>
+  <behavior>
+    The existing test exercises the partial-failure path (chmod 0o500 on the target dir → DistributionSymlink failure during `tome remove`). After the chmod-restore, the test currently asserts:
+    1. exit non-success
+    2. stderr contains `⚠`
+    3. stderr contains `"operations failed"`
+    4. stderr contains `"remove completed with"`
+    5. stderr contains `"retained"` OR `"retry"`
+
+    Add (TEST-01 / P1):
+    6. stdout does NOT contain `"✓ Removed directory"` (the success banner string)
+    7. stderr does NOT contain `"✓ Removed directory"` (defense-in-depth)
+
+    The assertion uses the literal substring `"Removed directory"` (without the `✓` glyph) since console color codes are stripped by `NO_COLOR=1` and the styled `✓` may render as the bare character. Asserting on `"Removed directory"` (no glyph) is robust against both styled and unstyled output.
+  </behavior>
+  <action>
+In `crates/tome/tests/cli.rs`, locate `remove_partial_failure_exits_nonzero_with_warning_marker` (line 3377) and add two assertions immediately after the existing assertion block (after line 3458, before the closing brace at 3459):
+
+```rust
+let stdout = String::from_utf8_lossy(&output.stdout);
+// TEST-01 / P1: success banner MUST NOT appear on partial failure.
+// The banner string is "✓ Removed directory" but the leading glyph may
+// be styled with ANSI codes; we assert on "Removed directory" (no glyph)
+// for robustness against console color rendering.
+assert!(
+    !stdout.contains("Removed directory"),
+    "stdout must NOT contain success banner on partial failure; got: {stdout}",
+);
+assert!(
+    !stderr.contains("Removed directory"),
+    "stderr must NOT contain success banner on partial failure (defense-in-depth); got: {stderr}",
+);
+```
+
+Place these AFTER the existing `assert!(stderr.contains(...))` block but BEFORE the closing brace. The `stderr` variable is already in scope from line 3443 (`let stderr = String::from_utf8_lossy(&output.stderr);`); add a parallel `stdout` extraction.
+
+Run: `cargo test -p tome --test cli remove_partial_failure_exits_nonzero_with_warning_marker`
+  </action>
+  <verify>
+    <automated>cd /Users/martin/dev/opensource/tome && cargo test -p tome --test cli remove_partial_failure_exits_nonzero_with_warning_marker 2>&1 | tail -10</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "stdout must NOT contain success banner|stderr must NOT contain success banner" crates/tome/tests/cli.rs` returns at least 2 matches (one stdout, one stderr).
+    - `rg -n "!stdout\.contains\(\"Removed directory\"\)|!stderr\.contains\(\"Removed directory\"\)" crates/tome/tests/cli.rs` returns at least 2 matches.
+    - `cargo test -p tome --test cli remove_partial_failure_exits_nonzero_with_warning_marker` passes.
+    - `cargo test -p tome --test cli remove_partial_failure_does_not_save_disk_state` still passes (sibling test, regression).
+  </acceptance_criteria>
+  <done>
+    `remove_partial_failure_exits_nonzero_with_warning_marker` asserts the success banner is absent from BOTH stdout AND stderr. Test passes; sibling `remove_partial_failure_does_not_save_disk_state` regression-clean.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 4: Add `remove_retry_succeeds_after_failure_resolved` + `lib_rs_remove_handler_prints_success_banner_before_regen_warnings` (TEST-02, TEST-04 regression)</name>
+  <files>crates/tome/tests/cli.rs</files>
+  <read_first>
+    - crates/tome/tests/cli.rs lines 3375–3540 (existing partial-failure tests — fixture pattern to mirror)
+    - crates/tome/tests/cli.rs lines 1–80 (test helpers — `tome()`, `create_skill`, `remove_test_env`)
+    - crates/tome/src/lib.rs (the `Command::Remove` handler region, plus the Reassign and Fork handlers — all three contain `for w in &regen_warnings` loops; the source-order test must anchor to the Remove handler so it is not affected by Reassign/Fork ordering)
+  </read_first>
+  <behavior>
+    - Test 1 (`remove_retry_succeeds_after_failure_resolved`): TEST-02 / P2. End-to-end retention contract:
+      1. Set up source dir + target dir, `tome sync --no-triage` to prime.
+      2. chmod 0o500 the target dir.
+      3. `tome remove local --force` → expect exit failure, ⚠ marker, config entry preserved.
+      4. chmod 0o755 the target dir (restore).
+      5. `tome remove local --force` → expect exit success, success banner present.
+      6. Assert config entry for `local` is gone (`tome.toml` no longer contains `[directories.local]`).
+      7. Assert manifest no longer contains the `my-skill` entry.
+      8. Assert library dir for `my-skill` is gone (`<tome_home>/library/my-skill` does not exist).
+    - Test 2 (`lib_rs_remove_handler_prints_success_banner_before_regen_warnings`): TEST-04 / P4 regression. Source-order assertion: the `println!("Removed directory ...")` MUST appear earlier in `crates/tome/src/lib.rs` than the `for w in &regen_warnings` loop in the SAME `Command::Remove` handler region.
+
+      **Anchor design:** `lib.rs` contains THREE `for w in &regen_warnings` loops — one each in Remove, Reassign, and Fork handlers. A naïve `lib_rs.find("for w in &regen_warnings")` returns the FIRST match (currently Remove, but only by coincidence of source ordering). To prevent a false-positive failure if a future refactor reorders the handlers (e.g., moves Reassign above Remove, or introduces a new handler with its own regen_warnings loop above Remove), the test FIRST locates the byte index of `"Command::Remove"` and uses that as the search start for both `"Removed directory"` and `"for w in &regen_warnings"`. This guarantees the test fails ONLY when the Remove handler itself regresses.
+
+      We assert at the source level (file byte-position) rather than at the process-output level because stdout vs stderr ordering is determined by terminal interleaving, not by Rust flush order — assert_cmd captures them as separate streams and gives us no temporal ordering signal.
+
+      ```rust
+      #[test]
+      fn lib_rs_remove_handler_prints_success_banner_before_regen_warnings() {
+          // TEST-04 / P4 regression: pin the source-order in lib.rs Command::Remove
+          // happy-path. The success banner `println!("Removed directory ...")` MUST
+          // appear earlier in the file than the `for w in &regen_warnings ... eprintln!`
+          // loop. If a future refactor reorders these, this test fails.
+          //
+          // ANCHORING: lib.rs contains three `for w in &regen_warnings` loops —
+          // one each in Remove, Reassign, Fork handlers. Without anchoring to
+          // `Command::Remove` first, a future reorder of Reassign or Fork (or
+          // a new handler inserted above Remove with its own regen-warnings
+          // loop) could create a false-positive failure unrelated to Remove.
+          // We anchor all subsequent searches to `region_start` to keep the
+          // test focused on the Remove handler contract.
+
+          let lib_rs_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/lib.rs");
+          let lib_rs = std::fs::read_to_string(&lib_rs_path)
+              .unwrap_or_else(|e| panic!("lib.rs must exist at {}: {e}", lib_rs_path.display()));
+
+          let region_start = lib_rs
+              .find("Command::Remove")
+              .expect("lib.rs must contain `Command::Remove` handler");
+
+          let banner_offset = lib_rs[region_start..]
+              .find("Removed directory")
+              .expect("✓ Removed directory banner must appear inside Command::Remove region");
+          let banner_idx = region_start + banner_offset;
+
+          let warnings_offset = lib_rs[region_start..]
+              .find("for w in &regen_warnings")
+              .expect("regen_warnings loop must appear inside Command::Remove region");
+          let warnings_idx = region_start + warnings_offset;
+
+          assert!(
+              banner_idx < warnings_idx,
+              "TEST-04 option a: `Removed directory` banner (byte {}) MUST precede `for w in &regen_warnings` loop (byte {}) inside the Command::Remove handler region (starts at byte {})",
+              banner_idx,
+              warnings_idx,
+              region_start,
+          );
+      }
+      ```
+
+      This lives in `tests/cli.rs` for locality with the other `remove_*` tests. It runs in <10ms with no fixture cost.
+
+      The TEST-02 retry test stays as the integration test it should be.
+  </behavior>
+  <action>
+**Step 1 — Add `remove_retry_succeeds_after_failure_resolved`** to `crates/tome/tests/cli.rs` immediately after `remove_partial_failure_does_not_save_disk_state` (~line 3540). Mirror the fixture pattern from the existing test:
+
+```rust
+#[cfg(unix)]
+#[test]
+fn remove_retry_succeeds_after_failure_resolved() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // TEST-02 / P2: end-to-end I2/I3 retention contract.
+    //   1. Partial failure → config entry + manifest preserved (existing v0.8 contract)
+    //   2. User fixes the underlying condition (chmod 0o755)
+    //   3. Second `tome remove` succeeds, leaves NO leftover state
+    //
+    // Without this test, the retry path is only exercised by manual UAT.
+    // A future refactor that mutates config/manifest on the failure path
+    // (regressing #461 H2) would silently break retry — the second
+    // `tome remove` would fail with "directory not found in config".
+
+    let tmp = TempDir::new().unwrap();
+    let skills_dir = tmp.path().join("skills");
+    create_skill(&skills_dir, "my-skill");
+
+    let target_dir = tmp.path().join("target");
+    std::fs::create_dir_all(&target_dir).unwrap();
+
+    remove_test_env(
+        &tmp,
+        &format!(
+            "[directories.local]\npath = \"{}\"\ntype = \"directory\"\nrole = \"source\"\n\n[directories.test-target]\npath = \"{}\"\ntype = \"directory\"\nrole = \"target\"\n",
+            skills_dir.display(),
+            target_dir.display()
+        ),
+    );
+
+    // Prime: sync to wire library + target symlink.
+    tome()
+        .args(["--tome-home", tmp.path().to_str().unwrap(), "sync", "--no-triage"])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+    assert!(target_dir.join("my-skill").exists(), "fixture: target symlink must exist after sync");
+
+    // Step 1 — partial failure: chmod 0o500 on target dir.
+    std::fs::set_permissions(&target_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+    let first = tome()
+        .args(["--tome-home", tmp.path().to_str().unwrap(), "remove", "local", "--force"])
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+    assert!(!first.status.success(), "first remove must fail on chmod 0o500");
+    let first_stderr = String::from_utf8_lossy(&first.stderr);
+    assert!(first_stderr.contains("⚠"), "first remove stderr missing ⚠ marker: {first_stderr}");
+
+    // Step 1.5 — assert config entry preserved (I2 retention).
+    let config_after_fail = std::fs::read_to_string(tmp.path().join("tome.toml")).unwrap();
+    assert!(
+        config_after_fail.contains("[directories.local]"),
+        "config entry for 'local' must be preserved on partial failure; got: {config_after_fail}"
+    );
+
+    // Step 2 — user fixes the underlying cause.
+    std::fs::set_permissions(&target_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    // Step 3 — retry: second `tome remove` should succeed cleanly.
+    let second = tome()
+        .args(["--tome-home", tmp.path().to_str().unwrap(), "remove", "local", "--force"])
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+    assert!(
+        second.status.success(),
+        "retry remove must succeed after chmod restore; stderr: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    let second_stdout = String::from_utf8_lossy(&second.stdout);
+    assert!(
+        second_stdout.contains("Removed directory"),
+        "retry stdout must contain success banner; got: {second_stdout}"
+    );
+
+    // Step 4 — assert clean state: no config entry, no manifest entry, no library dir.
+    let config_after_success = std::fs::read_to_string(tmp.path().join("tome.toml")).unwrap();
+    assert!(
+        !config_after_success.contains("[directories.local]"),
+        "config entry for 'local' must be removed after retry success; got: {config_after_success}"
+    );
+
+    let manifest_path = tmp.path().join(".tome-manifest.json");
+    if manifest_path.exists() {
+        let manifest = std::fs::read_to_string(&manifest_path).unwrap();
+        assert!(
+            !manifest.contains("\"my-skill\""),
+            "manifest must not contain my-skill after retry success; got: {manifest}"
+        );
+    }
+
+    let library_skill = tmp.path().join("library").join("my-skill");
+    assert!(
+        !library_skill.exists(),
+        "library dir for my-skill must be gone after retry success; still exists at {}",
+        library_skill.display()
+    );
+}
+```
+
+**Step 2 — Add `lib_rs_remove_handler_prints_success_banner_before_regen_warnings`** in the same file (place near the other `remove_*` tests, ~line 3540 after the test from Step 1). The test ANCHORS its `String::find()` searches to the `Command::Remove` handler region in `lib.rs` so a future reorder of the Reassign or Fork handlers (each of which contains its own `for w in &regen_warnings` loop) cannot create a false-positive failure unrelated to the Remove ordering contract:
+
+```rust
+#[test]
+fn lib_rs_remove_handler_prints_success_banner_before_regen_warnings() {
+    // TEST-04 / P4 regression: pin the source-order in lib.rs Command::Remove
+    // happy-path. The success banner `println!("Removed directory ...")` MUST
+    // appear earlier in the file than the `for w in &regen_warnings ... eprintln!`
+    // loop. If a future refactor reorders these, this test fails.
+    //
+    // ANCHORING: lib.rs contains three `for w in &regen_warnings` loops —
+    // one each in Remove, Reassign, Fork handlers. Without anchoring to
+    // `Command::Remove` first, a future reorder of Reassign or Fork (or
+    // a new handler inserted above Remove with its own regen-warnings
+    // loop) could create a false-positive failure unrelated to Remove.
+    // We anchor all subsequent searches to `region_start` to keep the
+    // test focused on the Remove handler contract.
+    //
+    // We assert at the source level (file byte-position) rather than at the
+    // process-output level because stdout vs stderr ordering is determined
+    // by terminal interleaving, not by Rust flush order — assert_cmd captures
+    // them as separate streams and gives us no temporal ordering signal.
+
+    let lib_rs_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/lib.rs");
+    let lib_rs = std::fs::read_to_string(&lib_rs_path)
+        .unwrap_or_else(|e| panic!("lib.rs must exist at {}: {e}", lib_rs_path.display()));
+
+    let region_start = lib_rs
+        .find("Command::Remove")
+        .expect("lib.rs must contain `Command::Remove` handler");
+
+    let banner_offset = lib_rs[region_start..]
+        .find("Removed directory")
+        .expect("✓ Removed directory banner must appear inside Command::Remove region");
+    let banner_idx = region_start + banner_offset;
+
+    let warnings_offset = lib_rs[region_start..]
+        .find("for w in &regen_warnings")
+        .expect("regen_warnings loop must appear inside Command::Remove region");
+    let warnings_idx = region_start + warnings_offset;
+
+    assert!(
+        banner_idx < warnings_idx,
+        "TEST-04 option a: `Removed directory` banner (byte {}) MUST precede `for w in &regen_warnings` loop (byte {}) inside the Command::Remove handler region (starts at byte {})",
+        banner_idx,
+        warnings_idx,
+        region_start,
+    );
+}
+```
+
+Run:
+```bash
+cargo test -p tome --test cli remove_retry_succeeds_after_failure_resolved
+cargo test -p tome --test cli lib_rs_remove_handler_prints_success_banner_before_regen_warnings
+```
+  </action>
+  <verify>
+    <automated>cd /Users/martin/dev/opensource/tome && cargo test -p tome --test cli remove_retry_succeeds_after_failure_resolved 2>&1 | tail -10 && cargo test -p tome --test cli lib_rs_remove_handler_prints_success_banner_before_regen_warnings 2>&1 | tail -10</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "fn remove_retry_succeeds_after_failure_resolved" crates/tome/tests/cli.rs` returns exactly 1 match.
+    - `rg -n "fn lib_rs_remove_handler_prints_success_banner_before_regen_warnings" crates/tome/tests/cli.rs` returns exactly 1 match.
+    - `rg -n "Command::Remove" crates/tome/tests/cli.rs` returns at least 1 match (the anchor literal in the source-order test).
+    - `rg -n "region_start" crates/tome/tests/cli.rs` returns at least 3 matches (variable declaration + 2 reuses for banner_idx and warnings_idx — proves the anchoring shape was implemented).
+    - `cargo test -p tome --test cli remove_retry_succeeds_after_failure_resolved` passes.
+    - `cargo test -p tome --test cli lib_rs_remove_handler_prints_success_banner_before_regen_warnings` passes.
+    - `cargo test -p tome --test cli remove_partial_failure_exits_nonzero_with_warning_marker` still passes (regression).
+    - `cargo test -p tome --test cli remove_partial_failure_does_not_save_disk_state` still passes (regression).
+    - `make ci` passes.
+  </acceptance_criteria>
+  <done>
+    `remove_retry_succeeds_after_failure_resolved` exercises the I2/I3 retention contract end-to-end (partial failure → fix → retry succeeds → no leftover state). `lib_rs_remove_handler_prints_success_banner_before_regen_warnings` pins the deferred-warnings ordering at source-byte level, anchored to the `Command::Remove` handler region so reorders of Reassign/Fork cannot create a false positive. Existing partial-failure tests still pass.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- `cargo test -p tome remove::tests::failure_kind_all_length_matches_variant_count` — passes.
+- `cargo test -p tome remove::tests::failure_kind_all_ordering_pinned` — passes.
+- `cargo test -p tome remove::tests::remove_failure_new_relative_path_panics_in_debug` — passes.
+- `cargo test -p tome remove::tests::remove_failure_new_absolute_path_succeeds` — passes.
+- `cargo test -p tome --test cli remove_partial_failure_exits_nonzero_with_warning_marker` — passes (with new banner-absence asserts).
+- `cargo test -p tome --test cli remove_retry_succeeds_after_failure_resolved` — passes (new e2e test).
+- `cargo test -p tome --test cli lib_rs_remove_handler_prints_success_banner_before_regen_warnings` — passes (source-order regression, anchored to Command::Remove region).
+- `cargo test -p tome --test cli remove_partial_failure_does_not_save_disk_state` — passes (regression).
+- `make ci` — clean.
+- `rg -nU "Removed directory.*\\n(.*\\n){0,8}for w in &regen_warnings" crates/tome/src/lib.rs` — at least 1 match.
+- `rg -nU "for w in &regen_warnings.*\\n(.*\\n){0,8}Removed directory" crates/tome/src/lib.rs` — 0 matches (within the Command::Remove region — Reassign / Fork are unaffected and may legally have warnings before/after their own banners).
+</verification>
+
+<success_criteria>
+- `FailureKind::ALL` cannot drift from the enum: `_ensure_failure_kind_all_exhaustive` const fn forces a compile error if a new variant is added without updating ALL (POLISH-04 option c).
+- `RemoveFailure::new` carries `debug_assert!(path.is_absolute(), ...)` (POLISH-05 option a).
+- `tome remove` happy-path success banner appears BEFORE the `regen_warnings` print loop in `lib.rs` (TEST-04 option a — deferred warnings).
+- `remove_partial_failure_exits_nonzero_with_warning_marker` asserts the success banner is absent from BOTH stdout AND stderr on partial failure (TEST-01 / P1).
+- `remove_retry_succeeds_after_failure_resolved` exercises the full I2/I3 retention contract: partial failure preserves config + manifest → user fixes condition → retry succeeds with no leftover state (TEST-02 / P2).
+- `lib_rs_remove_handler_prints_success_banner_before_regen_warnings` pins the source-byte order so a future reorder regression is caught at test time. The test ANCHORS its searches to the `Command::Remove` handler region so reorders of unrelated handlers (Reassign / Fork — each with its own regen_warnings loop) cannot create a false-positive failure (TEST-04 regression guard).
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/10-phase-8-review-tail/10-02-SUMMARY.md` recording:
+- POLISH-04 option chosen: (c) exhaustive-match sentinel — `_ensure_failure_kind_all_exhaustive` + `const _: () = { assert!(...) }`.
+- POLISH-05 option chosen: (a) keep `new()` + add `debug_assert!`.
+- TEST-04 option chosen: (a) deferred warnings (success banner first).
+- New test names (4 in remove::tests, 2 in tests/cli.rs).
+- Updated test name (`remove_partial_failure_exits_nonzero_with_warning_marker` gains banner-absence asserts).
+- Drift-guard manual verification: confirm a temporary `FailureKind::Bogus` triggers the compile error (revert before commit).
+- One-line confirmation: POLISH-04 + POLISH-05 + TEST-01 + TEST-02 + TEST-04 closed.
+</output>

--- a/.planning/phases/10-phase-8-review-tail/10-03-arboard-pin-and-relocate-deadcode-PLAN.md
+++ b/.planning/phases/10-phase-8-review-tail/10-03-arboard-pin-and-relocate-deadcode-PLAN.md
@@ -1,0 +1,475 @@
+---
+phase: 10-phase-8-review-tail
+plan: 03
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - Cargo.toml
+  - crates/tome/src/relocate.rs
+autonomous: true
+requirements: [POLISH-06, TEST-05]
+issue: "https://github.com/MartinP7r/tome/issues/463 + https://github.com/MartinP7r/tome/issues/462"
+
+must_haves:
+  truths:
+    - "`arboard` is pinned to a patch-version range (`>=3.6, <3.7`, matching the current Cargo.lock-resolved 3.6.1) in the workspace `Cargo.toml`, with a code comment documenting the bump-review policy: \"review CHANGELOG.md for new arboard::Error variants before bumping; the browse module match-arms must remain exhaustive.\""
+    - "`SkillMoveEntry.source_path` is REMOVED from `crates/tome/src/relocate.rs` (POLISH-05 / TEST-05 option a — remove). The `#[allow(dead_code)]` attribute is also gone."
+    - "Removing `source_path` does NOT regress the SAFE-03 warning surface: `provenance_from_link_result` is still invoked from the `plan()` body for managed skills (the symlink-read warning fires), but its return value is now logged inline and discarded instead of being stored on the SkillMoveEntry. The SAFE-03 unit test `provenance_from_link_result_warns_and_returns_none_on_err` must still pass."
+    - "Three pre-existing tests in `relocate.rs::tests` that ASSERT on `SkillMoveEntry.source_path` (lines 582, 804, 918–924 as of the time of writing) are surgically updated: the SAFE-03 corrupt-symlink integration test stops asserting on the removed field; the standalone `provenance_from_link_result_warns_and_returns_none_on_err` (line 940) becomes the sole regression guard for the SAFE-03 stderr-warning contract."
+  artifacts:
+    - path: "Cargo.toml"
+      provides: "Workspace `[workspace.dependencies]` arboard line is pinned to a patch range (e.g., `\">=3.6, <3.7\"` for current Cargo.lock 3.6.1) instead of `\"3\"`. A `#` comment above the line explains the bump-review policy."
+      contains: "arboard"
+    - path: "crates/tome/src/relocate.rs"
+      provides: "`SkillMoveEntry` no longer has a `source_path: Option<PathBuf>` field. `#[allow(dead_code)]` annotation is removed. `provenance_from_link_result` is retained — called for its stderr-warning side effect with `let _ = ...` discarding the return. Three test-side assertions on `source_path` (lines 582, 804, 918–924) are deleted or replaced."
+      contains: "SkillMoveEntry"
+  key_links:
+    - from: "Cargo.toml [workspace.dependencies]"
+      to: "arboard patch-version pin + comment"
+      via: "version range narrows from `\"3\"` to `\">=3.6, <3.7\"` (matching current Cargo.lock-resolved 3.6.1)"
+      pattern: "arboard.*=.*\">=3"
+    - from: "crates/tome/src/relocate.rs SkillMoveEntry"
+      to: "no source_path field"
+      via: "field declaration removed"
+      pattern: "SkillMoveEntry"
+    - from: "crates/tome/src/relocate.rs"
+      to: "no #[allow(dead_code)]"
+      via: "annotation removed"
+      pattern: "allow\\(dead_code\\)"
+---
+
+<objective>
+Pin `arboard` to a patch-version range with a documented bump-review policy in the workspace `Cargo.toml`, and remove the dead `SkillMoveEntry.source_path` field from `crates/tome/src/relocate.rs` along with its `#[allow(dead_code)]` attribute.
+
+This is the cleanup bundle — two small, independent items that don't fit the TUI or Remove buckets. Both are blast-radius-of-1: one Cargo.toml edit, one Rust struct-field deletion plus three corresponding test-assertion deletions.
+
+**Closes:** POLISH-06 (D6, arboard drift hygiene), TEST-05 (P5, dead `source_path` field).
+
+**Decisions pinned:**
+- POLISH-06 option: **(a) patch-version pin** (`">=3.6, <3.7"` style, NOT a `cfg(test)` enum-growth canary). Pin is simpler, more obvious, and the bump-review comment captures the same "audit when this changes" intent without test-runtime overhead.
+- TEST-05 option: **(a) REMOVE the field** (NOT wire it into `copy_library`/`recreate_target_symlinks`). Wiring it would mean using the symlink target to validate the recreated managed-skill symlink — but `recreate_target_symlinks` already only re-points symlinks that lived in DISTRIBUTION dirs (`recreate_target_symlinks` operates on `plan.targets`, not `plan.skills`). The library-side managed symlinks are recreated implicitly when `copy_library` walks the source tree and copies symlinks via `read_link` + `os::unix::fs::symlink` (lines 419–424). The `source_path` would be redundant with that read. So: delete the field.
+
+Purpose: Remove future-bump silent-breakage hazard for `arboard::Error` variant additions; eliminate `#[allow(dead_code)]` from `relocate.rs` so the file passes future "no-allow-dead-code" lints cleanly.
+
+Output: 2-line Cargo.toml edit, ~10-line struct/import cleanup in relocate.rs, three test-assertion deletions.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/REQUIREMENTS.md
+
+@Cargo.toml
+@crates/tome/src/relocate.rs
+@crates/tome/src/browse/app.rs
+
+<interfaces>
+<!-- Key types and contracts the executor needs. Extracted from codebase. -->
+
+Current `Cargo.toml` (lines 13–15):
+```toml
+[workspace.dependencies]
+anyhow = "1"
+arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
+```
+
+After POLISH-06 (option a — patch pin, current Cargo.lock resolves to 3.6.1):
+```toml
+[workspace.dependencies]
+anyhow = "1"
+# Pin arboard to a patch-version range. Bump-review policy: when
+# bumping the upper bound (e.g., `<3.7` → `<3.8`), review CHANGELOG.md
+# for new `arboard::Error` variants. The match-arms in
+# `crates/tome/src/browse/app.rs::execute_action(CopyPath)` and the
+# `try_clipboard_set_text_with_retry` helper must remain exhaustive.
+# Adding a new variant unobserved is a silent UX regression — the
+# fall-through `format!("Could not copy: {other}")` branch hides the
+# semantic of the new error from the user (POLISH-06 / #463 D6).
+arboard = { version = ">=3.6, <3.7", default-features = false, features = ["wayland-data-control"] }
+```
+
+**Pin range selection:** check the current `Cargo.lock` for the resolved arboard version. Cargo.lock currently resolves to `3.6.1` — pin `">=3.6, <3.7"`. If a future arboard 3.7.x lands and Cargo.lock has been bumped before this plan executes, widen accordingly to `">=3.7, <3.8"`. The range MUST allow the current resolved version (so `cargo build` doesn't break) but block minor bumps. Use:
+```bash
+rg "^name = \"arboard\"" Cargo.lock -A 1 | head -5
+```
+
+**Why range vs `~3.6`:** `~3.6` is equivalent to `>=3.6, <3.7` (the patch range we want). Either form works; use the explicit `>=N.M, <N.(M+1)` form because it makes the bump-review intent literally readable in the comment.
+
+Current `crates/tome/src/relocate.rs::SkillMoveEntry` (lines 32–39):
+```rust
+#[derive(Debug)]
+pub(crate) struct SkillMoveEntry {
+    pub name: SkillName,
+    pub is_managed: bool,
+    /// For managed skills, the original symlink target (external source path).
+    #[allow(dead_code)]
+    pub source_path: Option<PathBuf>,
+}
+```
+
+After TEST-05 (option a — remove):
+```rust
+#[derive(Debug)]
+pub(crate) struct SkillMoveEntry {
+    pub name: SkillName,
+    pub is_managed: bool,
+}
+```
+
+The `plan()` body currently constructs `SkillMoveEntry { name, is_managed, source_path }`. After removal, drop `source_path` from the construction (line ~115).
+
+The `provenance_from_link_result` helper (lines 316–327) is currently called from the `plan()` body to populate `source_path`. After `source_path` is removed, the helper has no consumer:
+- **Option α:** drop the helper too. Cleaner; one fewer dead function.
+- **Option β:** keep the helper but call it for its SIDE EFFECT (the stderr warning on Err) and discard the return value with `let _ =`.
+
+The SAFE-03 contract (#449) requires that an unreadable symlink produces a stderr warning during `relocate plan`. If we drop the helper entirely, the warning is gone and SAFE-03 regresses.
+
+**Decision: option β.** Keep `provenance_from_link_result` (the warning is SAFE-03's whole point); discard its return value. Update its doc comment to reflect that the return value is no longer used in the relocate path.
+
+Updated plan() body in relocate.rs (~lines 88–117):
+```rust
+for (name, entry) in manifest.iter() {
+    if entry.managed {
+        // SAFE-03 / #449: surface read_link errors as stderr warnings during
+        // relocate planning so the user can diagnose unreadable symlinks
+        // before commit. The provenance return value is no longer stored
+        // on SkillMoveEntry (POLISH-05 / TEST-05 option a) — we call this
+        // for its side effect only.
+        let link_path = old_library_dir.join(name.as_str());
+        if link_path.is_symlink() {
+            let _ = provenance_from_link_result(std::fs::read_link(&link_path), &link_path);
+        }
+    }
+
+    skills.push(SkillMoveEntry {
+        name: name.clone(),
+        is_managed: entry.managed,
+    });
+}
+```
+
+The `let _ = ...` makes the discard explicit; clippy is happy.
+
+**Imports check:** `use std::path::PathBuf` may now have fewer consumers in relocate.rs after the field removal. Run `cargo clippy` and trim if it warns about unused imports. (`PathBuf` is likely still used elsewhere — `RelocatePlan.old_library_dir: PathBuf`, etc.)
+
+**Pre-existing tests that ASSERT on `source_path`** (verified by reading `crates/tome/src/relocate.rs`):
+
+```text
+582: assert!(p.skills[0].source_path.is_none());
+804: assert!(managed.source_path.is_some());
+918–924: assert!(corrupt.source_path.is_none(), "source_path must be None ...", corrupt.source_path);
+```
+
+These three sites do NOT construct `SkillMoveEntry` literally — they assert on the field of an entry that `plan()` already built. After the field is removed, all three call sites compile-fail with `error[E0609]: no field 'source_path' on type 'SkillMoveEntry'`. Task 2 / Step 5 below specifies the surgical fix for each site.
+
+The standalone `provenance_from_link_result_warns_and_returns_none_on_err` test (around line 940) drives `provenance_from_link_result` directly with a synthetic `io::Error` and does NOT touch `SkillMoveEntry`. It continues to verify the SAFE-03 stderr-warning contract and is the actual regression guard once the integration-style assertion at lines 918–924 is gone.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Pin `arboard` to a patch-version range with bump-review comment (POLISH-06)</name>
+  <files>Cargo.toml</files>
+  <read_first>
+    - Cargo.toml lines 13–16 (workspace.dependencies arboard line)
+    - Cargo.lock (resolved arboard version — determines the lower bound of the pin range)
+  </read_first>
+  <action>
+**Step 1 — Determine current resolved arboard version**:
+
+```bash
+rg "^name = \"arboard\"" -A 1 Cargo.lock | head -10
+```
+
+Look for the line `version = "3.X.Y"`. Note the `3.X` major.minor — that's the lower bound. The upper bound is `3.(X+1)` exclusive. As of the time of writing, the resolved version is `3.6.1`, so the pin is `">=3.6, <3.7"`. Use whatever Cargo.lock currently shows.
+
+**Step 2 — Edit `Cargo.toml`**. Replace line 15:
+
+```toml
+arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
+```
+
+With (substituting `3.X` for the resolved minor — `3.6` for current Cargo.lock 3.6.1):
+
+```toml
+# Pin arboard to a patch-version range. Bump-review policy: when bumping
+# the upper bound, review CHANGELOG.md for new `arboard::Error` variants.
+# The match-arms in `crates/tome/src/browse/app.rs::execute_action`
+# (CopyPath arm) and `try_clipboard_set_text_with_retry` must remain
+# exhaustive — a new variant unobserved is a silent UX regression because
+# the fall-through `Could not copy: {other}` branch hides the semantic
+# of the new error from the user. Closes #463 / POLISH-06 (D6).
+arboard = { version = ">=3.6, <3.7", default-features = false, features = ["wayland-data-control"] }
+```
+
+**Step 3 — Verify the pin doesn't break the build**:
+
+```bash
+cargo build -p tome 2>&1 | tail -10
+```
+
+If it fails because the resolved version is outside the new range, widen the range to include the resolved version. The pin should match what's already in `Cargo.lock`.
+
+**Step 4 — Verify no `arboard` 4.x or other major bumps slip through**:
+
+```bash
+cargo update -p arboard --dry-run 2>&1 | head -20
+```
+
+Should show "no updates available" or only patch updates within the pinned range.
+
+**Step 5 — Verify `crates/tome/Cargo.toml` line 16** still uses `arboard = { workspace = true }` — no change needed there. The pin lives in the workspace manifest only.
+  </action>
+  <verify>
+    <automated>cd /Users/martin/dev/opensource/tome && cargo build -p tome 2>&1 | tail -5 && cargo clippy -p tome --all-targets -- -D warnings 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "^arboard\\s*=\\s*\\{" Cargo.toml` returns exactly 1 match.
+    - `rg -n "arboard.*\">=3" Cargo.toml` returns exactly 1 match (pin uses an explicit `>=N.M` lower bound).
+    - `rg -n "arboard.*<3" Cargo.toml` returns exactly 1 match (pin uses an explicit `<N.(M+1)` upper bound).
+    - `rg -n "Bump-review policy" Cargo.toml` returns exactly 1 match (comment present).
+    - `rg -n "match-arms.*exhaustive|exhaustive.*match-arms" Cargo.toml` returns at least 1 match (comment names the consumer site).
+    - `rg -n "POLISH-06|#463" Cargo.toml` returns at least 1 match (traceability).
+    - `cargo build -p tome` is clean.
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+    - `Cargo.lock`'s arboard version is unchanged from before the edit (the pin must not force a downgrade or upgrade — it should accept the currently-resolved version).
+  </acceptance_criteria>
+  <done>
+    `arboard` workspace dependency is pinned to a patch-version range with a multi-line comment documenting the bump-review policy and citing POLISH-06 / #463 D6. Build and clippy clean. Cargo.lock unchanged.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Remove dead `SkillMoveEntry.source_path` field + `#[allow(dead_code)]` (TEST-05)</name>
+  <files>crates/tome/src/relocate.rs</files>
+  <read_first>
+    - crates/tome/src/relocate.rs lines 30–40 (SkillMoveEntry struct decl)
+    - crates/tome/src/relocate.rs lines 85–120 (plan() body — source_path construction)
+    - crates/tome/src/relocate.rs lines 305–328 (provenance_from_link_result — keep, update doc)
+    - crates/tome/src/relocate.rs lines 575–585 (first plan-level test asserting source_path.is_none() at line 582)
+    - crates/tome/src/relocate.rs lines 795–810 (execute_preserves_managed_symlinks — asserts source_path.is_some() at line 804)
+    - crates/tome/src/relocate.rs lines 905–945 (managed_symlink_unreadable_records_no_provenance + provenance_from_link_result_warns_and_returns_none_on_err)
+  </read_first>
+  <action>
+**Step 1 — Remove the `source_path` field from `SkillMoveEntry`** (lines 32–39 in `crates/tome/src/relocate.rs`):
+
+Replace:
+```rust
+/// A single skill that will be moved.
+#[derive(Debug)]
+pub(crate) struct SkillMoveEntry {
+    pub name: SkillName,
+    pub is_managed: bool,
+    /// For managed skills, the original symlink target (external source path).
+    #[allow(dead_code)]
+    pub source_path: Option<PathBuf>,
+}
+```
+
+With:
+```rust
+/// A single skill that will be moved during a `tome relocate`.
+#[derive(Debug)]
+pub(crate) struct SkillMoveEntry {
+    pub name: SkillName,
+    /// True for managed skills (library symlink → external source dir).
+    /// Used by `copy_library` to preserve the symlink shape during the
+    /// move (lines ~419–424).
+    pub is_managed: bool,
+}
+```
+
+**Step 2 — Update `plan()` body** (lines 85–117). Replace the current block:
+
+```rust
+let source_path = if entry.managed {
+    let link_path = old_library_dir.join(name.as_str());
+    if link_path.is_symlink() {
+        provenance_from_link_result(std::fs::read_link(&link_path), &link_path)
+    } else {
+        None
+    }
+} else {
+    None
+};
+
+skills.push(SkillMoveEntry {
+    name: name.clone(),
+    is_managed: entry.managed,
+    source_path,
+});
+```
+
+With:
+
+```rust
+// SAFE-03 / #449: managed-skill symlinks are checked here so an unreadable
+// symlink produces a stderr warning during plan() instead of silently
+// disappearing during execute(). The provenance Option<PathBuf> is no
+// longer stored on SkillMoveEntry (TEST-05 / POLISH-05 option a — removed
+// as dead code). We call provenance_from_link_result for its stderr
+// side effect only and discard the return value.
+if entry.managed {
+    let link_path = old_library_dir.join(name.as_str());
+    if link_path.is_symlink() {
+        let _ = provenance_from_link_result(std::fs::read_link(&link_path), &link_path);
+    }
+}
+
+skills.push(SkillMoveEntry {
+    name: name.clone(),
+    is_managed: entry.managed,
+});
+```
+
+**Step 3 — Update `provenance_from_link_result` doc comment** (lines 305–315) to reflect the new "called for side effect only" usage:
+
+```rust
+/// Translate a `read_link` result into a provenance `Option<PathBuf>`, warning
+/// on Err instead of silently dropping (SAFE-03 / #449).
+///
+/// **Note (TEST-05 / POLISH-05 option a):** the return value is no longer
+/// consumed by `relocate::plan()` — `SkillMoveEntry.source_path` was removed
+/// as dead code. The function is retained because its primary purpose is
+/// the stderr WARNING on the Err arm; the `Option<PathBuf>` return shape is
+/// kept for testability (the SAFE-03 unit test asserts `None` on the Err
+/// path). Future consumers (e.g., a debug tool that needs provenance) can
+/// use the return value; current callers `let _ = ...` it.
+fn provenance_from_link_result(raw: std::io::Result<PathBuf>, link_path: &Path) -> Option<PathBuf> {
+    match raw {
+        Ok(raw_target) => Some(resolve_symlink_target(link_path, &raw_target)),
+        Err(e) => {
+            eprintln!(
+                "warning: could not read symlink at {}: {e}",
+                link_path.display()
+            );
+            None
+        }
+    }
+}
+```
+
+The function body is UNCHANGED — only the doc comment is updated.
+
+**Step 4 — Check `mod tests` for literal `SkillMoveEntry { ... }` constructions** (line 519 onwards):
+
+```bash
+rg -n "SkillMoveEntry\\s*\\{" crates/tome/src/relocate.rs
+```
+
+If matches exist with `source_path: ...` set explicitly in a struct literal, remove the field from those literal constructions. Based on a current scan of the file, NO test constructs `SkillMoveEntry` literally — tests drive `plan()` and let it build entries. So this step is expected to be a no-op grep that confirms there's nothing to fix here. Proceed to Step 5.
+
+**Step 5 — Delete the existing `source_path` ASSERTIONS in `relocate.rs::tests`.**
+
+Three pre-existing tests assert on `SkillMoveEntry.source_path` (NOT construct it). After Step 1 removes the field, all three compile-fail with `error[E0609]: no field 'source_path' on type 'SkillMoveEntry'`. Each must be fixed by deleting (or replacing) the assertion line(s). Locations are stable as of the time of writing:
+
+- **Line 582** (in the first plan-level test, around the `assert_eq!(p.skills.len(), 1)` block at lines 579–582): delete the line
+  ```rust
+  assert!(p.skills[0].source_path.is_none());
+  ```
+  No replacement needed — the surrounding `assert!(!p.skills[0].is_managed);` at line 581 already covers the unmanaged-classification intent. (For an unmanaged skill, `source_path` was always `None`; the assertion was redundant with the `is_managed` check.)
+
+- **Line 804** (in `execute_preserves_managed_symlinks`): delete the line
+  ```rust
+  assert!(managed.source_path.is_some());
+  ```
+  Replace with `assert!(managed.is_managed);` to keep an assertion at that spot. (Preserves the test's "we found the managed entry" verification — the surrounding `find` filters by name only; the `is_managed` assertion confirms the entry was correctly classified by `plan()`.)
+
+- **Lines 918–924** (in `managed_symlink_unreadable_records_no_provenance` — the SAFE-03 corrupt-symlink integration test): delete the entire block
+  ```rust
+  assert!(
+      corrupt.source_path.is_none(),
+      "source_path must be None when the symlink cannot be read (either via the new \
+       read_link Err arm or the outer is_symlink-false branch — both uphold SAFE-03's \
+       contract); got {:?}",
+      corrupt.source_path
+  );
+  ```
+  No replacement needed — the SAFE-03 stderr-warning contract is preserved by the standalone `provenance_from_link_result_warns_and_returns_none_on_err` test (around line 940), which directly tests `provenance_from_link_result` with a synthetic `io::Error`. That test does NOT touch `SkillMoveEntry` and continues to verify the warning side-effect — making it the actual SAFE-03 regression guard. The deleted block was a redundant integration-style assertion on `source_path` and is no longer meaningful once that field is gone.
+
+  The surrounding `assert!(corrupt.is_managed, "corrupt-skill manifest entry is managed");` block (lines 914–917) STAYS — it still pins that the manifest entry was correctly classified as managed even when the symlink could not be read.
+
+**Run `cargo build -p tome --tests` after each deletion** to confirm the build is clean. Then run:
+
+```bash
+cargo test -p tome relocate::tests
+```
+
+The `provenance_from_link_result_warns_and_returns_none_on_err` test (line ~940) MUST still pass — the function's return shape is unchanged. The `managed_symlink_unreadable_records_no_provenance` test continues to pass because its remaining assertions (existence of the entry in `plan.skills`, `is_managed == true`) do not touch the removed field.
+
+**Step 6 — Verify no other consumer of `source_path` exists** in the crate:
+
+```bash
+rg -n "source_path" crates/tome/src/
+```
+
+After Steps 1–5, this should return 0 matches in `relocate.rs`. Pre-existing matches in OTHER files (unlikely — they would refer to a different `source_path` field, not the one on `SkillMoveEntry`) need their own treatment if found; document them in the SUMMARY as out-of-scope or fix inline.
+
+**Step 7 — Verify `#[allow(dead_code)]` is gone from `relocate.rs`**:
+
+```bash
+rg -n "#\\[allow\\(dead_code\\)\\]" crates/tome/src/relocate.rs
+```
+
+Should return 0 matches. (The `RemovePlan::is_empty` `#[allow(dead_code)]` at `crates/tome/src/remove.rs:36` is a separate item not in scope for this task — leave it alone.)
+
+Run: `cargo build -p tome && cargo test -p tome relocate::tests && cargo clippy -p tome --all-targets -- -D warnings`
+  </action>
+  <verify>
+    <automated>cd /Users/martin/dev/opensource/tome && cargo build -p tome --tests 2>&1 | tail -5 && cargo test -p tome relocate::tests 2>&1 | tail -10 && cargo clippy -p tome --all-targets -- -D warnings 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -c "source_path" crates/tome/src/relocate.rs` returns 0 (field declaration AND all three assertion references gone — Steps 1, 2, and 5 combined).
+    - `rg -n "#\\[allow\\(dead_code\\)\\]" crates/tome/src/relocate.rs` returns 0 matches.
+    - `rg -n "pub source_path" crates/tome/src/relocate.rs` returns 0 matches (defense-in-depth).
+    - `rg -n "pub struct SkillMoveEntry" crates/tome/src/relocate.rs` returns exactly 1 match.
+    - `rg -n "let _ = provenance_from_link_result" crates/tome/src/relocate.rs` returns at least 1 match (the side-effect-only call).
+    - `rg -n "TEST-05.*option a|POLISH-05.*option a" crates/tome/src/relocate.rs` returns at least 1 match (decision documented in code).
+    - `cargo build -p tome --tests` is clean (no "no field `source_path` on type `SkillMoveEntry`" errors anywhere — proves the test-side assertions were removed in Step 5).
+    - `cargo test -p tome relocate::tests` passes (all existing tests, including SAFE-03 unit test `provenance_from_link_result_warns_and_returns_none_on_err`).
+    - `cargo clippy -p tome --all-targets -- -D warnings` is clean.
+  </acceptance_criteria>
+  <done>
+    `SkillMoveEntry` no longer has a `source_path` field; `#[allow(dead_code)]` is gone from `relocate.rs`. `provenance_from_link_result` is retained (called for SAFE-03 stderr warning side effect; return value discarded with `let _`). The three pre-existing tests asserting on `source_path` (lines 582, 804, 918–924) are surgically updated. Existing SAFE-03 unit test still passes. Build + clippy clean.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- `cargo build -p tome --tests` — clean (after both tasks; proves test-side assertions on `source_path` were removed).
+- `cargo test -p tome relocate::tests` — all pre-existing tests pass (SAFE-03 unit test included).
+- `cargo clippy -p tome --all-targets -- -D warnings` — clean.
+- `make ci` — clean.
+- `rg -n "arboard.*\">=3" Cargo.toml` — exactly 1 match.
+- `rg -n "Bump-review policy" Cargo.toml` — exactly 1 match.
+- `rg -c "source_path" crates/tome/src/relocate.rs` — 0.
+- `rg -n "#\\[allow\\(dead_code\\)\\]" crates/tome/src/relocate.rs` — 0 matches.
+- Cargo.lock arboard version unchanged from pre-edit.
+</verification>
+
+<success_criteria>
+- `arboard` is pinned to a patch-version range in workspace `Cargo.toml` with a multi-line comment documenting the bump-review policy and citing POLISH-06 / #463 D6 (POLISH-06 option a).
+- `SkillMoveEntry.source_path` is removed; `#[allow(dead_code)]` is gone from `relocate.rs` (TEST-05 option a).
+- The three pre-existing test-side assertions on `source_path` are surgically updated (lines 582, 804, 918–924).
+- SAFE-03 stderr warning surface is preserved: `provenance_from_link_result` is still invoked from `plan()` (for its side effect), and the standalone unit test `provenance_from_link_result_warns_and_returns_none_on_err` continues to pass as the SAFE-03 regression guard.
+- Build + clippy clean. Cargo.lock unchanged.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/10-phase-8-review-tail/10-03-SUMMARY.md` recording:
+- POLISH-06 option chosen: (a) patch-version pin with bump-review comment.
+- TEST-05 option chosen: (a) REMOVE the field.
+- Resolved `arboard` version at edit time (e.g., `3.6.1`) and the resulting pin range (e.g., `>=3.6, <3.7`).
+- Whether `provenance_from_link_result` was kept (option β: side-effect-only call, return value discarded) or removed.
+- Test-assertion deletions: line numbers actually edited (may shift slightly from 582/804/918 if the file has been edited between plan write and execution).
+- One-line confirmation: POLISH-06 + TEST-05 closed.
+</output>


### PR DESCRIPTION
## Summary

Phase 10 of v0.9 — closes the 11 post-merge review items from #462 (P1-P5) and #463 (D1-D6) in one cut. Three plans organized into a single wave (parallel-safe across disjoint module boundaries).

## 3 plans, 1 wave

| Plan | Requirements | Files |
|------|-------------|-------|
| 10-01 TUI / StatusMessage redesign | POLISH-01, POLISH-02, POLISH-03, TEST-03 | \`browse/{app,ui,mod}.rs\` |
| 10-02 Remove correctness + test coverage | POLISH-04, POLISH-05, TEST-01, TEST-02, TEST-04 | \`remove.rs\`, \`lib.rs\`, \`tests/cli.rs\` |
| 10-03 Arboard pin + relocate dead code | POLISH-06, TEST-05 | \`Cargo.toml\`, \`relocate.rs\` |

## What ships in each plan

**10-01 — TUI / StatusMessage redesign**
- StatusMessage becomes a single enum (\`Success | Warning | Pending\`) with \`body()\`/\`glyph()\`/\`severity()\` accessors; UI formats \`"{glyph} {body}"\` at render time
- \`status_message_from_open_result\` helper extracted from ViewSource handler with all three arms unit-tested via synthetic \`ExitStatus\` values
- "Opening: <path>..." status renders BEFORE \`xdg-open\`/\`open\` blocks via closure-callback redraw threading from \`run_loop\` → \`handle_key\` → \`handle_view_source\`
- ClipboardOccupied auto-retries once with 100ms backoff before any warning surfaces

**10-02 — Remove correctness + test coverage**
- \`FailureKind::ALL\` compile-enforced via exhaustive-match sentinel function + \`const _: () = { assert!(ALL.len() == 4); };\` (no \`strum\` dep)
- \`RemoveFailure::new\` gains \`debug_assert!(path.is_absolute(), ...)\` invariant
- \`regen_warnings\` deferred until AFTER the success banner on the happy path (option a from #462 P4); source-byte regression test anchored to \`Command::Remove\` region to avoid false-positives if Reassign/Fork are reordered later
- New assertions: success-banner-absence on partial failure, retry-after-fix end-to-end pinning the I2/I3 retention contract

**10-03 — Arboard pin + relocate dead code**
- \`arboard\` pinned to \`>=3.6, <3.7\` (matching current Cargo.lock 3.6.1) with bump-review-on-bump policy comment
- Dead \`SkillMoveEntry.source_path\` field removed; the three existing test assertions on it (relocate.rs:582, 804, 918-924) are explicitly deleted; \`#[allow(dead_code)]\` is gone
- SAFE-03 stderr contract preserved by the standalone \`provenance_from_link_result_warns_and_returns_none_on_err\` test which doesn't touch \`SkillMoveEntry\`

## Plan-check trail

Verified across 8 dimensions over 2 iterations:

- **Iter 1:** 2 IMPORTANT + 3 SUGGESTION findings.
  - IMPORTANT: Plan 10-03 originally missed the three existing \`source_path\` ASSERTIONS in relocate.rs tests — would have compile-failed when the field is removed
  - IMPORTANT: Plan 10-01 Task 2 had 9 design reversals between \`pending_redraw\`, direct \`&mut Terminal\` threading, and the eventual closure-callback — buried the chosen approach
  - SUGGESTION × 3: 10-01 frontmatter missing \`browse/mod.rs\`; 10-03 must_haves used 3.4 instead of 3.6.1; 10-02 source-byte test needed \`Command::Remove\` anchor to prevent false-positives from Reassign/Fork reorders
- **Iter 2:** \`PLANS APPROVED\` — all 5 fixes landed correctly, no regressions.

## Notable design picks (each justified in plan body)

- **POLISH-04 option (c) sentinel** over (a) strum: keeps zero-dep posture; sentinel is compile-enforced
- **POLISH-05 option (a) keep+assert** over (b) replace constructor with struct literals: smaller blast radius, debug-only invariant
- **POLISH-06 option (a) patch-pin** over (b) cfg(test) canary: pin already prevents silent variant addition
- **TEST-04 option (a) defer warnings** over (b) scope-prefix: success banner is the user's anchor, warnings as footnote feels natural
- **TEST-05 option (a) remove field** over (b) wire it: codebase analysis confirms \`copy_library\` and \`recreate_target_symlinks\` already preserve managed-symlink shape via direct \`read_link\`; field is genuinely dead

## Coverage

11/11 POLISH-XX/TEST-XX requirements covered, each by exactly one plan. No orphans, no duplicates.

## Test plan

- [x] No code changes; planning docs only
- [x] All 3 plan files have valid frontmatter (\`phase\`, \`plan\`, \`type\`, \`wave\`, \`depends_on\`, \`files_modified\`, \`autonomous\`, \`requirements\`, \`issue\`)
- [x] Wave 1 file disjointness verified: 10-01 (browse/), 10-02 (remove + lib + tests/cli.rs), 10-03 (Cargo.toml + relocate.rs) — no overlap
- [x] Plan-checker iteration 2 returned \`## PLANS APPROVED\`

Refs #462 #463