### PR TITLE
chore: archive v0.9 milestone

### DIFF
--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,5 +1,21 @@
 # Milestones
 
+## v0.9 Cross-Machine Config Portability & Polish (Shipped: 2026-04-29)
+
+**Phases completed:** 2 phases (9 + 10), 6 plans, ~26 tasks
+
+**Key accomplishments:**
+
+- **Cross-machine config portability** (#458) — `[directory_overrides.<name>]` schema in `machine.toml` lets a single `tome.toml` checked into dotfiles work across machines with different filesystem layouts. Override application happens at config load time (after tilde expansion, before `Config::validate`) so every downstream command (`sync`, `status`, `doctor`, `lockfile::generate`) operates on the merged result.
+- **Override surfacing** (#458) — Typo'd override target names produce a stderr `warning:` line without aborting load; override-induced validation failures surface a distinct error class naming `machine.toml` (not `tome.toml`); `tome status` and `tome doctor` mark overridden directories with `(override)` in text output and `override_applied: bool` in JSON.
+- **Bare-slug `tome add` expansion** (PR #471, included in v0.9.0) — `tome add planetscale/database-skills` now expands to `https://github.com/planetscale/database-skills` so users can paste org/repo tokens directly without ceremony.
+- **TUI polish** (#463 D1-D3) — `tome browse open` paints "Opening: <path>..." before blocking on `xdg-open`/`open` via closure-callback redraw threading; `StatusMessage` redesigned as `Success | Warning | Pending` enum with `body()`/`glyph()`/`severity()` accessors and `pub(super)` visibility; `ClipboardOccupied` auto-retries once with 100ms backoff before surfacing a warning.
+- **Type-design polish** (#463 D4-D6) — `FailureKind::ALL` compile-enforced via exhaustive-match sentinel + `const _: () = { assert!(...len() == 4); };`; `RemoveFailure::new` gains `debug_assert!(path.is_absolute(), ...)` invariant; `arboard` pinned to `>=3.6, <3.7` with bump-review-on-bump comment in `Cargo.toml`; dead `SkillMoveEntry.source_path` field removed from `relocate.rs`.
+- **Test coverage closing the v0.8 review tail** (#462 P1-P5) — `status_message_from_open_result` helper extracted from ViewSource match with all three arms (Ok+success, Ok+non-zero exit, Err) unit-tested via synthetic `ExitStatus`; `regen_warnings` deferred until after the success banner with source-byte regression test anchored to `Command::Remove` region; partial-failure success-banner-absence assertion + retry-after-fix end-to-end test pinning the I2/I3 retention contract.
+- **Test footprint:** 526 unit + 136 integration = 662 total tests at v0.9.0 (was 514 + 130 = 644 at v0.8.1; +18 new tests from v0.9 phases plus +4 `tome add` slug tests bundled in).
+
+---
+
 ## v0.8 Wizard UX & Safety Hardening (Shipped: 2026-04-27)
 
 **Phases completed:** 2 phases, 7 plans, 26 tasks

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -104,44 +104,29 @@ The wizard-surface work below shipped in v0.6 (as WIZ-01–05) but lacked valida
 
 ## Current State
 
-**Shipped:** v0.8.1 (2026-04-27)
+**Shipped:** v0.9.0 (2026-04-29)
 
-v0.8 milestone complete — Wizard UX & Safety Hardening. 8 requirements shipped (WUX-01..05 + SAFE-01..03) across Phases 7+8, plus the v0.8.1 hotfix (HOTFIX-01..03 across Phase 8.1) closing 3 post-merge findings from #461. Archive: [`milestones/v0.8-ROADMAP.md`](milestones/v0.8-ROADMAP.md).
+v0.9 milestone complete — Cross-Machine Config Portability & Polish. 16 requirements shipped (5 PORT + 6 POLISH + 5 TEST) across Phases 9-10. Archive: [`milestones/v0.9-ROADMAP.md`](milestones/v0.9-ROADMAP.md).
 
 **Highlights:**
-- Wizard handles greenfield, brownfield, and legacy machine states — no more silent overwrites or default-path footguns
-- `tome remove` aggregates partial-cleanup failures with grouped stderr summary + non-zero exit; save chain reordered so retention messaging surfaces before save errors
-- `tome browse` `open` + `copy path` work on Linux (`xdg-open` + `arboard`), with success/failure surfacing in TUI status bar
-- `relocate.rs` surfaces `read_link` failures instead of silently dropping
-- Lockfile regen for `tome remove`/`reassign`/`fork` no longer silently drops git-sourced skills
+- A single `tome.toml` checked into dotfiles now works across machines via per-machine `[directory_overrides.<name>]` blocks in `machine.toml` — overrides apply once at config load, every downstream command (`sync`, `status`, `doctor`, `lockfile::generate`) sees the merged result
+- `tome status` and `tome doctor` mark overridden directories with `(override)` in text output and `override_applied: bool` in JSON
+- `tome browse open` paints "Opening: <path>..." before blocking on `xdg-open`; `StatusMessage` redesigned as `Success | Warning | Pending` enum; `ClipboardOccupied` auto-retries with 100ms backoff
+- `FailureKind::ALL` compile-enforced via exhaustive-match sentinel; `RemoveFailure::new` gains `path.is_absolute()` debug invariant; `arboard` patch-pinned with bump-review policy
+- `regen_warnings` deferred until after the success banner; partial-failure success-banner-absence + retry-after-fix end-to-end tests pin the I2/I3 retention contract
+- Bare-slug `tome add` (PR #471) bundled in — `tome add planetscale/database-skills` expands to `https://github.com/planetscale/database-skills`
 
-**Carry-over:** 2 Linux-runtime UAT items in `08-HUMAN-UAT.md` (clipboard runtime + xdg-open runtime) pending Linux desktop hardware. Accepted as carry-over.
+**Carry-over:** 2 Linux-runtime UAT items in `08-HUMAN-UAT.md` (clipboard runtime + xdg-open runtime) still pending Linux desktop hardware. Accepted as carry-over for the third consecutive milestone.
 
-## Current Milestone: v0.9 Cross-Machine Config Portability & Polish
+## Next Milestone Goals
 
-**Goal:** A single `tome.toml` checked into dotfiles can be applied across machines with different filesystem layouts — without manual edits per machine. Bundled with two polish backlogs (#462, #463) to clear the v0.8 review tail in one cut.
+**v1.0 tome Desktop (Tauri GUI)** — drafted, ready to ratify
 
-**Target features:**
-- **Cross-machine portability** ([#458](https://github.com/MartinP7r/tome/issues/458)) — `machine.toml` path overrides allow per-machine remapping of directory paths so the same `tome.toml` is portable across machines. New schema fields + override-apply timing in the config load pipeline.
-- **Type design + TUI architecture polish** ([#463](https://github.com/MartinP7r/tome/issues/463)) — 6 items from the Phase 8 post-merge review: StatusMessage type redesign, `.status()` TUI blocking, clipboard auto-retry, `FailureKind::ALL` compile-enforcement, `RemoveFailure::new` justification, arboard drift hygiene.
-- **Test coverage + wording + dead code polish** ([#462](https://github.com/MartinP7r/tome/issues/462)) — 5 items from the same review: success-banner-absence assertion, retry e2e test, `ViewSource .status()` middle-branch coverage, regen-warning ordering, dead `source_path` field cleanup.
-
-**Scope anchor:** Epic [#458](https://github.com/MartinP7r/tome/issues/458) (primary) + #462/#463 (carry-over from v0.8 post-merge review).
-
-**Key context:**
-- Bare-slug expansion in `tome add` (PR #471) merged to main 2026-04-27; ships with v0.9 (no v0.8.2 patch release planned).
-- Single-user constraint still holds — no migration tooling; users with existing `tome.toml` get explicit migration docs if schema changes.
-- Cross-machine portability has been intentionally deferred since v0.8 epic #459 because the design needs new schema fields + override-apply timing — a bigger lift than fits a single phase.
-
-## Looking Beyond v0.9
-
-**v1.0 tome Desktop (Tauri GUI)** — drafted 2026-04-28
-
-Forward-planning artifacts: [`milestones/v1.0-REQUIREMENTS.md`](milestones/v1.0-REQUIREMENTS.md) + [`milestones/v1.0-ROADMAP.md`](milestones/v1.0-ROADMAP.md). 32 requirements across 7 categories (CORE / VIEW / SYNC / CFG / OPS / BAK / DIST) + 5 cross-cutting NF gates. 7 phases (10–16). Rough size: 15–22 weeks of focused work; alpha after Phase 11, beta after Phase 13, ship after Phase 16.
+Forward-planning artifacts complete: [`milestones/v1.0-REQUIREMENTS.md`](milestones/v1.0-REQUIREMENTS.md) + [`milestones/v1.0-ROADMAP.md`](milestones/v1.0-ROADMAP.md). 32 requirements across 7 categories (CORE / VIEW / SYNC / CFG / OPS / BAK / DIST) + 5 cross-cutting NF gates. 7 phases (proposed numbering 11–17). Rough size: 15–22 weeks of focused work; alpha after Phase 12, beta after Phase 14, ship after Phase 17.
 
 Tauri 2 chosen over Electron + napi-rs (D-GUI-01): the Rust crate becomes the native backend directly, ~8 MB bundle, built-in code-signed auto-update, reuses Developer ID flow. CLI ships unchanged from `crates/tome`; the GUI lives in a new `crates/tome-desktop` workspace member.
 
-Sequenced after v0.9 by default (D-GUI-09). Ratify via `/gsd:new-milestone` when v0.9 ships and v1.0 becomes the active milestone.
+Run `/gsd:new-milestone` to ratify v1.0 and start phase planning.
 
 <details>
 <summary>Previous milestones (recap)</summary>
@@ -162,9 +147,9 @@ Sequenced after v0.9 by default (D-GUI-09). Ratify via `/gsd:new-milestone` when
 
 ## Context
 
-tome is at Cargo.toml `0.8.1` (released 2026-04-27 via cargo-dist). Codebase: ~25.2k lines of Rust across 20+ source modules in a single crate. v0.6 introduced the unified directory model; v0.7 hardened the wizard surface; v0.8 closed the new-machine/dotfiles-sync UX gap and shipped partial-failure visibility + cross-platform browse actions.
+tome is at Cargo.toml `0.9.0` (released 2026-04-29 via cargo-dist). Codebase: ~26k lines of Rust across 20+ source modules in a single crate. v0.6 introduced the unified directory model; v0.7 hardened the wizard surface; v0.8 closed the new-machine/dotfiles-sync UX gap and shipped partial-failure visibility + cross-platform browse actions; v0.9 shipped per-machine `[directory_overrides.<name>]` for cross-machine portability and cleared the v0.8 review tail.
 
-The Rust codebase uses `anyhow` for errors, `serde`/`toml` for config, `clap` for CLI, `ratatui` for the TUI browser, and `nucleo-matcher` for fuzzy search. Tests use `assert_cmd` + `tempfile` + `insta` snapshots. CI runs on Ubuntu and macOS. 590 tests total (464 unit + 126 integration as of v0.8.1).
+The Rust codebase uses `anyhow` for errors, `serde`/`toml` for config, `clap` for CLI, `ratatui` for the TUI browser, and `nucleo-matcher` for fuzzy search. Tests use `assert_cmd` + `tempfile` + `insta` snapshots. CI runs on Ubuntu and macOS. 662 tests total (526 unit + 136 integration as of v0.9.0).
 
 Config is `directories: BTreeMap<DirectoryName, DirectoryConfig>` where each entry has a `role` (managed/synced/source/target) and `type` (claude-plugins/directory/git). `Config::save_checked` enforces expand → `validate()` → TOML round-trip → write; no invalid config can reach disk.
 
@@ -200,13 +185,24 @@ Config is `directories: BTreeMap<DirectoryName, DirectoryConfig>` where each ent
 | Glyph-prefix dispatch (✓ → `theme.accent`, ⚠ → `theme.alert`) for status bar (v0.8 Phase 8 / SAFE-02) | Reuses existing theme fields; no new `theme.warning` needed | ✓ Good |
 | Lockfile-as-cache for offline resolved-paths recovery (v0.8.1 Phase 8.1 / HOTFIX-01) | Reads previous lockfile + on-disk repo cache; no `git fetch` from destructive commands; per-directory warnings replace silent skip | ✓ Good — closes #461 H1 silent-drop regression |
 | `if !result.failures.is_empty()` block fires before save chain in `Command::Remove` (v0.8.1 Phase 8.1 / HOTFIX-02) | Save-chain `?` propagation was masking the I2/I3 retention messaging on disk-write errors | ✓ Good — closes #461 H2 |
+| `[directory_overrides.<name>]` lives in `machine.toml` (v0.9 Phase 9 / PORT-01) | Sync boundary already correct — `machine.toml` is per-machine and never synced; reusing it for path overrides preserves the "tome.toml is portable" invariant | ✓ Good — closes #458 cross-machine portability epic |
+| `Config::apply_machine_overrides` between `expand_tildes()` and `validate()` (v0.9 Phase 9 / PORT-02) | Single insertion point in the load pipeline guarantees all downstream code sees the merged result; no second code path can observe pre-override paths | ✓ Good — single source of truth |
+| `override_applied: bool` on `DirectoryConfig` with `#[serde(skip)]` (v0.9 Phase 9 / PORT-05) | Single source of truth for status/doctor surfacing; round-trip byte-equality of `tome.toml` preserved | ✓ Good — chosen over snapshot-diff |
+| Override-induced validation errors via message-content wrapper, not typed enum (v0.9 Phase 9 / PORT-04) | Matches existing tome convention (`anyhow::Result` + grep-able message templates); typed-enum migration noted as v1.0 follow-up if a programmatic consumer needs it | ✓ Good — defensible per plan-checker |
+| `StatusMessage = Success \| Warning \| Pending` enum with `body()`/`glyph()`/`severity()` accessors (v0.9 Phase 10 / POLISH-02) | Removes dual-source-of-truth between severity and pre-formatted glyph in body; UI formats `"{glyph} {body}"` at render time | ✓ Good |
+| Closure-callback redraw threading for pre-block TUI updates (v0.9 Phase 10 / POLISH-01) | Keeps `App` independent of `ratatui::DefaultTerminal`; redraw fires BEFORE `.status()` blocks (a flag-based approach would only redraw on the next event loop iteration, too late) | ✓ Good — chosen over `pending_redraw` flag and `&mut Terminal` threading |
+| `FailureKind::ALL` compile-enforced via exhaustive-match sentinel + const-len assert (v0.9 Phase 10 / POLISH-04) | Catches "added a variant without updating ALL" at compile time; no `strum` dep needed | ✓ Good — chosen over runtime canary |
+| `arboard` patch-pin (`>=3.6, <3.7`) with bump-review comment (v0.9 Phase 10 / POLISH-06) | Prevents silent variant addition (`arboard::Error` is `#[non_exhaustive]`); review-on-bump policy documented in `Cargo.toml` | ✓ Good |
+| Defer `regen_warnings` until after success banner (v0.9 Phase 10 / TEST-04) | Success banner is the user's anchor; warnings as a footnote feel more natural than scoped-prefix on every line. Source-byte regression test anchored to `Command::Remove` region for false-positive resistance | ✓ Good — chosen over `[lockfile regen]` prefix |
 
 ## Evolution
 
 This document evolves at phase transitions and milestone boundaries.
 
 ---
-*Last updated: 2026-04-29 — Phase 10 complete (Phase 8 Review Tail). All 11 v0.8 review-tail items shipped: POLISH-01..06 (#463 D1-D6 — TUI block UX, StatusMessage enum redesign, ClipboardOccupied retry, FailureKind::ALL compile-enforce, RemoveFailure::new invariant, arboard patch-pin) + TEST-01..05 (#462 P1-P5 — banner-absent assertion, retry-after-fix e2e, ViewSource helper extraction, regen-warnings reorder, dead source_path field removed). 662 tests passing (526 unit + 136 integration; +14 since Phase 10 start). v0.9 milestone is now functionally complete — both Phase 9 + Phase 10 shipped. Ready for `/gsd:complete-milestone v0.9` after PR merges to main and `make release VERSION=0.9.0`.*
+*Last updated: 2026-04-29 after v0.9 milestone — v0.9.0 shipped via cargo-dist (commits c183e3f Phase 10 + 0ae6288 version bump on main). v0.9 milestone archived: 16 v0.9 requirements (5 PORT + 6 POLISH + 5 TEST) shipped across Phases 9 and 10 (10 in 1 wave, 9 in 2 waves). 662 tests passing (526 unit + 136 integration). Linux-runtime UAT items in `08-HUMAN-UAT.md` carried over for the third consecutive milestone (still pending hardware). Ready for v1.0 — Tauri GUI milestone artifacts already drafted in `milestones/v1.0-{REQUIREMENTS,ROADMAP}.md`; ratify via `/gsd:new-milestone` to start phase planning.*
+
+*Last updated: 2026-04-29 — Phase 10 complete (Phase 8 Review Tail). All 11 v0.8 review-tail items shipped: POLISH-01..06 (#463 D1-D6) + TEST-01..05 (#462 P1-P5). 662 tests passing. v0.9 milestone functionally complete — ready for milestone closure.*
 
 *Last updated: 2026-04-28 — Phase 9 complete (Cross-Machine Path Overrides). All 5 PORT requirements shipped: `[directory_overrides.<name>]` schema in machine.toml, override-apply timing in load pipeline, typo warning, distinct machine.toml error class, and `(override)` annotation in `tome status`/`tome doctor` (text + JSON). 648 tests passing (514 unit + 134 integration; +58 since Phase 9 start). Phase 10 (#462 + #463 polish bundle) is the remaining v0.9 work.*
 

--- a/.planning/RETROSPECTIVE.md
+++ b/.planning/RETROSPECTIVE.md
@@ -78,16 +78,66 @@
 - Phase 8.1 wall time: ~16 min for 3 sequential waves + verification (vs ~30 min projected for 3 plans)
 - Integration test revert-and-rerun sanity checks added ~3 min per plan but caught 0 false-positives this milestone — still worth it as a discipline
 
+## Milestone: v0.9 — Cross-Machine Config Portability & Polish
+
+**Shipped:** 2026-04-29 (v0.9.0)
+**Phases:** 2 (9 + 10) | **Plans:** 6 | **Tasks:** ~26
+
+### What Was Built
+
+- **Cross-machine portability** (#458) — `[directory_overrides.<name>]` schema in `machine.toml`, `Config::apply_machine_overrides` between `expand_tildes()` and `validate()`, threaded through Sync/Status/Doctor/Init via `Config::load_with_overrides`. Typo guard (stderr `warning:`), distinct `machine.toml` error class for override-induced validation failures, `(override)` annotation in `tome status`/`tome doctor` text + `override_applied: true` in JSON.
+- **TUI polish** (#463 D1-D3) — `StatusMessage` collapsed to `Success | Warning | Pending` enum with `body()`/`glyph()`/`severity()` accessors and `pub(super)` visibility; UI formats `"{glyph} {body}"` at render time. "Opening: <path>..." renders before `xdg-open`/`open` blocks via closure-callback redraw threading from `run_loop` → `handle_key` → `handle_view_source`. `ClipboardOccupied` auto-retries once with 100ms backoff.
+- **Type-design polish** (#463 D4-D6) — `FailureKind::ALL` compile-enforced via exhaustive-match sentinel + const-len assert; `RemoveFailure::new` `debug_assert!(path.is_absolute())`; `arboard` patch-pinned with bump-review comment; dead `SkillMoveEntry.source_path` field removed.
+- **Test coverage** (#462 P1-P5) — `status_message_from_open_result` 3-arm tests via synthetic `ExitStatus`; banner-absence assertion; retry-after-fix end-to-end pinning the I2/I3 retention contract; `regen_warnings` deferred until after success banner with source-byte regression test anchored to `Command::Remove` region.
+- **Bonus:** Bare-slug `tome add planetscale/database-skills` expansion (PR #471, bundled in v0.9.0).
+
+### What Worked
+
+- **Forward-planning v1.0 in parallel.** While v0.9 phases were executing, the v1.0 Tauri GUI artifacts (`milestones/v1.0-{REQUIREMENTS,ROADMAP}.md`) were drafted independently. Reference made it from forward-plan to "ready-to-ratify" status by the time v0.9 closed. Saves a future planning session's fresh-start cost.
+- **Wave 1 parallel execution in Phase 10.** Three plans, three modules, zero file overlap, ~32 min wall time vs ~80 min sequential. The planner's deliberate file-disjointness during plan boundary decisions (browse vs remove + lib + tests/cli.rs vs Cargo.toml + relocate) is what made true-parallel safe.
+- **Plan-checker iteration 2 catches.** Twice this milestone the plan-checker caught issues the planner missed — Phase 9's `DirectoryConfig` struct-literal cascade (~38 sites compile-fail without explicit guidance) and Phase 10's `SkillMoveEntry.source_path` test assertions (3 tests compile-fail when the field is removed). Both would have surfaced as executor surprises mid-task; iter-2 review was the right place to catch them.
+- **Memory-driven discipline pays off.** Three direct-to-main / stacked-PR / empty-squash incidents during Phase 9 setup — all caught either by the permission system or by the now-canonical pre-commit `git status -sb` check. Zero such incidents in Phase 10 setup or execution. The discipline is paying its way.
+
+### What Was Inefficient
+
+- **Phase 9 setup chain (3 PRs deep before plans landed on main).** `b8d7ac8` direct-to-main → #474 revert → #475 stacked-PR misroute → #476 empty squash → #477 clean cherry-pick. Five PRs to land what should have been one. Each recovery was correct *for the bug it knew about*, but each had a fresh GitHub-sequencing footgun the previous one didn't anticipate. The cumulative memory entry now has 3 layers of process-bug coverage; future sessions should skip the chain entirely.
+- **`gsd-tools milestone complete` produced bogus stats.** Counted "11 phases / 36 plans / 78 tasks" (cumulative across the project's entire history, not v0.9-specific) and listed accomplishments from every prior phase including `RED:` as a literal line extracted from a TDD-style summary header. Required manual MILESTONES.md rewrite. Worth filing upstream.
+- **v0.9-ROADMAP.md archive captured pre-collapse snapshot** (same v0.7/v0.8 issue) — needed manual patch to flip 🚧 → ✅ and update active-section header. Pattern is consistent across milestones; could be fixed by ordering: collapse current ROADMAP first, *then* let `milestone complete` archive it.
+
+### Patterns Established
+
+- **Forward-plan adjacent milestones during current execution.** `milestones/v1.0-{REQUIREMENTS,ROADMAP}.md` was drafted while v0.9 was still in flight. When v0.9 closed, the next milestone wasn't a blank slate. Worth carrying as a discipline: "if a future milestone has obvious shape, draft it speculatively while waiting on the current one's verification cycles."
+- **Plan-check "removal" work is high-leverage.** Removing a struct field reverberates beyond the constructor sites — any code that READS the field also breaks. Plan-checker-iter-2 caught this twice (Phase 9 struct-literal cascade, Phase 10 source_path assertions). Could be turned into a planner heuristic: "when removing a struct field, grep for ALL references (constructions AND reads/asserts) and enumerate them in the plan."
+- **Parallel-wave plan partitioning.** When a phase has ≥3 plans, optimize the file-disjointness of the partition, not just the logical grouping. Phase 10 Wave 1 nailed this — three plans across three modules with zero overlap, true-parallel safe.
+
+### Key Lessons
+
+1. **Verify the actual file landed, not just the merge.** PR #476 squash-merged successfully but produced an empty commit (`d22b3d8`) — the UI showed the right diff, the merge succeeded, but the destination tree was unchanged. After ANY recovery PR, `git ls-tree HEAD <expected_path>` is the only honest check. Added to memory.
+2. **Branch-discipline doesn't just save direct-to-main commits — it saves planning-doc inconsistency too.** All v0.9 setup-chain incidents started with the same root cause: a subagent's `git checkout main` invisible to the orchestrator. The pre-commit `git status -sb` check is now the single most-load-bearing discipline this project has.
+3. **Three milestone-closure runs deep, the workflow's `gsd-tools milestone complete` still produces wrong stats.** Don't trust the auto-generated MILESTONES.md entry — always rewrite it manually with milestone-scoped accomplishments + correct phase/plan/task counts.
+
+### Cost Observations
+
+- Model mix: orchestrator + planner on Opus, executors on Opus, verifier + plan-checker on Sonnet — typical balanced profile
+- v0.9 wall time: ~3 days (Phase 9 over 1 day + Phase 10 in <1 day + setup-chain overhead)
+- Phase 10 was the smoothest execution this entire milestone — proves the discipline accumulated through Phases 7/8/8.1/9 pays off when nothing breaks the chain
+
 ## Cross-Milestone Trends
 
-| Metric | v0.6 | v0.8 |
-|--------|------|------|
-| Phases | 3 | 3 (7, 8, 8.1) |
-| Plans | 11 | 10 |
-| Tasks | ~19 | ~26 |
-| Timeline | 2 days | ~5 days incl. hotfix |
-| Known gaps | 5 (WIZ-01–05) | 2 (Linux UAT carry-over) |
-| Critical bugs found in review | 3 | 3 (#461 H1/H2/H3) |
-| Hotfix release | — | v0.8.1 (3 fixes) |
+| Metric | v0.6 | v0.8 | v0.9 |
+|--------|------|------|------|
+| Phases | 3 | 3 (7, 8, 8.1) | 2 (9, 10) |
+| Plans | 11 | 10 | 6 |
+| Tasks | ~19 | ~26 | ~26 |
+| Timeline | 2 days | ~5 days incl. hotfix | ~3 days |
+| Known gaps | 5 (WIZ-01–05) | 2 (Linux UAT carry-over) | 2 (Linux UAT carry-over still) |
+| Critical bugs found in review | 3 | 3 (#461 H1/H2/H3) | 0 |
+| Hotfix release | — | v0.8.1 (3 fixes) | — |
+| Plan-checker iter-2 catches | n/a | n/a | 2 (struct-literal cascade, source_path assertions) |
+| Process incidents (direct-to-main / stacked-PR / empty-squash) | 0 | 0 | 3 (Phase 9 setup chain) |
 
-**Recurring pattern:** Post-merge review consistently catches issues that phase verification misses — both as a quality gate. v0.6 had a 3-issue PR review; v0.8 had a 3-issue post-merge re-review. Worth formalizing as a phase exit criterion.
+**Recurring pattern:** Post-merge review consistently catches issues that phase verification misses — both as a quality gate. v0.6 had a 3-issue PR review; v0.8 had a 3-issue post-merge re-review. v0.9 had ZERO post-merge findings — possibly because the v0.8 review tail (#462 + #463) was cleared in-milestone via Phase 10, depriving the next post-merge review of low-hanging items.
+
+**New pattern:** Plan-checker iteration 2 ("removal-work miss" — fields removed without enumerating consumers) is now a recurring catch. Worth turning into a planner-skill heuristic.
+
+**Discipline trend:** Process incidents went 0 → 0 → 3 → 0 (across v0.6, v0.7 unrecorded, v0.8, v0.9). The v0.9 spike was concentrated in Phase 9 setup; Phase 10 had zero. The branch-discipline memory entry is now load-bearing — every future session inherits it.

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -5,8 +5,8 @@
 - ✅ **v0.6 Unified Directory Model** — Phases 1-3 (shipped 2026-04-16) — [archive](milestones/v0.6-ROADMAP.md)
 - ✅ **v0.7 Wizard Hardening** — Phases 4-6 (shipped 2026-04-22) — [archive](milestones/v0.7-ROADMAP.md)
 - ✅ **v0.8 Wizard UX & Safety Hardening** — Phases 7-8 + 8.1 hotfix (shipped 2026-04-27) — [archive](milestones/v0.8-ROADMAP.md)
-- 🚧 **v0.9 Cross-Machine Config Portability & Polish** (active since 2026-04-28) — epic [#458](https://github.com/MartinP7r/tome/issues/458) + #462 + #463
-- 📋 **v1.0 tome Desktop (Tauri GUI)** — drafted — see [milestones/v1.0-REQUIREMENTS.md](milestones/v1.0-REQUIREMENTS.md) and [milestones/v1.0-ROADMAP.md](milestones/v1.0-ROADMAP.md). Sequenced after v0.9 by default; ratify via `/gsd:new-milestone` when v0.9 ships.
+- ✅ **v0.9 Cross-Machine Config Portability & Polish** — Phases 9-10 (shipped 2026-04-29) — [archive](milestones/v0.9-ROADMAP.md)
+- 📋 **v1.0 tome Desktop (Tauri GUI)** — drafted, ready to ratify — see [milestones/v1.0-REQUIREMENTS.md](milestones/v1.0-REQUIREMENTS.md) and [milestones/v1.0-ROADMAP.md](milestones/v1.0-ROADMAP.md). Run `/gsd:new-milestone` when ready.
 
 ## Phases
 
@@ -44,51 +44,24 @@
 
 </details>
 
-### v0.9 Cross-Machine Config Portability & Polish (Active)
+<details>
+<summary>✅ v0.9 Cross-Machine Config Portability & Polish (Phases 9-10) — SHIPPED 2026-04-29</summary>
 
-Epic: [#458](https://github.com/MartinP7r/tome/issues/458) — `machine.toml` path overrides for cross-machine portability. Bundled with #462 (test/wording/dead-code polish) and #463 (type-design + TUI architecture polish) to clear the v0.8 post-merge review tail in one cut.
+- [x] Phase 9: Cross-Machine Path Overrides (3/3 plans) — `[directory_overrides.<name>]` schema in `machine.toml`, override-apply timing in load pipeline, typo warning, distinct `machine.toml` error class, `(override)` annotation in `tome status`/`tome doctor` text+JSON (PORT-01..05)
+- [x] Phase 10: Phase 8 Review Tail (3/3 plans) — `StatusMessage` enum redesign, `status_message_from_open_result` helper, "Opening: ..." pre-block UX, `ClipboardOccupied` retry, `FailureKind::ALL` compile-enforcement, `RemoveFailure::new` invariant, `arboard` patch-pin, deferred regen-warnings, banner-absence + retry e2e tests, dead `source_path` removal (POLISH-01..06 + TEST-01..05)
 
-- [x] **Phase 9: Cross-Machine Path Overrides** — `[directory_overrides.<name>]` in `machine.toml` lets a single `tome.toml` work across machines with different filesystem layouts (PORT-01..05) (completed 2026-04-28)
-- [x] **Phase 10: Phase 8 Review Tail — Type Design, TUI Polish & Test Coverage** — close the 11 post-merge review items from #462 + #463 (POLISH-01..06, TEST-01..05) (completed 2026-04-29)
+**Released as:** v0.9.0 (2026-04-29). Includes the bare-slug `tome add` improvement (PR #471) bundled in.
 
-### v1.0 tome Desktop — Tauri GUI (Drafted)
+</details>
 
-Forward-planning artifacts:
+### v1.0 tome Desktop — Tauri GUI (Ready to ratify)
+
+Drafted forward-planning artifacts (run `/gsd:new-milestone` to ratify):
+
 - [`milestones/v1.0-REQUIREMENTS.md`](milestones/v1.0-REQUIREMENTS.md) — 32 requirements across 7 categories (CORE / VIEW / SYNC / CFG / OPS / BAK / DIST) plus 5 cross-cutting NF gates.
-- [`milestones/v1.0-ROADMAP.md`](milestones/v1.0-ROADMAP.md) — 7 phases (10–16) with three intermediate cuts (alpha after 11, beta after 13, rc after 15, v1.0 after 16). Rough size: 15–22 weeks of focused work.
-
-**Sequencing:** v0.9 → v1.0 by default (D-GUI-09). v0.9 hardens `machine.toml` semantics that v1.0 leans on. Swap allowed; parallelism not recommended.
+- [`milestones/v1.0-ROADMAP.md`](milestones/v1.0-ROADMAP.md) — 7 phases (proposed numbering 11–17) with three intermediate cuts (alpha, beta, rc, v1.0). Rough size: 15–22 weeks of focused work.
 
 **Framework:** Tauri 2 (D-GUI-01). Reuses Rust crate as native backend; no N-API. ~8 MB bundle vs Electron's ~150 MB; built-in code-signed auto-update; same Developer ID flow as the CLI.
-
-Phases will be planned via `/gsd:new-milestone` when v1.0 becomes active. Phase numbering assumes v0.9 takes Phases 9–10; renumber if v0.9's phase footprint differs.
-
-## Phase Details
-
-### Phase 9: Cross-Machine Path Overrides
-**Goal**: A single `tome.toml` checked into dotfiles can be applied across machines with different filesystem layouts via per-machine `[directory_overrides.<name>]` blocks in `machine.toml`.
-**Depends on**: Phase 8.1 (v0.8.1 baseline — load pipeline + machine.toml schema stable)
-**Requirements**: PORT-01, PORT-02, PORT-03, PORT-04, PORT-05
-**Success Criteria** (what must be TRUE):
-  1. User can add `[directory_overrides.<name>]` blocks to `machine.toml` and a subsequent `tome sync` / `tome status` operates on the overridden `path` for that directory without any edits to the synced `tome.toml`.
-  2. Override application happens once at config load time (after tilde expansion, before `Config::validate`), so every downstream command (`sync`, `status`, `doctor`, `lockfile::generate`) sees the same merged result — no second code path can observe pre-override paths.
-  3. An override targeting a directory name that doesn't exist in `tome.toml` produces a single stderr `warning:` line naming the typo and continues loading; it does not abort the command.
-  4. A validation failure caused by an override (e.g., overridden path overlaps `library_dir`) surfaces with a distinct error class that names `machine.toml` as the file to edit, not `tome.toml`.
-  5. `tome status` and `tome doctor` mark each overridden directory entry visibly (e.g., `(override)` annotation or dedicated column) so the user can answer "why is this path different on this machine?" without diffing files.
-**Plans**: TBD
-
-### Phase 10: Phase 8 Review Tail — Type Design, TUI Polish & Test Coverage
-**Goal**: Close the 11 post-merge review items from #462 (P1-P5) and #463 (D1-D6) so the v0.8 review tail is fully cleared in one cut.
-**Depends on**: Phase 9 (sequential — keeps PORT delivery clean and avoids interleaving review-tail churn with the portability epic)
-**Requirements**: POLISH-01, POLISH-02, POLISH-03, POLISH-04, POLISH-05, POLISH-06, TEST-01, TEST-02, TEST-03, TEST-04, TEST-05
-**Success Criteria** (what must be TRUE):
-  1. `tome browse` `open` shows an "Opening: <path>..." status before blocking on `xdg-open`/`open`, any keystrokes typed during the block are drained instead of replayed, and `ClipboardOccupied` errors are auto-retried once with a 100ms backoff before any warning reaches the status bar.
-  2. `StatusMessage` is a single `Success(String) | Warning(String)` enum with `body()`/`glyph()`/`severity()` accessors, `pub(super)` visibility, and audited test-only derives — pre-formatted glyphs in `text` are gone and `ViewSource .status()` routes through a tested `status_message_from_open_result(...)` helper covering Ok+success, Ok+non-zero exit, and Err arms.
-  3. `FailureKind::ALL` cannot drift from the enum (compile-enforced via `EnumIter` or equivalent), `RemoveFailure::new` either carries a real `debug_assert!` invariant or is replaced by struct-literal construction at the four call sites, and `arboard` is pinned to a patch range with a documented bump-review policy in `Cargo.toml`.
-  4. `regen_warnings` ordering on the happy path is pinned in code (deferred until after the success banner OR scoped with a `[lockfile regen]` prefix) and a regression test fails if the order regresses; the dead `SkillMoveEntry.source_path` field is either removed or wired into `copy_library`/`recreate_target_symlinks`, and `#[allow(dead_code)]` is gone from `relocate.rs`.
-  5. `remove_partial_failure_exits_nonzero_with_warning_marker` asserts the `✓ Removed directory` success banner is **absent** from stdout on partial failure, and an end-to-end test pins the I2/I3 retention contract: partial failure → user fixes the underlying condition → second `tome remove <name>` succeeds with empty `failures`, config entry gone, manifest empty, library dir gone.
-**Plans**: TBD
-**UI hint**: yes
 
 ## Progress
 
@@ -103,5 +76,5 @@ Phases will be planned via `/gsd:new-milestone` when v1.0 becomes active. Phase 
 | 7. Wizard UX (Greenfield / Brownfield / Legacy) | v0.8 | 4/4 | Complete | 2026-04-23 |
 | 8. Safety Refactors (Partial-Failure Visibility & Cross-Platform) | v0.8 | 3/3 | Complete | 2026-04-24 |
 | 8.1. v0.8.1 hotfix — lockfile regen + save chain | v0.8 | 3/3 | Complete | 2026-04-27 |
-| 9. Cross-Machine Path Overrides | v0.9 | 2/3 | Complete    | 2026-04-28 |
-| 10. Phase 8 Review Tail — Type Design, TUI Polish & Test Coverage | v0.9 | 3/3 | Complete    | 2026-04-29 |
+| 9. Cross-Machine Path Overrides | v0.9 | 3/3 | Complete | 2026-04-28 |
+| 10. Phase 8 Review Tail — Type Design, TUI Polish & Test Coverage | v0.9 | 3/3 | Complete | 2026-04-29 |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,16 +1,16 @@
 ---
 gsd_state_version: 1.0
-milestone: v0.9
-milestone_name: Cross-Machine Config Portability & Polish
-status: executing
-stopped_at: Completed 10-01-tui-status-message-redesign-PLAN.md (POLISH-01 + POLISH-02 + POLISH-03 + TEST-03)
-last_updated: "2026-04-29T03:09:56.317Z"
+milestone: null
+milestone_name: null
+status: between-milestones
+stopped_at: v0.9 milestone shipped (v0.9.0 — 2026-04-29); ready to ratify v1.0 via /gsd:new-milestone
+last_updated: "2026-04-29T00:00:00.000Z"
 last_activity: 2026-04-29
 progress:
-  total_phases: 11
-  completed_phases: 11
-  total_plans: 36
-  completed_plans: 36
+  total_phases: 0
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
   percent: 0
 ---
 
@@ -18,20 +18,16 @@ progress:
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-04-28)
+See: .planning/PROJECT.md (updated 2026-04-29)
 
 **Core value:** Every AI coding tool on a developer's machine shares the same skill library without manual copying or per-tool configuration.
-**Current focus:** Phase 10 — phase-8-review-tail
+**Current focus:** Between milestones — v0.9 shipped, v1.0 (Tauri GUI) drafted and ready to ratify
 
 ## Current Position
 
-Milestone: v0.9 — Cross-Machine Config Portability & Polish
-Phase: 10
-Plan: Not started
-Status: Ready to execute
-Last activity: 2026-04-29
-
-Progress: [░░░░░░░░░░] 0% (0/2 phases complete)
+Milestone: (none — between milestones)
+Last shipped: v0.9.0 (2026-04-29)
+Next: v1.0 — tome Desktop (Tauri GUI) — drafted in `milestones/v1.0-{REQUIREMENTS,ROADMAP}.md`; run `/gsd:new-milestone` to ratify and start phase planning.
 
 ## Accumulated Context
 
@@ -39,40 +35,23 @@ Progress: [░░░░░░░░░░] 0% (0/2 phases complete)
 
 Historical decisions are archived in:
 
-- `.planning/PROJECT.md` — rolling Key Decisions table (v0.6 + v0.7 + v0.8)
+- `.planning/PROJECT.md` — rolling Key Decisions table (v0.6 + v0.7 + v0.8 + v0.9)
+- `.planning/milestones/v0.9-ROADMAP.md` — per-phase decisions for v0.9
 - `.planning/milestones/v0.8-ROADMAP.md` — per-phase decisions for v0.8
 - `.planning/milestones/v0.7-ROADMAP.md` — per-phase decisions for v0.7
 - `.planning/milestones/v0.6-ROADMAP.md` — per-phase decisions for v0.6
 
-v0.9-specific decisions (so far):
-
-- **D-1 (v0.9 scope):** Bundle #462 (test/wording/dead-code polish) and #463 (type design + TUI architecture polish) into v0.9 alongside the cross-machine portability driver. Trade-off: bigger milestone, longer cycle, but clears the v0.8 review tail in one cut and avoids a v0.8.2 patch release.
-- **D-2 (v0.9 scope):** Bare-slug `tome add` improvement (PR #471, merged 2026-04-27 to main) ships with v0.9 — no separate v0.8.2 patch release.
-- **D-3 (v0.9 phasing):** Two-phase shape — Phase 9 (PORT, 5 reqs) lands the portability epic as a coherent unit; Phase 10 (POLISH + TEST, 11 reqs) lands the entire #462/#463 review tail in one cut. Coarse granularity favours fewer phases; TEST-03 ↔ POLISH-02 coupling (both touch `ViewSource .status()` / `StatusMessage`) makes co-location natural and avoids splitting tightly-related work.
-- [Phase 09-cross-machine-path-overrides]: PORT-01/02: machine.toml [directory_overrides.<name>] schema with apply timing in canonical run() load path (expand_tildes → apply_machine_overrides → validate)
-- [Phase 09]: PORT-05: tome status + tome doctor surface [directory_overrides.<name>] activations via (override) text annotation and override_applied: bool JSON field. DoctorReport.directory_issues schema break: tuples → DirectoryDiagnostic struct
-- [Phase 09]: PORT-03: warn_unknown_overrides emits stderr typo guard for [directory_overrides.<name>] entries that don't match any configured directory; load continues unchanged
-- [Phase 09]: PORT-04: override-induced validate() failures wrap with distinct error class naming machine.toml; discriminator gates wrapping (pre-override valid AND >=1 override applied)
-- [Phase 10]: POLISH-06: arboard pinned to >=3.6, <3.7 (option a, patch-pin) with bump-review comment in Cargo.toml. Cargo.lock unchanged.
-- [Phase 10]: TEST-05: SkillMoveEntry.source_path REMOVED (option a) instead of wired-into-execute. provenance_from_link_result retained for SAFE-03 stderr-warning side effect (let _ = ...). Three test-side assertions deleted.
-- [Phase 10]: POLISH-04: chose option (c) exhaustive-match sentinel — _ensure_failure_kind_all_exhaustive const fn + const _: () = { assert!(FailureKind::ALL.len() == 4); }; smaller blast-radius than strum::EnumIter (option a)
-- [Phase 10]: POLISH-05: chose option (a) keep new() + add debug_assert!(path.is_absolute(), ...); single-site edit vs option (b) replacing 4 call sites
-- [Phase 10]: TEST-04: chose option (a) defer regen_warnings until after success banner — banner is user's anchor; option (b) [lockfile regen] prefix would add visual noise on every line
-- [Phase 10-phase-8-review-tail]: POLISH-01 redraw threading: closure-callback (\&mut dyn FnMut(\&App)) over pending_redraw flag (too late) and \&mut DefaultTerminal injection (couples App to ratatui type)
-- [Phase 10-phase-8-review-tail]: ui::render widened to &App; viewport-cache mutation hoisted to run_loop via new ui::body_height_for_area(area) pure helper, so the redraw closure can call terminal.draw(|f| ui::render(f, a)) without &mut conflict
-- [Phase 10-phase-8-review-tail]: POLISH-03 retry test bound: 600ms (not the originally-pinned 250ms) — macOS arboard under parallel cargo test has 5–500ms NSPasteboard contention; 600ms still catches the regression we care about (a SECOND retry hop)
-
 ### Pending Todos / Carry-over
 
-- **Linux UAT (v0.8 carry-over):** 2 pending items in `.planning/phases/08-*/08-HUMAN-UAT.md` — clipboard runtime + xdg-open runtime tests on a Linux desktop. Pending hardware. Run `/gsd:verify-work 08` when on Linux.
+- **Linux UAT (carry-over from v0.8):** 2 pending items in `.planning/phases/08-*/08-HUMAN-UAT.md` (clipboard runtime + xdg-open runtime tests). Pending Linux desktop hardware. Run `/gsd:verify-work 08` when on Linux. Carried over for the third consecutive milestone.
 - **Pre-existing flake:** `backup::tests::push_and_pull_roundtrip` — passes in isolation, intermittent in full suite. Worth a separate investigation pass.
 
 ### Blockers/Concerns
 
-- None for v0.9 Phase 9 entry.
+- None for v1.0 ratification.
 
 ## Session Continuity
 
-Last session: 2026-04-29T03:03:40.157Z
-Stopped at: Completed 10-01-tui-status-message-redesign-PLAN.md (POLISH-01 + POLISH-02 + POLISH-03 + TEST-03)
+Last session: 2026-04-29T00:00:00.000Z
+Stopped at: v0.9 milestone archived to milestones/v0.9-{ROADMAP,REQUIREMENTS}.md; PROJECT.md evolved; REQUIREMENTS.md deleted (fresh for v1.0).
 Resume file: None

--- a/.planning/milestones/v0.9-REQUIREMENTS.md
+++ b/.planning/milestones/v0.9-REQUIREMENTS.md
@@ -1,3 +1,12 @@
+# Requirements Archive: v0.9 Cross-Machine Config Portability & Polish
+
+**Archived:** 2026-04-29
+**Status:** SHIPPED
+
+For current requirements, see `.planning/REQUIREMENTS.md`.
+
+---
+
 # v0.9 Requirements: Cross-Machine Config Portability & Polish
 
 ## Milestone Goals

--- a/.planning/milestones/v0.9-ROADMAP.md
+++ b/.planning/milestones/v0.9-ROADMAP.md
@@ -1,0 +1,109 @@
+# Roadmap: tome
+
+## Milestones
+
+- ✅ **v0.6 Unified Directory Model** — Phases 1-3 (shipped 2026-04-16) — [archive](milestones/v0.6-ROADMAP.md)
+- ✅ **v0.7 Wizard Hardening** — Phases 4-6 (shipped 2026-04-22) — [archive](milestones/v0.7-ROADMAP.md)
+- ✅ **v0.8 Wizard UX & Safety Hardening** — Phases 7-8 + 8.1 hotfix (shipped 2026-04-27) — [archive](milestones/v0.8-ROADMAP.md)
+- ✅ **v0.9 Cross-Machine Config Portability & Polish** — Phases 9-10 (shipped 2026-04-29) — epic [#458](https://github.com/MartinP7r/tome/issues/458) + #462 + #463
+- 📋 **v1.0 tome Desktop (Tauri GUI)** — drafted — see [milestones/v1.0-REQUIREMENTS.md](milestones/v1.0-REQUIREMENTS.md) and [milestones/v1.0-ROADMAP.md](milestones/v1.0-ROADMAP.md). Sequenced after v0.9 by default; ratify via `/gsd:new-milestone` when v0.9 ships.
+
+## Phases
+
+<details>
+<summary>✅ v0.6 Unified Directory Model (Phases 1-3) — SHIPPED 2026-04-16</summary>
+
+- [x] Phase 1: Unified Directory Foundation (3/5 plans) — config type system, pipeline rewrite, state schema
+- [x] Phase 2: Git Sources & Selection (4/4 plans) — git clone/update, per-dir filtering, tome remove
+- [x] Phase 3: Import, Reassignment & Browse Polish (2/2 plans) — tome add/reassign/fork, browse TUI polish
+
+**Known gaps:** WIZ-01 through WIZ-05 (wizard rewrite) deferred — closed as "hardened" in v0.7.
+
+</details>
+
+<details>
+<summary>✅ v0.7 Wizard Hardening (Phases 4-6) — SHIPPED 2026-04-22</summary>
+
+- [x] Phase 4: Wizard Correctness (3/3 plans) — `Config::validate()` Conflict+Why+Suggestion errors, library↔distribution overlap detection (Cases A/B/C), `Config::save_checked` expand→validate→round-trip→write pipeline (WHARD-01/02/03)
+- [x] Phase 5: Wizard Test Coverage (4/4 plans) — `--no-input` plumbing + `assemble_config` helper extraction, pure-helper unit tests, `tome init --dry-run --no-input` integration tests, 12-combo `(DirectoryType, DirectoryRole)` matrix (WHARD-04/05/06)
+- [x] Phase 6: Display Polish & Docs (2/2 plans) — wizard summary migrated to `tabled::Table` with `Style::rounded()` + `PriorityMax::right()` truncation, PROJECT.md "Hardened in v0.7" subsection, CHANGELOG WHARD-07/08 entries (WHARD-07/08)
+
+**Closed WIZ-01..05:** v0.6's known wizard gaps are now shipped AND hardened.
+
+</details>
+
+<details>
+<summary>✅ v0.8 Wizard UX & Safety Hardening (Phases 7-8 + 8.1) — SHIPPED 2026-04-27</summary>
+
+- [x] Phase 7: Wizard UX — Greenfield / Brownfield / Legacy (4/4 plans) — `tome init` handles new machines, existing configs, and pre-v0.6 cruft without surprises; resolved `tome_home` surfaced up-front and optionally persisted via XDG config (WUX-01/02/03/04/05)
+- [x] Phase 8: Safety Refactors — Partial-Failure Visibility & Cross-Platform (3/3 plans) — `tome remove` aggregates partial-cleanup failures with non-zero exit, `tome browse` works on Linux via `xdg-open` + `arboard`, silent `read_link().ok()` drops replaced with stderr warnings (SAFE-01/02/03)
+- [x] Phase 8.1: v0.8.1 hotfix — lockfile regen + save chain (3/3 plans) — `resolved_paths_from_lockfile_cache` helper restores git-skill provenance after Remove/Reassign/Fork (H1), `Command::Remove` save chain reordered to surface partial-failure ⚠ block before save errors (H2), failure-summary wording reworded (H3)
+
+**Released as:** v0.8.0 (2026-04-26) + v0.8.1 hotfix (2026-04-27)
+**Carry-over:** 2 Linux-runtime UAT items in `08-HUMAN-UAT.md` (clipboard / xdg-open) — accepted as carry-over pending Linux desktop hardware
+
+</details>
+
+### v0.9 Cross-Machine Config Portability & Polish — SHIPPED 2026-04-29
+
+Released as v0.9.0 (2026-04-29).
+
+Epic: [#458](https://github.com/MartinP7r/tome/issues/458) — `machine.toml` path overrides for cross-machine portability. Bundled with #462 (test/wording/dead-code polish) and #463 (type-design + TUI architecture polish) to clear the v0.8 post-merge review tail in one cut.
+
+- [x] **Phase 9: Cross-Machine Path Overrides** — `[directory_overrides.<name>]` in `machine.toml` lets a single `tome.toml` work across machines with different filesystem layouts (PORT-01..05) (completed 2026-04-28)
+- [x] **Phase 10: Phase 8 Review Tail — Type Design, TUI Polish & Test Coverage** — close the 11 post-merge review items from #462 + #463 (POLISH-01..06, TEST-01..05) (completed 2026-04-29)
+
+### v1.0 tome Desktop — Tauri GUI (Drafted)
+
+Forward-planning artifacts:
+- [`milestones/v1.0-REQUIREMENTS.md`](milestones/v1.0-REQUIREMENTS.md) — 32 requirements across 7 categories (CORE / VIEW / SYNC / CFG / OPS / BAK / DIST) plus 5 cross-cutting NF gates.
+- [`milestones/v1.0-ROADMAP.md`](milestones/v1.0-ROADMAP.md) — 7 phases (10–16) with three intermediate cuts (alpha after 11, beta after 13, rc after 15, v1.0 after 16). Rough size: 15–22 weeks of focused work.
+
+**Sequencing:** v0.9 → v1.0 by default (D-GUI-09). v0.9 hardens `machine.toml` semantics that v1.0 leans on. Swap allowed; parallelism not recommended.
+
+**Framework:** Tauri 2 (D-GUI-01). Reuses Rust crate as native backend; no N-API. ~8 MB bundle vs Electron's ~150 MB; built-in code-signed auto-update; same Developer ID flow as the CLI.
+
+Phases will be planned via `/gsd:new-milestone` when v1.0 becomes active. Phase numbering assumes v0.9 takes Phases 9–10; renumber if v0.9's phase footprint differs.
+
+## Phase Details
+
+### Phase 9: Cross-Machine Path Overrides
+**Goal**: A single `tome.toml` checked into dotfiles can be applied across machines with different filesystem layouts via per-machine `[directory_overrides.<name>]` blocks in `machine.toml`.
+**Depends on**: Phase 8.1 (v0.8.1 baseline — load pipeline + machine.toml schema stable)
+**Requirements**: PORT-01, PORT-02, PORT-03, PORT-04, PORT-05
+**Success Criteria** (what must be TRUE):
+  1. User can add `[directory_overrides.<name>]` blocks to `machine.toml` and a subsequent `tome sync` / `tome status` operates on the overridden `path` for that directory without any edits to the synced `tome.toml`.
+  2. Override application happens once at config load time (after tilde expansion, before `Config::validate`), so every downstream command (`sync`, `status`, `doctor`, `lockfile::generate`) sees the same merged result — no second code path can observe pre-override paths.
+  3. An override targeting a directory name that doesn't exist in `tome.toml` produces a single stderr `warning:` line naming the typo and continues loading; it does not abort the command.
+  4. A validation failure caused by an override (e.g., overridden path overlaps `library_dir`) surfaces with a distinct error class that names `machine.toml` as the file to edit, not `tome.toml`.
+  5. `tome status` and `tome doctor` mark each overridden directory entry visibly (e.g., `(override)` annotation or dedicated column) so the user can answer "why is this path different on this machine?" without diffing files.
+**Plans**: TBD
+
+### Phase 10: Phase 8 Review Tail — Type Design, TUI Polish & Test Coverage
+**Goal**: Close the 11 post-merge review items from #462 (P1-P5) and #463 (D1-D6) so the v0.8 review tail is fully cleared in one cut.
+**Depends on**: Phase 9 (sequential — keeps PORT delivery clean and avoids interleaving review-tail churn with the portability epic)
+**Requirements**: POLISH-01, POLISH-02, POLISH-03, POLISH-04, POLISH-05, POLISH-06, TEST-01, TEST-02, TEST-03, TEST-04, TEST-05
+**Success Criteria** (what must be TRUE):
+  1. `tome browse` `open` shows an "Opening: <path>..." status before blocking on `xdg-open`/`open`, any keystrokes typed during the block are drained instead of replayed, and `ClipboardOccupied` errors are auto-retried once with a 100ms backoff before any warning reaches the status bar.
+  2. `StatusMessage` is a single `Success(String) | Warning(String)` enum with `body()`/`glyph()`/`severity()` accessors, `pub(super)` visibility, and audited test-only derives — pre-formatted glyphs in `text` are gone and `ViewSource .status()` routes through a tested `status_message_from_open_result(...)` helper covering Ok+success, Ok+non-zero exit, and Err arms.
+  3. `FailureKind::ALL` cannot drift from the enum (compile-enforced via `EnumIter` or equivalent), `RemoveFailure::new` either carries a real `debug_assert!` invariant or is replaced by struct-literal construction at the four call sites, and `arboard` is pinned to a patch range with a documented bump-review policy in `Cargo.toml`.
+  4. `regen_warnings` ordering on the happy path is pinned in code (deferred until after the success banner OR scoped with a `[lockfile regen]` prefix) and a regression test fails if the order regresses; the dead `SkillMoveEntry.source_path` field is either removed or wired into `copy_library`/`recreate_target_symlinks`, and `#[allow(dead_code)]` is gone from `relocate.rs`.
+  5. `remove_partial_failure_exits_nonzero_with_warning_marker` asserts the `✓ Removed directory` success banner is **absent** from stdout on partial failure, and an end-to-end test pins the I2/I3 retention contract: partial failure → user fixes the underlying condition → second `tome remove <name>` succeeds with empty `failures`, config entry gone, manifest empty, library dir gone.
+**Plans**: TBD
+**UI hint**: yes
+
+## Progress
+
+| Phase | Milestone | Plans Complete | Status | Completed |
+|-------|-----------|----------------|--------|-----------|
+| 1. Unified Directory Foundation | v0.6 | 3/5 | Complete | 2026-04-14 |
+| 2. Git Sources & Selection | v0.6 | 4/4 | Complete | 2026-04-15 |
+| 3. Import, Reassignment & Browse Polish | v0.6 | 2/2 | Complete | 2026-04-16 |
+| 4. Wizard Correctness | v0.7 | 3/3 | Complete | 2026-04-19 |
+| 5. Wizard Test Coverage | v0.7 | 4/4 | Complete | 2026-04-20 |
+| 6. Display Polish & Docs | v0.7 | 2/2 | Complete | 2026-04-22 |
+| 7. Wizard UX (Greenfield / Brownfield / Legacy) | v0.8 | 4/4 | Complete | 2026-04-23 |
+| 8. Safety Refactors (Partial-Failure Visibility & Cross-Platform) | v0.8 | 3/3 | Complete | 2026-04-24 |
+| 8.1. v0.8.1 hotfix — lockfile regen + save chain | v0.8 | 3/3 | Complete | 2026-04-27 |
+| 9. Cross-Machine Path Overrides | v0.9 | 2/3 | Complete    | 2026-04-28 |
+| 10. Phase 8 Review Tail — Type Design, TUI Polish & Test Coverage | v0.9 | 3/3 | Complete    | 2026-04-29 |


### PR DESCRIPTION
## Summary

Archives the v0.9 Cross-Machine Config Portability & Polish milestone. v0.9.0 already shipped via \`make release\` (commits c183e3f Phase 10 + 0ae6288 version bump on main). This PR is documentation-only.

- 16 v0.9 requirements (5 PORT + 6 POLISH + 5 TEST) all validated; 11 plans across Phases 9 + 10
- Plus the bare-slug \`tome add\` improvement (PR #471) bundled into v0.9.0
- Archives created: \`.planning/milestones/v0.9-ROADMAP.md\` (with archive-snapshot patched to ✅ shipped state) + \`.planning/milestones/v0.9-REQUIREMENTS.md\`
- \`ROADMAP.md\` collapses v0.9 into a \`<details>\` block matching v0.6/v0.7/v0.8 conventions; verbose phase-detail sections removed (now in archive)
- \`PROJECT.md\` evolved: 11 POLISH-XX/TEST-XX moved to Validated; Current State section reflects v0.9.0 ship; Next Milestone Goals points at v1.0 Tauri GUI; Key Decisions extended with 9 new v0.9 entries
- \`RETROSPECTIVE.md\` extended with v0.9 milestone retrospective and updated cross-milestone trends (now 3 milestones tracked + 2 new patterns documented)
- \`STATE.md\` reset to between-milestones, ready for v1.0 ratification
- \`REQUIREMENTS.md\` renamed to \`milestones/v0.9-REQUIREMENTS.md\`

No code changes. Documentation/planning artifacts only.

## Note on tags

v0.9.0 release tag already exists from \`make release\` (commit \`0ae6288\`). The complete-milestone workflow's \`git tag -a v0.9\` step was **intentionally skipped** per stored project policy — release tags come from \`make release\`, not from milestone closure. (Same pattern as the v0.8 closure.)

## Note on MILESTONES.md

\`gsd-tools milestone complete\` produced a malformed v0.9 entry with cumulative stats ("11 phases / 36 plans / 78 tasks" — counted across the project's entire history) and accomplishments from every prior phase including a literal \`RED:\` line extracted from a TDD-style summary header. The MILESTONES.md entry has been **manually rewritten** with milestone-scoped 6 accomplishments and correct counts (2 phases / 6 plans / ~26 tasks). Filed mentally as a v1.0-era \`gsd-tools\` improvement target.

## Out of scope (intentionally untracked)

- \`.planning/milestones/v1.0-{REQUIREMENTS,ROADMAP}.md\` — v1.0 Tauri GUI forward-planning artifacts authored separately. Referenced from this PR's PROJECT.md and ROADMAP.md (markdown links will appear broken on GitHub until you commit those separately, then folded into v1.0 ratification).
- \`docs/migration/rust-to-typescript-feature-inventory.md\` — same separate-session forward-planning work.

## Carry-over

- 2 Linux-runtime UAT items in \`08-HUMAN-UAT.md\` still pending hardware (third consecutive milestone)
- Pre-existing \`backup::tests::push_and_pull_roundtrip\` flake — investigation deferred

## Test plan

- [x] No code changes; planning docs only
- [x] All 16 v0.9 requirements have phase mappings + \`[x]\` complete in archived REQUIREMENTS.md
- [x] v0.9 archive snapshot patched to reflect shipped state (✅ shipped 2026-04-29, not 🚧 active)