### PR TITLE
chore(v1.0-prep): doc drift cleanup + targeted safety fixes

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,18 +1,20 @@
 # Architecture
 
-**Analysis Date:** 2025-04-05
+**Analysis Date:** 2026-04-30 (v0.9.0)
 
 ## Pattern Overview
 
-**Overall:** Two-tier source → library → target pipeline
+**Overall:** Two-tier discovery → library → distribution pipeline. Each configured directory declares a `type` and a `role` (`managed`/`synced`/`source`/`target`); the pipeline asks each directory's role what to do with it.
 
 **Key Characteristics:**
 - Unix-only symlink-based distribution (uses `std::os::unix::fs::symlink`)
 - Idempotent consolidation with SHA-256 content hashing
 - Managed vs. local dual consolidation strategies
-- Data-driven target configuration (BTreeMap-based)
+- Data-driven directory configuration (BTreeMap-based, role-driven)
+- Per-machine path overrides via `[directory_overrides.<name>]` in `machine.toml` (PORT-01..05, v0.9)
 - Dry-run threading throughout all operations
 - Atomic file writes with temp+rename pattern
+- Plan / render / execute pattern for `add`, `remove`, `reassign`, `relocate`, `eject`
 
 ## Layers
 
@@ -26,7 +28,7 @@
 **Configuration Layer:**
 - Purpose: Load, validate, and manage TOML config files
 - Location: `crates/tome/src/config.rs`, `crates/tome/src/paths.rs`, `crates/tome/src/machine.rs`
-- Contains: `Config` (sources/targets), `TargetName`, `SkillName`, `TomePaths` (path bundling), `MachinePrefs` (per-machine disable lists)
+- Contains: `Config` (`directories: BTreeMap<DirectoryName, DirectoryConfig>`), `DirectoryName`, `DirectoryType`, `DirectoryRole`, `SkillName`, `TomePaths` (path bundling), `MachinePrefs` (per-machine disable lists + `[directory_overrides.<name>]` path remapping)
 - Depends on: `serde`, file I/O, tilde expansion
 - Used by: All domain operations
 
@@ -75,7 +77,7 @@
 **Linting & Validation:**
 - Purpose: Validate SKILL.md frontmatter and directory structure
 - Location: `crates/tome/src/lint.rs`, `crates/tome/src/skill.rs`, `crates/tome/src/validation.rs`
-- Contains: Frontmatter parsing (YAML), content hashing, skill name/target name validation
+- Contains: Frontmatter parsing (YAML), content hashing, skill name / directory name validation (shared `validate_identifier`)
 - Depends on: `serde_yaml`, `sha2`, regex patterns
 - Used by: Lint command, consolidate (validation)
 
@@ -130,15 +132,25 @@
 - Examples: `crates/tome/src/discover.rs` (SkillName type)
 - Pattern: Newtype wrapper with `new()` constructor, lenient validation (rejects empty + path separators), strict convention checking (lowercase + digits + hyphens)
 
-**TargetName:**
-- Purpose: Validated, type-safe target identifier
-- Examples: `crates/tome/src/config.rs` (TargetName type)
-- Pattern: Same as SkillName; prevents accidental string parameter mixing
+**DirectoryName:**
+- Purpose: Validated, type-safe directory identifier
+- Examples: `crates/tome/src/config.rs` (DirectoryName type)
+- Pattern: Same as SkillName; prevents accidental string parameter mixing. Used as the key in `Config::directories`.
 
-**SourceType:**
-- Purpose: Enum-based source discovery strategy
-- Examples: `crates/tome/src/config.rs` (SourceType enum)
-- Pattern: Variants = ClaudePlugins (plugin-based), Directory (flat walkdir). Determines consolidation strategy.
+**DirectoryType:**
+- Purpose: Enum-based discovery strategy
+- Examples: `crates/tome/src/config.rs` (DirectoryType enum)
+- Pattern: Variants = `ClaudePlugins` (reads `installed_plugins.json`), `Directory` (flat walkdir), `Git` (shallow clone into `~/.tome/repos/<sha256>/` then walk). Determines consolidation strategy.
+
+**DirectoryRole:**
+- Purpose: Enum-based pipeline role
+- Examples: `crates/tome/src/config.rs` (DirectoryRole enum)
+- Pattern: Variants = `Managed` (read-only source), `Synced` (source AND target — same dir is both read AND written), `Source` (discovery only), `Target` (distribution only). `is_discovery()` / `is_distribution()` accessors.
+
+**DirectoryOverride:**
+- Purpose: Per-machine path remapping for a single `[directories.<name>]` entry
+- Examples: `crates/tome/src/machine.rs` (DirectoryOverride struct)
+- Pattern: Lives in `MachinePrefs::directory_overrides` (`BTreeMap<DirectoryName, DirectoryOverride>`). Currently only `path` is supported (PORT-01); applied at config load before validation.
 
 **TomePaths:**
 - Purpose: Bundle tome_home + library_dir + config_dir to prevent swaps

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,6 +1,6 @@
 # Coding Conventions
 
-**Analysis Date:** 2026-04-05
+**Analysis Date:** 2026-04-30 (v0.9.0)
 
 ## Naming Patterns
 
@@ -17,12 +17,12 @@
 **Variables:**
 - Lowercase snake_case: `tmp_dir`, `source_path`, `skill_name`
 - Single-letter loop variables acceptable in short contexts: `for (k, v) in...`
-- Collection variables use plural forms: `sources`, `targets`, `skills`, `directories`
+- Collection variables use plural forms: `skills`, `directories`, `failures`
 
 **Types:**
-- PascalCase for struct/enum names: `SkillName`, `TargetName`, `DiscoveredSkill`, `SkillOrigin`, `SyncReport`
+- PascalCase for struct/enum names: `SkillName`, `DirectoryName`, `DiscoveredSkill`, `SkillOrigin`, `SyncReport`
 - Newtype wrappers use transparent repr: `pub struct SkillName(String);`
-- Enums descriptive and specific: `SourceType::ClaudePlugins`, `SkillOrigin::Managed { provenance }`
+- Enums descriptive and specific: `DirectoryType::ClaudePlugins`, `DirectoryRole::Synced`, `SkillOrigin::Managed { provenance }`
 
 ## Code Style
 
@@ -207,7 +207,7 @@ pub struct SyncReport { ... }
 ## Type Safety
 
 **Newtype Pattern:**
-- Used for domain types to prevent mixing (e.g., `SkillName`, `TargetName`, `ContentHash`)
+- Used for domain types to prevent mixing (e.g., `SkillName`, `DirectoryName`, `ContentHash`)
 - Provides validation at construction time
 - Implements `AsRef<str>`, `Display`, `Borrow<str>` for ergonomics
 - Custom `Deserialize` impl validates on deserialization

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,6 +1,6 @@
 # Technology Stack
 
-**Analysis Date:** 2026-04-05
+**Analysis Date:** 2026-04-30 (v0.9.0)
 
 ## Languages
 
@@ -27,6 +27,7 @@
 - `ratatui` 0.30 - Terminal UI framework (TUI) for `tome browse` command
 - `crossterm` 0.29 - Terminal event handling and cursor control
 - `nucleo-matcher` 0.3 - Fuzzy matching for interactive search in browse view
+- `arboard` `>=3.6, <3.7` patch-pinned - Cross-platform clipboard for `tome browse` copy-path action (X11 + Wayland data-control); pinned with bump-review policy in workspace `Cargo.toml` (POLISH-06)
 
 **Data & Configuration:**
 - `serde` 1 with derive - Serialization/deserialization framework

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,11 +1,11 @@
 # Codebase Structure
 
-**Analysis Date:** 2025-04-05
+**Analysis Date:** 2026-04-30 (v0.9.0)
 
 ## Directory Layout
 
 ```
-/Users/martin/code/opensource/tome/
+/Users/martin/dev/opensource/tome/
 ├── crates/                              # Workspace members
 │   └── tome/                            # Main crate (binary + library)
 │       ├── src/                         # Source code
@@ -124,7 +124,7 @@
 - `crates/tome/src/browse/fuzzy.rs`: nucleo-matcher fuzzy search
 
 **Utilities & Helpers:**
-- `crates/tome/src/config.rs`: TOML loading, TargetName, SkillName, tilde expansion
+- `crates/tome/src/config.rs`: TOML loading, `DirectoryName`, `DirectoryType`, `DirectoryRole`, `DirectoryConfig`, `Config::apply_machine_overrides`, tilde expansion
 - `crates/tome/src/paths.rs`: TomePaths bundling, symlink resolution
 - `crates/tome/src/machine.rs`: Per-machine preferences (machine.toml)
 - `crates/tome/src/validation.rs`: Shared validation (identifiers, content hashing)
@@ -163,8 +163,8 @@
 - Submodules: Namespace under parent (e.g., `browse/mod.rs`, `browse/app.rs`)
 
 **Types:**
-- Newtype wrappers: `SkillName(String)`, `TargetName(String)`, `ContentHash(String)`
-- Enums: `Command` (subcommands), `SourceType` (discovery strategy), `TargetMethod` (distribution method)
+- Newtype wrappers: `SkillName(String)`, `DirectoryName(String)`, `ContentHash(String)`, `TomePaths`
+- Enums: `Command` (subcommands), `DirectoryType` (`ClaudePlugins`/`Directory`/`Git`), `DirectoryRole` (`Managed`/`Synced`/`Source`/`Target`), `SkillOrigin` (`Managed { provenance }` / `Local`)
 - Structs: Descriptive names, e.g., `DiscoveredSkill`, `SkillEntry`, `ConsolidateResult`
 
 **Functions:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,15 @@ This file provides guidance to Claude Code (claude.ai/code) and other AI agents 
 
 ## Current State
 
-**v0.6.0 (unreleased)** — Unified Directory Model milestone complete. Config uses `[directories.*]` BTreeMap replacing separate `[[sources]]` + `[targets.*]`. Git-backed skill repos with shallow clone, ref pinning, SHA in lockfile. Per-directory skill filtering (`enabled`/`disabled` in `machine.toml`). CLI commands: `tome add`, `tome remove`, `tome reassign`, `tome fork`. Browse TUI: adaptive theming, fuzzy match highlighting, scrollbar, markdown preview, help overlay. Known gap: wizard rewrite (WIZ-01–05) deferred.
+**v0.9.0 (shipped 2026-04-29)** — between milestones; v1.0 (Tauri GUI) drafted in `.planning/milestones/v1.0-{REQUIREMENTS,ROADMAP}.md`, awaiting `/gsd:new-milestone` to ratify.
+
+Cumulative through v0.9:
+- **v0.6 — Unified Directory Model**: `[directories.*]` BTreeMap replacing `[[sources]]` + `[targets.*]`; git-backed skill repos with shallow clone + ref pinning + SHA in lockfile; per-directory skill filtering (`enabled`/`disabled` in `machine.toml`); CLI commands `tome add`, `tome remove`, `tome reassign`, `tome fork`; browse TUI polish (theming, fuzzy highlighting, scrollbar, markdown preview, help overlay).
+- **v0.7 — Wizard Hardening**: WIZ-01–05 formally validated and unit-tested (registry invariants, `find_known_directories_in` coverage, circular-path detection); legacy pre-v0.6 config detection (WUX-03).
+- **v0.8 — Cross-Platform Polish**: partial-failure visibility in `tome browse`; cross-platform clipboard via arboard; xdg-open integration; HOTFIX-01/02/03 (lockfile regen + save chain ordering).
+- **v0.9 — Cross-Machine Path Overrides**: `[directory_overrides.<name>]` schema in `machine.toml` (PORT-01..05); override-induced validation errors named `machine.toml`; `(override)` annotation in `tome status`/`tome doctor`; Phase-8 review tail (`StatusMessage` enum redesign, `RemoveFailure` invariants, `arboard` patch-pin policy, dead-code removal).
+
+Open carry-overs: 2 Linux-runtime UAT items (clipboard + xdg-open) pending Linux hardware; intermittent `backup::tests::push_and_pull_roundtrip` flake.
 
 ## Quick Reference
 
@@ -140,7 +148,7 @@ The main binary. All domain logic lives here as a library (`lib.rs` re-exports a
 4. **Cleanup** (`cleanup.rs`) — Remove stale entries from library (skills no longer in any source), broken symlinks from targets, and disabled skill symlinks from target directories. Interactive in TTY mode; auto-removes with warning otherwise.
 
 **Other modules:**
-- `wizard.rs` — Interactive `tome init` setup using `dialoguer`. Auto-discovers known directory locations. (Note: still uses legacy source/target model — wizard rewrite deferred.)
+- `wizard.rs` — Interactive `tome init` setup using `dialoguer`. Uses the merged `KNOWN_DIRECTORIES` registry (WIZ-01, hardened in v0.7). Auto-discovers known directory locations and detects legacy pre-v0.6 configs.
 - `config.rs` — TOML config at `~/.tome/tome.toml`. `Config::load_or_default` handles missing files gracefully. All path fields support `~` expansion. `DirectoryName`, `DirectoryType`, `DirectoryRole`, `DirectoryConfig` types.
 - `manifest.rs` — Library manifest (`.tome-manifest.json`): tracks provenance, content hashes, and sync timestamps for each skill. Provides `hash_directory()` for deterministic SHA-256 of directory contents.
 - `doctor.rs` — Diagnoses library issues (orphan directories, missing manifest entries, broken legacy symlinks) and missing directory paths; interactive per-item repair for orphans.
@@ -214,9 +222,9 @@ This project uses **GitHub Issues** for backlog and roadmap intent, and **GSD** 
 <!-- GSD:project-start source:PROJECT.md -->
 ## Project
 
-**tome v0.6 — Unified Directory Model**
+**tome v0.9 — Cross-Machine Path Overrides (shipped); v1.0 — Desktop GUI (drafted)**
 
-tome is a CLI tool that manages AI coding agent skills across multiple tools (Claude Code, Codex, Antigravity, Cursor, etc.). It discovers skills from configured directories, consolidates them into a central library, and distributes them to target tools via symlinks. v0.6 shipped the unified directory model where each configured directory declares its type and role.
+tome is a CLI tool that manages AI coding agent skills across multiple tools (Claude Code, Codex, Antigravity, Cursor, etc.). It discovers skills from configured directories, consolidates them into a central library, and distributes them to target tools via symlinks. The unified directory model (v0.6) is the foundation; subsequent milestones hardened the wizard (v0.7), polished cross-platform UX (v0.8), and added per-machine path overrides for portability (v0.9). v1.0 will add a Tauri desktop GUI on top of the existing CLI library.
 
 **Core Value:** Every AI coding tool on a developer's machine shares the same skill library without manual copying or per-tool configuration. One config, one library, every tool.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-29
+
+The **v0.9 Cross-Machine Path Overrides** milestone. Adds a per-machine path-remapping layer in `machine.toml` so the same `tome.toml` can ship in dotfiles across machines with divergent on-disk layouts. Bundles a Phase-8 review-tail pass that hardens the v0.8 `tome browse` partial-failure UX and lifts a `StatusMessage` enum.
+
 ### Added
 
-- `tome add <owner>/<repo>` now expands a bare GitHub slug to `https://github.com/<owner>/<repo>` so users can paste an `org/repo` token directly from the address bar without ceremony. URLs (anything containing `://` or starting with `git@`) are left untouched, and the heuristic refuses paths with relative segments (`./foo`, `../bar`) or invalid characters (spaces, etc.) so a typo never confidently rewrites to the wrong clone target. Example: `tome add planetscale/database-skills` is now equivalent to `tome add https://github.com/planetscale/database-skills`.
+- `[directory_overrides.<name>]` section in `machine.toml` for per-machine path remapping. Each override entry can supply a `path` that replaces the value in `tome.toml`, allowing the same shared config to work across machines whose home layouts differ. Override application happens at config load (after tilde expansion, before `Config::validate`), so all downstream code sees the canonical post-override paths. Unknown override directory names emit a typo-target stderr warning instead of silently being ignored. Override-induced validation failures are wrapped with a distinct error attributing them to `machine.toml` rather than `tome.toml`. (PORT-01..04, [#458](https://github.com/MartinP7r/tome/issues/458))
+- `(override)` annotation in `tome status` and `tome doctor` text and JSON output for any directory whose path was rewritten by a `machine.toml` override, so the user can tell at a glance which paths come from the portable config and which come from the machine-local layer. (PORT-05)
+- TUI status-bar `Pending` state for in-progress actions: `Opening: <path>...` appears in `tome browse` before the `xdg-open`/`open` syscall returns, replacing the prior "no feedback" gap. Pre-block status messages drain pending TTY events to avoid stale keypresses interleaving with the `Success`/`Warning` outcome banner. (POLISH-01)
+- `ClipboardOccupied` errors in `tome browse copy path` now auto-retry once with a 100 ms backoff before surfacing the warning, so most transient X11/Wayland data-control collisions become invisible to the user. (POLISH-03)
+- Test additions: success-banner-absence assertion on `tome remove` partial-failure (TEST-01); end-to-end retry-after-fix coverage (TEST-02); `status_message_from_open_result` 3-arm unit tests (TEST-03); `regen_warnings` deferred-emit ordering (TEST-04).
+
+### Changed
+
+- `StatusMessage` redesigned as a `Success | Warning | Pending` enum with `body`, `glyph`, and `severity` accessors. Old code that built status text by string concatenation is gone; all callers funnel through the enum so glyph + colorization stay consistent. (POLISH-02, [#463](https://github.com/MartinP7r/tome/issues/463))
+- `FailureKind::ALL` is now compile-time-enforced via an exhaustive-match sentinel: adding a new `FailureKind` variant without updating `ALL` is a compile error. Eliminates the silent-drop class of bugs where a new failure kind would be omitted from the partial-failure summary. (POLISH-04)
+- `RemoveFailure::new` adds a `debug_assert!(path.is_absolute())` invariant. Catches the "relative path leaked into a removal failure record" class of bug in debug builds before it reaches the user-facing summary. (POLISH-05)
+- `arboard` is now patch-pinned to `>=3.6, <3.7` with an in-line bump-review policy (Cargo.toml). The match arms in `browse/app.rs::execute_action` and `try_clipboard_set_text_with_retry` must remain exhaustive — a new `arboard::Error` variant unobserved is a silent UX regression because the fall-through branch hides the semantic. The pin forces a manual review on minor bumps. (POLISH-06)
 
 ### Fixed
 
-- `tome remove` now aggregates partial-cleanup failures and exits non-zero with a distinct `⚠ N operations failed` summary grouped by failure kind (distribution symlinks, library entries, library symlinks, git cache). The success banner (`✓ Removed directory ...`) is suppressed entirely when failures occur, so it cannot hide a `⚠` warning that scrolled off-screen. On partial failure the directory's config entry AND its manifest entries are preserved so the user can re-run `tome remove <name>` after addressing the underlying cause (typically permission fixes) — previously the config was unconditionally dropped, leaving orphaned filesystem artifacts with no programmatic recovery path. Previously the command reported success while filesystem artifacts leaked. ([#413](https://github.com/MartinP7r/tome/issues/413))
-- `tome browse` actions `open` (ViewSource) and `copy path` (CopyPath) now work on Linux — `open` dispatches to `xdg-open` and `copy path` uses the `arboard` crate with both X11 and Wayland (`wayland-data-control`) backends enabled. `open` now uses `.status()` instead of `.spawn()` so a non-zero exit from `xdg-open` (no MIME handler, no DISPLAY) surfaces as `⚠ xdg-open exited N for: <path>` instead of the previous silent `✓ Opened` lie. Clipboard failures surface targeted hints: `⚠ Clipboard unavailable (headless or unsupported session)` for `ClipboardNotSupported`, `⚠ Clipboard busy (another app is holding it); try again` for `ClipboardOccupied`. Both success (`✓`) and failure (`⚠`) outcomes appear in the TUI status bar in place of the keybind line until the next keypress, replacing the prior macOS-only silent-drop behavior. The `sh -c "echo -n ${path} | pbcopy"` invocation is removed (eliminates a command-injection vector). ([#414](https://github.com/MartinP7r/tome/issues/414))
-- Wizard summary table now aligns correctly in interactive terminals. Previously, the bold ANSI escape codes wrapping header cells (e.g. `\x1b[1mNAME\x1b[0m`) were counted as visible characters by `tabled 0.20`'s default width calculation, inflating header cell widths by 8 columns and misaligning the column dividers with the body rows. Enabled tabled's `ansi` feature so escape sequences are correctly excluded from width measurement.
 - `tome relocate` now emits a stderr warning (`warning: could not read symlink at <path>: <error>`) when a managed-skill symlink cannot be read, instead of silently recording the entry as having no provenance. Mirrors the eprintln-warning pattern shipped in PR #448. ([#449](https://github.com/MartinP7r/tome/issues/449))
+
+### Internal
+
+- Dead `SkillMoveEntry.source_path` field removed; `tome relocate` no longer carries the unused field through its move plan. (TEST-05)
+
+## [0.8.2] - 2026-04-27
+
+### Added
+
+- `tome add <owner>/<repo>` now expands a bare GitHub slug to `https://github.com/<owner>/<repo>` so users can paste an `org/repo` token directly from the address bar without ceremony. URLs (anything containing `://` or starting with `git@`) are left untouched, and the heuristic refuses paths with relative segments (`./foo`, `../bar`) or invalid characters (spaces, etc.) so a typo never confidently rewrites to the wrong clone target. Example: `tome add planetscale/database-skills` is now equivalent to `tome add https://github.com/planetscale/database-skills`. ([#471](https://github.com/MartinP7r/tome/pull/471))
+
+## [0.8.1] - 2026-04-26
+
+The **v0.8.1 hotfix** for the v0.8.0 release. Fixes a lockfile regen + save chain ordering issue surfaced immediately after the v0.8.0 cut. ([#468](https://github.com/MartinP7r/tome/pull/468))
+
+### Fixed
+
+- `tome sync` save-chain ordering: lockfile regeneration runs after manifest persist so a partial-failure mid-chain cannot leave the lockfile pointing at a manifest entry that was never written. Distinct error wording on lockfile-vs-manifest failures so the user can tell which step blew up. (HOTFIX-01/02/03)
+
+## [0.8.0] - 2026-04-26
+
+The **v0.8 Safety Refactors** milestone — partial-failure visibility, cross-platform `tome browse`, and surfaced warnings. Closes the longstanding gap where `tome remove` and `tome browse` actions could fail silently. ([#460](https://github.com/MartinP7r/tome/pull/460))
+
+### Fixed
+
+- `tome remove` now aggregates partial-cleanup failures and exits non-zero with a distinct `⚠ N operations failed` summary grouped by failure kind (distribution symlinks, library entries, library symlinks, git cache). The success banner (`✓ Removed directory ...`) is suppressed entirely when failures occur, so it cannot hide a `⚠` warning that scrolled off-screen. On partial failure the directory's config entry AND its manifest entries are preserved so the user can re-run `tome remove <name>` after addressing the underlying cause (typically permission fixes) — previously the config was unconditionally dropped, leaving orphaned filesystem artifacts with no programmatic recovery path. Previously the command reported success while filesystem artifacts leaked. (SAFE-01, [#413](https://github.com/MartinP7r/tome/issues/413))
+- `tome browse` actions `open` (ViewSource) and `copy path` (CopyPath) now work on Linux — `open` dispatches to `xdg-open` and `copy path` uses the `arboard` crate with both X11 and Wayland (`wayland-data-control`) backends enabled. `open` now uses `.status()` instead of `.spawn()` so a non-zero exit from `xdg-open` (no MIME handler, no DISPLAY) surfaces as `⚠ xdg-open exited N for: <path>` instead of the previous silent `✓ Opened` lie. Clipboard failures surface targeted hints: `⚠ Clipboard unavailable (headless or unsupported session)` for `ClipboardNotSupported`, `⚠ Clipboard busy (another app is holding it); try again` for `ClipboardOccupied`. Both success (`✓`) and failure (`⚠`) outcomes appear in the TUI status bar in place of the keybind line until the next keypress, replacing the prior macOS-only silent-drop behavior. The `sh -c "echo -n ${path} | pbcopy"` invocation is removed (eliminates a command-injection vector). (SAFE-02, [#414](https://github.com/MartinP7r/tome/issues/414))
+- Wizard summary table now aligns correctly in interactive terminals. Previously, the bold ANSI escape codes wrapping header cells (e.g. `\x1b[1mNAME\x1b[0m`) were counted as visible characters by `tabled 0.20`'s default width calculation, inflating header cell widths by 8 columns and misaligning the column dividers with the body rows. Enabled tabled's `ansi` feature so escape sequences are correctly excluded from width measurement.
 
 ## [0.7.0] - 2026-04-23
 

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -235,9 +235,16 @@ pub fn run(cli: Cli) -> Result<()> {
                     }
                     wizard::BrownfieldAction::Edit => match existing_config {
                         Ok(c) => Some(c.clone()),
-                        Err(_) => unreachable!(
-                            "brownfield_decision does not offer Edit for unparsable configs"
-                        ),
+                        Err(e) => {
+                            // The Edit action is only offered when the existing
+                            // config parses cleanly (see wizard::brownfield_decision).
+                            // Reaching this arm with Err means a refactor broke that
+                            // invariant; bail with a recoverable error so the user
+                            // gets an actionable message instead of a panic.
+                            anyhow::bail!(
+                                "internal: brownfield Edit reached with unparsable config: {e:#}"
+                            );
+                        }
                     },
                 }
             }
@@ -304,7 +311,14 @@ pub fn run(cli: Cli) -> Result<()> {
     let paths = TomePaths::new(tome_home, config.library_dir.clone())?;
 
     match cli.command {
-        Command::Init => unreachable!(),
+        Command::Init => {
+            // Init is dispatched ~150 lines above (see `if matches!(cli.command, Command::Init)`).
+            // Reaching this arm means a refactor broke that early-return contract;
+            // bail so the user sees an actionable error instead of a panic.
+            anyhow::bail!(
+                "internal: Command::Init reached the main dispatch but should have been handled by the early-return path"
+            );
+        }
         Command::Add {
             url,
             name,
@@ -641,7 +655,14 @@ pub fn run(cli: Cli) -> Result<()> {
             let new_config = Config::load(&config_path)?;
             relocate::verify(&new_config, &plan.new_library_dir, paths.tome_home())?;
         }
-        Command::Version => unreachable!(),
+        Command::Version => {
+            // Version is dispatched ~500 lines above (see `if matches!(cli.command, Command::Version)`).
+            // Reaching this arm means a refactor broke that early-return contract;
+            // bail so the user sees an actionable error instead of a panic.
+            anyhow::bail!(
+                "internal: Command::Version reached the main dispatch but should have been handled by the early-return path"
+            );
+        }
         Command::Completions { shell, print } => {
             if print {
                 print_completions(shell);

--- a/crates/tome/src/lockfile.rs
+++ b/crates/tome/src/lockfile.rs
@@ -208,8 +208,15 @@ pub fn save(lockfile: &Lockfile, tome_home: &Path) -> Result<()> {
     let content = format!("{content}\n");
     std::fs::write(&tmp_path, &content)
         .with_context(|| format!("failed to write temp lockfile {}", tmp_path.display()))?;
-    std::fs::rename(&tmp_path, &path)
-        .with_context(|| format!("failed to rename lockfile {}", path.display()))
+    if let Err(e) = std::fs::rename(&tmp_path, &path) {
+        // Best-effort cleanup so a stale `tome.lock.tmp` doesn't accumulate
+        // after a failed save. Ignore the cleanup result on purpose: the
+        // rename error is the real failure; masking it with a cleanup
+        // error would hide the actual cause.
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e).with_context(|| format!("failed to rename lockfile {}", path.display()));
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/tome/src/machine.rs
+++ b/crates/tome/src/machine.rs
@@ -167,8 +167,15 @@ pub fn save(prefs: &MachinePrefs, path: &Path) -> Result<()> {
     let tmp_path = path.with_extension("toml.tmp");
     std::fs::write(&tmp_path, &content)
         .with_context(|| format!("failed to write temp file {}", tmp_path.display()))?;
-    std::fs::rename(&tmp_path, path)
-        .with_context(|| format!("failed to rename to {}", path.display()))
+    if let Err(e) = std::fs::rename(&tmp_path, path) {
+        // Best-effort cleanup so a stale `machine.toml.tmp` doesn't
+        // accumulate after a failed save. Ignore the cleanup result on
+        // purpose: the rename error is the real failure; masking it with
+        // a cleanup error would hide the actual cause.
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e).with_context(|| format!("failed to rename to {}", path.display()));
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/tome/src/manifest.rs
+++ b/crates/tome/src/manifest.rs
@@ -140,13 +140,22 @@ pub fn save(manifest: &Manifest, tome_home: &Path) -> Result<()> {
     let content = serde_json::to_string_pretty(manifest).context("failed to serialize manifest")?;
     std::fs::write(&tmp_path, &content)
         .with_context(|| format!("failed to write temporary manifest {}", tmp_path.display()))?;
-    std::fs::rename(&tmp_path, &path).with_context(|| {
-        format!(
-            "failed to rename manifest {} -> {}",
-            tmp_path.display(),
-            path.display()
-        )
-    })
+    if let Err(e) = std::fs::rename(&tmp_path, &path) {
+        // Best-effort cleanup so a stale `.tome-manifest.tmp` doesn't
+        // accumulate after a failed save (e.g. read-only target). We
+        // ignore the cleanup result on purpose: the rename error is the
+        // real failure to surface; masking it with a cleanup error
+        // would hide the actual cause.
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e).with_context(|| {
+            format!(
+                "failed to rename manifest {} -> {}",
+                tmp_path.display(),
+                path.display()
+            )
+        });
+    }
+    Ok(())
 }
 
 /// Compute a deterministic SHA-256 hash of a directory's contents.

--- a/crates/tome/src/paths.rs
+++ b/crates/tome/src/paths.rs
@@ -115,7 +115,15 @@ pub fn symlink_points_to(link_path: &Path, expected_target: &Path) -> bool {
     };
 
     let resolved = std::fs::canonicalize(link_path).unwrap_or_else(|e| {
-        if link_path.exists() {
+        // We know the symlink itself exists (we just read_link()'d it
+        // successfully above). The previous gate `link_path.exists()`
+        // followed the symlink, which is false for broken symlinks —
+        // exactly the case we want to surface, so we'd silently swallow
+        // the error there. Use `symlink_metadata` (does NOT follow) so
+        // we warn for broken symlinks AND for permission errors, but not
+        // for the truly "link disappeared between read_link and canonicalize"
+        // race (which would also fail symlink_metadata).
+        if link_path.symlink_metadata().is_ok() {
             eprintln!(
                 "warning: could not canonicalize {}: {}",
                 link_path.display(),

--- a/crates/tome/src/relocate.rs
+++ b/crates/tome/src/relocate.rs
@@ -22,7 +22,7 @@ pub(crate) struct RelocatePlan {
     pub old_library_dir: PathBuf,
     pub new_library_dir: PathBuf,
     pub skills: Vec<SkillMoveEntry>,
-    /// (target_name, symlink_count) for each target with symlinks pointing into the library.
+    /// (directory_name, symlink_count) for each distribution directory with symlinks pointing into the library.
     pub targets: Vec<(DirectoryName, usize)>,
     pub cross_filesystem: bool,
     pub config_path: PathBuf,
@@ -105,9 +105,27 @@ pub(crate) fn plan(
         });
     }
 
-    // Count target symlinks that point into the old library
-    let canonical_old_for_targets =
-        std::fs::canonicalize(&old_library_dir).unwrap_or(old_library_dir.clone());
+    // Count target symlinks that point into the old library.
+    //
+    // We canonicalize the old library path because on macOS distribution
+    // symlinks may resolve through `/var → /private/var`. If canonicalize
+    // fails we fall back to the non-canonical path AND warn — silent
+    // fallback would undercount target symlinks, leaving the relocate plan
+    // claiming "0 symlinks to recreate" while `execute()` leaves dangling
+    // links in target tools. See review note C2.
+    let canonical_old_for_targets = match std::fs::canonicalize(&old_library_dir) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "warning: could not canonicalize old library path {} ({}); \
+                 distribution symlink count may be inaccurate on filesystems \
+                 with symlinked roots (e.g. macOS /var → /private/var)",
+                old_library_dir.display(),
+                e
+            );
+            old_library_dir.clone()
+        }
+    };
     let mut targets = Vec::new();
     for (dir_name, dir_config) in config.distribution_dirs() {
         let skills_dir = &dir_config.path;
@@ -355,11 +373,19 @@ fn move_cross_filesystem(plan: &RelocatePlan) -> Result<()> {
     // Copy
     copy_library(&plan.old_library_dir, &plan.new_library_dir)?;
 
-    // Verify content hashes for local skills
-    let manifest = manifest::load(
-        // tome_home is the parent of the config path
-        plan.config_path.parent().unwrap_or(Path::new("/")),
-    )?;
+    // Verify content hashes for local skills.
+    //
+    // The previous fallback `.unwrap_or(Path::new("/"))` would silently
+    // load the manifest from `/.tome-manifest.json` (a real path on the
+    // host) if the config path had no parent — a config-misuse bug
+    // would then read an unrelated file rather than failing fast.
+    let tome_home = plan.config_path.parent().with_context(|| {
+        format!(
+            "config path {} has no parent directory; cannot locate tome home for cross-filesystem manifest verification",
+            plan.config_path.display()
+        )
+    })?;
+    let manifest = manifest::load(tome_home)?;
 
     for entry in &plan.skills {
         if entry.is_managed {

--- a/crates/tome/src/wizard.rs
+++ b/crates/tome/src/wizard.rs
@@ -422,9 +422,12 @@ pub(crate) fn run(
         println!("{} Config saved!", style("done").green());
 
         // Offer to git-init the tome home directory for backup tracking
-        let tome_home = config_path
-            .parent()
-            .expect("config path should have a parent");
+        let tome_home = config_path.parent().with_context(|| {
+            format!(
+                "config path {} has no parent directory; cannot locate tome home for backup git-init",
+                config_path.display()
+            )
+        })?;
         if !tome_home.join(".git").exists() {
             if no_input {
                 // Surface the skipped step so CI/script users aren't surprised

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> **[System Diagram (Excalidraw)](https://excalidraw.com/#json=5-pjpDsna4Way3lfGW5km,p0bQwpcJEl6do68RrnKAgw)** — interactive diagram showing the two-tier source → library → target flow.
+> **[System Diagram (Excalidraw)](https://excalidraw.com/#json=5-pjpDsna4Way3lfGW5km,p0bQwpcJEl6do68RrnKAgw)** — interactive diagram showing the two-tier discovery → library → distribution flow.
 
 Rust workspace (edition 2024) with a single crate producing one binary.
 
@@ -12,34 +12,47 @@ The main binary. All domain logic lives here as a library (`lib.rs` re-exports a
 
 The core flow that `tome sync` and `tome init` both invoke (`lib.rs::sync`):
 
-1. **Discover** (`discover.rs`) — Scan configured sources for `*/SKILL.md` dirs. Two source types: `ClaudePlugins` (reads `installed_plugins.json`) and `Directory` (flat walkdir scan). First source wins on name conflicts; exclusion list applied.
-2. **Consolidate** (`library.rs`) — Two strategies based on source type: **managed** skills (ClaudePlugins) are symlinked from library → source dir (package manager owns the files); **local** skills (Directory) are copied into the library (library is the canonical home). A manifest (`.tome-manifest.json`) tracks SHA-256 content hashes for idempotent updates: unchanged skills are skipped, changed skills are re-copied or re-linked. Stale directory state (e.g., a plain directory where a symlink should be) is automatically repaired.
-3. **Distribute** (`distribute.rs`) — Push library skills to target tools via symlinks in each target's skills directory. Skills disabled in machine preferences are skipped.
-4. **Cleanup** (`cleanup.rs`) — Remove stale entries from library (skills no longer in any source), broken symlinks from targets, and disabled skill symlinks from target directories. Verifies symlinks point into the library before removing.
-5. **Lockfile** (`lockfile.rs`) — Generate `tome.lock` capturing a reproducible snapshot of the library state for diffing during `tome sync`.
+1. **Discover** (`discover.rs`) — Walk every directory whose role is `managed`, `synced`, or `source` looking for `*/SKILL.md`. Three directory types: `ClaudePlugins` (reads `installed_plugins.json`), `Directory` (flat walkdir scan), and `Git` (shallow-clones into `~/.tome/repos/<sha256>/` and then scans the clone). First directory wins on name conflicts; the `exclude` list is applied.
+2. **Consolidate** (`library.rs`) — Two strategies depending on directory role: **managed** skills (Claude plugins, git clones) are symlinked from library → source dir so the package manager continues to own the bytes; **local** skills (`directory`/`synced` sources) are copied into the library (the library is the canonical home). A manifest (`.tome-manifest.json`) tracks SHA-256 content hashes for idempotent updates: unchanged skills are skipped, changed skills are re-copied or re-linked. Stale directory state (e.g. a plain directory where a symlink should be) is automatically repaired.
+3. **Distribute** (`distribute.rs`) — Push library skills to every directory whose role is `synced` or `target` via symlinks. Skills disabled in `machine.toml` (globally or per-directory) are skipped, as are directories on the `disabled_directories` list.
+4. **Cleanup** (`cleanup.rs`) — Remove stale entries from the library (skills no longer in any source), broken symlinks from distribution directories, and disabled-skill symlinks. Verifies that every symlink points into the library before removing it.
+5. **Lockfile** (`lockfile.rs`) — Generate `tome.lock` capturing a reproducible snapshot of the library state for diffing on the next sync.
 
 ### Other Modules
 
-- `wizard.rs` — Interactive `tome init` setup using `dialoguer` (MultiSelect, Input, Confirm, Select). Auto-discovers known source locations (`~/.claude/plugins/cache`, `~/.claude/skills`, `~/.codex/skills`, `~/.gemini/antigravity/skills`).
-- `config.rs` — TOML config at `~/.tome/tome.toml`. `Config::load_or_default` handles missing files gracefully. All path fields support `~` expansion.
-- `doctor.rs` — Diagnoses library issues (orphan directories, missing manifest entries, broken legacy symlinks) and missing source paths; optionally repairs.
-- `status.rs` — Read-only summary of library, sources, targets, and health. Single-pass directory scan for efficiency.
-- `manifest.rs` — Library manifest (`.tome-manifest.json`): tracks provenance, content hashes, and sync timestamps for each skill. Provides `hash_directory()` for deterministic SHA-256 of directory contents.
-- `lockfile.rs` — Generates and loads `tome.lock` files. Each entry records skill name, content hash, source, and provenance metadata. Uses atomic temp+rename writes to prevent corruption.
-- `machine.rs` — Per-machine preferences (`~/.config/tome/machine.toml`). Tracks a `disabled` set of skill names and a `disabled_targets` set of target names. Uses atomic temp+rename writes. Loaded during sync to filter skills.
+- `wizard.rs` — Interactive `tome init` setup using `dialoguer` (MultiSelect, Input, Confirm, Select). Uses the merged `KNOWN_DIRECTORIES` registry (WIZ-01, hardened in v0.7) to auto-discover common tool locations (`~/.claude/plugins/cache`, `~/.claude/skills`, `~/.codex/skills`, `~/.gemini/antigravity/skills`, etc.). Detects pre-v0.6 legacy configs and offers cleanup (WUX-03).
+- `config.rs` — TOML config at `~/.tome/tome.toml`. `Config::load_or_default` handles missing files gracefully. Defines `DirectoryName`, `DirectoryType` (`ClaudePlugins`/`Directory`/`Git`), `DirectoryRole` (`Managed`/`Synced`/`Source`/`Target`), and `DirectoryConfig`. All path fields support `~` expansion. `Config::apply_machine_overrides` merges `[directory_overrides.<name>]` from `machine.toml` after expansion and before validation (PORT-01..04).
+- `add.rs` / `remove.rs` / `reassign.rs` — `tome add`, `tome remove`, `tome reassign`, `tome fork` commands. All use the plan/render/execute pattern so dry-run is free and tests are trivial. `remove` aggregates partial-cleanup failures into a `Vec<RemoveFailure>` and surfaces a `⚠ N operations failed` summary.
+- `git.rs` — Git clone / pull for `type = "git"` directories. Shallow clones to `~/.tome/repos/<sha256>/`, with `branch`/`tag`/`rev` ref pinning and SHA captured in the lockfile.
+- `doctor.rs` — Diagnoses library issues (orphan directories, missing manifest entries, broken legacy symlinks, missing directory paths); interactive per-item repair for orphans. Annotates `(override)` for paths sourced from `machine.toml` (PORT-05).
+- `status.rs` — Read-only summary of library, directories (with type/role + override annotations), and health. Single-pass directory scan for efficiency.
+- `manifest.rs` — Library manifest (`.tome-manifest.json`): tracks provenance, content hashes, and sync timestamps for each skill. Provides `hash_directory()` for deterministic SHA-256 of directory contents. Atomic temp+rename writes.
+- `lockfile.rs` — Generates and loads `tome.lock` files. Each entry records skill name, content hash, source directory, and provenance metadata (registry id, version, git commit SHA). Atomic temp+rename writes.
+- `machine.rs` — Per-machine preferences (`~/.config/tome/machine.toml`). Tracks `disabled` skill set, `disabled_directories` set, per-directory `disabled`/`enabled` skill filtering (`DirectoryPrefs`, MACH-04), and `[directory_overrides.<name>]` path remapping (PORT-01). Atomic temp+rename writes.
 - `update.rs` — Lockfile diffing and interactive triage logic, invoked by `tome sync` to surface added/changed/removed skills and offer to disable unwanted new skills.
-- `paths.rs` — Symlink path utilities: resolves relative symlink targets to absolute paths and checks whether a symlink points to a given destination.
+- `paths.rs` — `TomePaths` struct bundling `tome_home`/`library_dir`/`config_dir` to prevent parameter swaps. Symlink path utilities: resolves relative symlink targets to absolute paths and checks whether a symlink points to a given destination.
+- `relocate.rs` — Move the skill library to a new path with full safety guarantees: detects cross-filesystem moves, re-anchors all distribution symlinks, warns on unreadable managed-skill symlinks instead of silently dropping provenance.
+- `eject.rs` — Remove all of tome's distribution symlinks (reversible via `tome sync`).
+- `backup.rs` — Git-backed snapshot/restore/diff for the library. The pre-restore safety snapshot is the only recovery path if a restore was accidental, so `restore` aborts if the snapshot fails (#415).
+- `browse/` — TUI browser (`tome browse`): `app.rs` (state + key handling), `ui.rs` (ratatui rendering), `theme.rs` (adaptive dark/light), `fuzzy.rs` (nucleo-matcher), `markdown.rs` (preview rendering). The status bar uses a `StatusMessage { Success | Warning | Pending }` enum (POLISH-02) so glyph + colorization stay consistent across pre-block and post-block states.
+- `lint.rs` — Validates SKILL.md frontmatter; CI-friendly exit codes.
+- `install.rs` — Shell completion installation.
 
 ## Key Patterns
 
-- **Two-tier model**: Sources →(consolidate)→ Library →(distribute)→ Targets. The library is the source of truth. Managed skills (from package managers like Claude plugins) are symlinked from library → source dir (the package manager owns the files); local skills (from directory sources) are copied into the library (the library is canonical home). Distribution to targets always uses symlinks pointing into the library. This means the project is Unix-only (`std::os::unix::fs::symlink`).
-- **Targets are data-driven**: `config::targets` is a `BTreeMap<String, TargetConfig>` — any tool can be added as a target without code changes. The wizard uses a `KnownTarget` registry for auto-discovery of common tools.
+- **Two-tier model**: Discovery directories →(consolidate)→ Library →(distribute)→ Distribution directories. The library is the source of truth. Managed skills (Claude plugins, git clones) are symlinked from library → source dir; local skills (`directory`/`synced` sources) are copied into the library. Distribution always uses Unix symlinks (`std::os::unix::fs::symlink`) pointing into the library. Unix-only.
+- **Directories are data-driven**: `config::directories` is a `BTreeMap<DirectoryName, DirectoryConfig>` — any tool can be added as a directory with a role without code changes. The wizard's `KNOWN_DIRECTORIES` registry is used purely for auto-discovery convenience.
+- **Roles, not "sources vs targets"**: A directory can be `managed` (read-only source), `source` (discovery only), `target` (distribution only), or `synced` (both — same dir is read AND written, e.g. `~/.claude/skills`). The pipeline asks each directory's role what to do with it; there is no separate "sources" vs "targets" config.
 - **`dry_run` threading**: Most operations accept a `dry_run: bool` that skips filesystem writes but still counts what *would* change. Results report the same counts either way.
-- **Error handling**: `anyhow` for the application. Missing sources/paths produce warnings (stderr) rather than hard errors.
+- **Atomic writes**: `manifest.json`, `tome.lock`, and `machine.toml` are always written via temp file + rename. The temp file is in the same directory as the target so the rename is atomic on POSIX.
+- **Plan/render/execute**: `add`, `remove`, `reassign`, `relocate`, `eject` build an explicit plan, render it for the user, and only then execute. Dry-run is free; tests can assert plan structure without touching the filesystem.
+- **Newtypes at boundaries**: `SkillName`, `DirectoryName`, `ContentHash`, `TomePaths` validate at construction so downstream code doesn't have to. The shared `validate_identifier` rejects empty names, path separators, `.`, and `..`.
+- **Error handling**: `anyhow` for the application; `.with_context()` adds path context to every fs error. Missing sources/paths produce stderr warnings rather than hard errors. Symlink operations always verify the link points into the library before deleting.
+- **Per-machine portability**: The portable `tome.toml` describes the abstract topology; `machine.toml` provides path overrides (`[directory_overrides.<name>]`) and machine-local opt-outs. Override application happens at config load, before validation, so all downstream code sees post-override paths.
 
 ## Testing
 
-Unit tests are co-located with each module (`#[cfg(test)] mod tests`). Integration tests in `crates/tome/tests/cli.rs` exercise the binary via `assert_cmd`. Tests use `tempfile::TempDir` for filesystem isolation — no cleanup needed.
+Unit tests are co-located with each module (`#[cfg(test)] mod tests`). Integration tests in `crates/tome/tests/cli.rs` exercise the binary via `assert_cmd`. Snapshot tests use `insta` (filtered for tmpdir paths). Tests use `tempfile::TempDir` and `assert_fs::TempDir` for filesystem isolation — no cleanup needed.
 
 ## CI
 

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -2,16 +2,20 @@
 
 | Command | Description |
 |---------|-------------|
-| `tome init` | Interactive wizard to configure sources and targets |
+| `tome init` | Interactive wizard to configure directories |
 | `tome sync` | Discover, consolidate, triage changes, and distribute skills |
-| `tome status` | Show library, sources, targets, and health summary |
-| `tome list` (alias: `ls`) | List all discovered skills with sources (supports `--json`) |
+| `tome add <url\|slug>` | Register a git skill repository in `tome.toml` |
+| `tome remove <name>` | Remove a directory entry and clean up its artifacts |
+| `tome reassign <skill> <directory>` | Reassign a skill to a different directory |
+| `tome fork <skill> <local-directory>` | Fork a managed skill to a local directory for customization |
+| `tome status` | Show library, directories, and health summary |
+| `tome list` (alias: `ls`) | List all discovered skills with their directories (supports `--json`) |
 | `tome browse` | Interactively browse discovered skills with fuzzy search |
 | `tome doctor` | Diagnose and repair broken symlinks or config issues |
 | `tome lint` | Validate skill frontmatter and report issues |
 | `tome config` | Show current configuration |
 | `tome backup` | Git-backed backup and restore for the skill library |
-| `tome eject` | Remove tome's symlinks from all targets (reversible via `tome sync`) |
+| `tome eject` | Remove tome's symlinks from all distribution directories (reversible via `tome sync`) |
 | `tome relocate <path>` | Move the skill library to a new location |
 | `tome completions <shell>` | Install shell completions (bash, zsh, fish, powershell) |
 | `tome version` | Print version information |
@@ -32,12 +36,47 @@
 
 ### `tome sync`
 
-Runs the full pipeline: discover skills from sources, consolidate into the library, diff the lockfile to surface changes, distribute to targets, and clean up stale entries. When new or changed skills are detected, an interactive triage prompt lets you disable unwanted skills. Generates a `tome.lock` lockfile for reproducible snapshots.
+Runs the full pipeline: discover skills from configured directories, consolidate into the library, diff the lockfile to surface changes, distribute to targets, and clean up stale entries. When new or changed skills are detected, an interactive triage prompt lets you disable unwanted skills. Generates a `tome.lock` lockfile for reproducible snapshots.
 
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--force` | `-f` | Recreate all symlinks even if they appear up-to-date |
 | `--no-triage` | | Skip interactive triage of new/changed skills (for CI/scripts) |
+
+### `tome add`
+
+Register a git skill repository in `tome.toml`. Accepts either a full git URL (`https://github.com/owner/repo`, `git@github.com:owner/repo.git`) or a bare GitHub slug (`owner/repo`), which is expanded to `https://github.com/owner/repo` (v0.8.2+). The clone is shallow and lives in `~/.tome/repos/<sha256>/`.
+
+| Flag | Description |
+|------|-------------|
+| `URL` | Git repository URL or `owner/repo` slug |
+| `--name <name>` | Custom directory name (default: extracted from URL) |
+| `--branch <branch>` | Track a specific branch |
+| `--tag <tag>` | Pin to a specific tag |
+| `--rev <sha>` | Pin to a specific commit SHA |
+
+`--branch`, `--tag`, `--rev` are mutually exclusive.
+
+### `tome remove`
+
+Remove a directory entry and clean up all its artifacts: distribution symlinks, library entries, library symlinks, and (for git directories) the cached clone. Aggregates partial-cleanup failures and exits non-zero with a `⚠ N operations failed` summary if any cleanup step fails (the directory's config entry and manifest entries are preserved on partial failure so the command can be re-run after fixing the underlying cause).
+
+| Flag | Description |
+|------|-------------|
+| `NAME` | Directory name to remove (as shown in `tome status`) |
+| `--yes` | Skip confirmation prompt |
+
+### `tome reassign`
+
+Reassign a skill to a different directory — useful when the same skill appears under multiple sources and you want to pin which directory owns it.
+
+### `tome fork`
+
+Fork a managed (read-only) skill into a local directory so it can be edited. The local copy supersedes the managed one in the library.
+
+| Flag | Description |
+|------|-------------|
+| `--yes` | Skip confirmation prompt |
 
 ### `tome list`
 
@@ -78,11 +117,11 @@ Git-backed backup and restore. Subcommands:
 
 ### `tome eject`
 
-Removes all of tome's symlinks from target tool directories. Reversible — run `tome sync` to recreate them.
+Removes all of tome's symlinks from distribution directories. Reversible — run `tome sync` to recreate them.
 
 ### `tome relocate`
 
-Moves the skill library to a new path, updating symlinks in all targets.
+Moves the skill library to a new path, updating symlinks in all distribution directories. Detects cross-filesystem moves and warns when target symlinks need to be re-anchored.
 
 ### `tome completions`
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,70 +1,117 @@
 # Configuration
 
-## Main Config
+tome reads two TOML files:
 
-TOML at `~/.tome/tome.toml`:
+- `~/.tome/tome.toml` — the **portable** config (intended to be shared via dotfiles across machines).
+- `~/.config/tome/machine.toml` — **machine-local** preferences and path overrides (do *not* share this).
+
+The split is intentional: the portable config describes the abstract topology (which directories tome cares about, what role each plays), while `machine.toml` describes how that topology maps onto *this* machine's filesystem.
+
+## `tome.toml` — Portable Config
 
 ```toml
 library_dir = "~/.tome/skills"
 exclude = ["deprecated-skill"]
 
-[[sources]]
-name = "claude-plugins"
+[directories.claude-plugins]
 path = "~/.claude/plugins/cache"
 type = "claude-plugins"
 
-[[sources]]
-name = "standalone"
+[directories.local-skills]
 path = "~/.claude/skills"
 type = "directory"
+role = "synced"
 
-[targets.antigravity]
-enabled = true
-method = "symlink"
-skills_dir = "~/.gemini/antigravity/skills"
+[directories.team-skills]
+path = "https://github.com/myorg/team-skills"
+type = "git"
+branch = "main"
+
+[directories.antigravity]
+path = "~/.gemini/antigravity/skills"
+type = "directory"
+role = "target"
 ```
 
-### Fields
+> **Migrating from v0.5 or earlier?** The `[[sources]]` and `[targets.*]` sections were replaced with a single `[directories.<name>]` map in v0.6. tome will refuse to load old-format configs and print a migration hint. There is no automated migration tool — copy each `[[sources]]` entry to a `[directories.<name>]` entry with `role = "source"` (or `"managed"` for `claude-plugins`), and each `[targets.<name>]` entry to a `[directories.<name>]` entry with `role = "target"`.
+
+### Top-level fields
 
 | Field | Description |
 |-------|-------------|
 | `library_dir` | Path to the consolidated skill library. Supports `~` expansion. |
 | `exclude` | List of skill names to skip during discovery. |
 
-### Source Types
+### `[directories.<name>]` — entries
+
+A `<name>` is a kebab-case identifier. Each entry combines a `type` (how skills are discovered) with a `role` (whether it's a source, a target, or both).
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `path` | Yes | Filesystem path (or git URL when `type = "git"`). Tilde-expanded. |
+| `type` | No (defaults to `"directory"`) | One of `claude-plugins`, `directory`, `git`. |
+| `role` | No (each `type` has a default) | One of `managed`, `synced`, `source`, `target`. |
+| `branch` / `tag` / `rev` | No (`git` only, mutually exclusive) | Pin a git directory to a branch, tag, or commit SHA. |
+| `subdir` | No (`git` only) | If the repo nests skills under a subdirectory. |
+
+### Directory `type`
 
 | Type | Description |
 |------|-------------|
-| `claude-plugins` | Reads `installed_plugins.json` from the Claude Code plugin cache. Supports v1 (flat array) and v2 (namespaced object) formats. |
-| `directory` | Flat scan for `*/SKILL.md` directories. |
+| `claude-plugins` | Reads `installed_plugins.json` from the Claude Code plugin cache. Supports v1 (flat array) and v2 (namespaced object) formats. Always `role = "managed"`. |
+| `directory` | Flat scan for `*/SKILL.md` directories. Default. |
+| `git` | Shallow-clones a remote repo into `~/.tome/repos/<sha256>/` and treats the clone as a `directory` source. Always `role = "source"`. |
 
-### Target Methods
+### Directory `role`
 
-| Method | Fields | Description |
-|--------|--------|-------------|
-| `symlink` | `skills_dir` | Creates symlinks in the target's skills directory pointing into the library. |
+| Role | Discovery | Distribution | Typical use |
+|------|-----------|--------------|-------------|
+| `managed` | ✓ (read-only) | — | Plugin cache (e.g. Claude Code) |
+| `synced` | ✓ | ✓ | A directory that is both a skill source AND a tool that consumes them (e.g. `~/.claude/skills`) |
+| `source` | ✓ | — | A skill repo or local skill directory |
+| `target` | — | ✓ | A tool that only receives skills (e.g. Codex, Antigravity) |
 
-Targets are data-driven — any tool can be added without code changes. The `tome init` wizard auto-discovers common tool locations via a built-in `KnownTarget` registry.
+`tome init` picks a sensible default role from the type, but you can override it per directory.
 
-## Machine Preferences
+The directory model is fully data-driven: any new tool can be supported by adding a `[directories.<name>]` entry — no code changes required. The `tome init` wizard auto-discovers common tool locations via the built-in `KNOWN_DIRECTORIES` registry.
 
-Per-machine opt-in/opt-out at `~/.config/tome/machine.toml` (intentionally kept separate from `~/.tome/` — machine-specific preferences should not be in the portable tome home directory):
+## `machine.toml` — Machine-Local Preferences
 
 ```toml
+# Skip these skills entirely on this machine
 disabled = ["noisy-skill", "work-only-skill"]
-disabled_targets = ["openclaw"]
+
+# Don't distribute to these directories on this machine
+disabled_directories = ["openclaw"]
+
+# Per-directory skill filtering (mutually exclusive: pick disabled OR enabled per directory)
+[directory.antigravity]
+disabled = ["claude-only-skill"]
+
+[directory.work-laptop]
+enabled = ["work-skill-a", "work-skill-b"]  # allowlist — ONLY these are distributed
+
+# Per-machine path overrides for `tome.toml::directories.<name>.path` (PORT-01..05, v0.9)
+[directory_overrides.local-skills]
+path = "/Users/alice-corp/.claude/skills"
+
+[directory_overrides.team-skills]
+path = "/opt/shared/team-skills"
 ```
 
 | Field | Description |
 |-------|-------------|
-| `disabled` | List of skill names to skip during distribution (no symlinks created in targets). |
-| `disabled_targets` | List of target names to skip entirely on this machine. |
+| `disabled` | List of skill names to skip during distribution (no symlinks created in any target). |
+| `disabled_directories` | List of directory names to skip entirely on this machine. |
+| `[directory.<name>].disabled` | Skills to exclude from a single directory (blocklist). |
+| `[directory.<name>].enabled` | Allowlist — ONLY these skills are distributed to this directory. Mutually exclusive with `disabled` per directory (MACH-04). |
+| `[directory_overrides.<name>].path` | Replaces `directories.<name>.path` on this machine. Useful when the same `tome.toml` is shared across machines with different home layouts. Unknown override names emit a typo-target stderr warning. |
 
-Disabled skills remain in the library but are skipped during distribution.
+Override application happens at config load (after tilde expansion, before `Config::validate`), so all downstream code sees the canonical post-override paths. Any validation failure caused by an override is wrapped with an error attributing the problem to `machine.toml` rather than the portable `tome.toml`.
 
-This allows sharing a single library (e.g., via git) across machines while customizing which skills are active on each one.
+`tome status` and `tome doctor` annotate `(override)` next to any path that came from `machine.toml`, so you can tell at a glance which paths are portable and which are machine-local.
 
-`tome sync` automatically diffs the lockfile and offers interactive triage when new or changed skills are detected. The `--machine <path>` global flag overrides the default machine preferences path.
+The `--machine <path>` global flag overrides the default machine preferences path.
 
 ## Lockfile
 


### PR DESCRIPTION
## Summary

Bundle prep work for v1.0 from a comprehensive whole-codebase review (5 specialist agents: code, tests, errors, types, comments). Two commits:

1. **`docs:` bring user + agent docs in line with v0.9.0** — closes 3 milestones of accumulated documentation drift.
2. **`fix:` surface silent failures and clean up atomic-write tmp on rename error** — mechanical safety fixes; no happy-path behavior change.

### Documentation drift addressed

- **CLAUDE.md / AGENTS.md** opened with `v0.6.0 (unreleased)` (3 milestones stale) and falsely claimed `wizard rewrite (WIZ-01–05) deferred`. Replaced with cumulative summary through v0.9.
- **CHANGELOG.md** had v0.8.0, v0.8.1, v0.8.2, v0.9.0 entries misclassified as `[Unreleased]`. Backfilled all four release sections.
- **docs/src/configuration.md** told users to write `[[sources]]` / `[targets.*]` configs that the v0.6+ binary refuses to load — most user-damaging drift in the repo. Rewritten for the unified directory model with the v0.9 `[directory_overrides.<name>]` schema.
- **docs/src/architecture.md** still used "sources/targets" two-tier vocabulary; missing 11 modules from the layout. Rewritten.
- **docs/src/commands.md** missing `tome add`, `remove`, `reassign`, `fork` (all shipped in v0.6).
- **.planning/codebase/{ARCHITECTURE,STRUCTURE,CONVENTIONS,STACK}.md** referenced `TargetName` (0 occurrences in code; canonical name is `DirectoryName` with 165 occurrences). Updated terminology and analysis dates.

### Safety fixes

| File | Issue | Fix |
|------|-------|-----|
| `relocate.rs:110` | Silent `canonicalize` fallback could undercount target symlinks on macOS (`/var → /private/var`) | Warn before falling back |
| `relocate.rs:379` | `parent().unwrap_or(Path::new("/"))` could load manifest from host `/` | `.with_context()?` |
| `paths.rs:117` | `canonicalize` warning suppressed for broken symlinks (the case worth surfacing) | Use `symlink_metadata()` (doesn't follow) as warn gate |
| `manifest.rs::save`, `lockfile.rs::save`, `machine.rs::save` | Temp file leaked on rename failure | Best-effort `remove_file(tmp)` on Err arm |
| `lib.rs` × 3 | `unreachable!()` on cross-function invariants (BrownfieldAction::Edit Err, Command::Init dispatch, Command::Version dispatch) | `anyhow::bail!("internal: ...")` |
| `wizard.rs:427` | `.expect("config path should have a parent")` panics on `tome init --config tome.toml` | `.with_context()?` |

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --test cli` — 136/136 pass
- [x] `cargo test --lib -- --test-threads=4` — 526/526 pass (high parallelism hits the documented Bitwarden-signing flake in `backup::tests::*`; `--test-threads=4` is reliable; CI runs at lower parallelism)
- [ ] CI green on push

## Remaining issues (out of scope for this PR)

The whole-codebase review surfaced more findings than fit in a `chore` PR. Items below are filed mentally for follow-up issues:

**Critical / Important not addressed here**
- `skill.rs::parse` returns `Result<_, String>` from a public API — should be `anyhow::Result`. Affects `lint.rs` and `discover.rs` callers.
- `lib.rs::run()` is a 500-line `match`; needs extraction into `cmd_<name>` functions following the `add::add` / `remove::execute` pattern already used elsewhere.
- `config.rs` is 3042 LOC; split into `config/{mod,types,overrides}.rs`.
- `process::exit(1)` in `lib.rs::lint` (~line 364) bypasses cleanup — replace with downcastable error.

**Type-system improvements (Phase C in the action plan)**
- Lift `source_name: String` → `DirectoryName` across `DiscoveredSkill`, `SkillEntry`, `LockEntry`, `Manifest::update_source_name`. Single most impactful refactor; eliminates the largest remaining stringly-typed leak.
- Collapse `DirectoryConfig.{branch,tag,rev}` (3 mutually-exclusive `Option<String>`) into `Option<GitRef>` enum and move git-only fields into `DirectoryType::Git { ref_, subdir }`. Eliminates ~80 lines of `Config::validate`.
- Replace `scan_for_skills(managed_provenance: Option<Option<SkillProvenance>>)` with named `enum ScanMode { Local, Managed(Option<SkillProvenance>) }`.
- Tighten `Lockfile.skills` and `Lockfile.version` to `pub(crate)` with accessors (mirror `Manifest`).
- Replace `(verbose: bool, quiet: bool)` in CLI flags with `LogLevel` enum.

**Test coverage gaps**
- No test verifies "previous file intact when atomic save fails" (the temp-cleanup commit lays the groundwork but doesn't add the regression test).
- `distribute.rs` may clobber a pre-existing symlink that points outside the current library (foreign tome install / stale relocate). No test for this case.
- v0.9 cross-machine path overrides lack hostile-input tests (`..` traversal, symlink loops, two directories overriding to the same path).
- `tome remove <git-dir>` and `tome remove <claude-plugins-dir>` not exercised end-to-end.
- `browse/ui.rs` has zero rendering tests; ratatui ships `TestBackend` for snapshot tests.
- `tests/cli.rs` is 5580 LOC monolithic; split into per-domain files.
- Document or fix the `backup::tests::push_and_pull_roundtrip` and `diff_shows_changes` flake at high parallelism (Bitwarden SSH signing exhaustion, not a tome regression).

**Stylistic / smaller**
- `wizard.rs:212,277,376` use `println!` for diagnostics (should be `eprintln!` for stdout-vs-stderr discipline).
- Rename `relocate.rs::provenance_from_link_result` → `warn_if_unreadable_symlink` so the side-effect intent is in the function name rather than buried in docs.
- Add `impl TryFrom<String> for SkillName` to avoid clones at construction sites that already own the string.

These can be split into v1.0 prep follow-up issues or rolled into the v1.0 milestone planning.