### PR TITLE
fix(migrate-library): dry-run banner uses 'Plan validated' verb (#526)

### DIFF
--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -1031,7 +1031,7 @@ pub(crate) fn cmd_migrate_library(
     let result = migration_v010::execute(&plan, dry_run)?;
     {
         let mut stderr = std::io::stderr().lock();
-        let _ = migration_v010::render_result_to(&result, &mut stderr);
+        let _ = migration_v010::render_result_to(&result, dry_run, &mut stderr);
     }
 
     // HARD-04 sibling: bubble through anyhow rather than `process::exit(1)`.

--- a/crates/tome/src/migration_v010.rs
+++ b/crates/tome/src/migration_v010.rs
@@ -614,8 +614,13 @@ pub(crate) fn prompt_confirmation(mode: PromptMode) -> Result<bool> {
 /// Render the SAFE-01 grouped failure summary + final ✓/⚠ banner into `w`.
 /// Per HARD-15 stderr discipline, production callers pass an
 /// `io::stderr().lock()` writer.
+///
+/// `dry_run` switches the success-banner verb so the user can't misread
+/// a dry-run preview as a completed migration (#526). The partial/failed
+/// banner stays the same in both modes — failure surface is identical.
 pub(crate) fn render_result_to(
     result: &MigrationResult,
+    dry_run: bool,
     w: &mut impl std::io::Write,
 ) -> std::io::Result<()> {
     writeln!(w)?;
@@ -626,17 +631,19 @@ pub(crate) fn render_result_to(
     if result.is_partial_or_failed() {
         writeln!(w, "{}", style(&banner).yellow().bold())?;
     } else {
-        writeln!(
-            w,
-            "{}",
-            style(format!(
-                "✓ {} skill{} migrated to v0.10 shape",
+        let plural_s = if result.converted == 1 { "" } else { "s" };
+        let line = if dry_run {
+            format!(
+                "✓ Plan validated: {} skill{plural_s} ready to migrate (dry-run, no changes made)",
                 result.converted,
-                if result.converted == 1 { "" } else { "s" }
-            ))
-            .green()
-            .bold()
-        )?;
+            )
+        } else {
+            format!(
+                "✓ {} skill{plural_s} migrated to v0.10 shape",
+                result.converted,
+            )
+        };
+        writeln!(w, "{}", style(line).green().bold())?;
     }
 
     if result.failures.is_empty() {
@@ -1109,6 +1116,51 @@ mod tests {
         assert!(
             out.contains("may undercount"),
             "summary must warn estimate may undercount, got: {out}"
+        );
+    }
+
+    #[test]
+    fn render_result_to_dry_run_uses_validated_verb() {
+        // #526 — dry-run banner must not claim migration completed.
+        // Live mode says "migrated"; dry-run says "Plan validated"
+        // + "(dry-run, no changes made)".
+        let result = MigrationResult {
+            converted: 57,
+            skipped_broken_source: 0,
+            failed: 0,
+            failures: vec![],
+        };
+
+        let mut live_buf = Vec::new();
+        render_result_to(&result, false, &mut live_buf).unwrap();
+        let live = String::from_utf8(live_buf).unwrap();
+        assert!(
+            live.contains("57 skills migrated to v0.10 shape"),
+            "live banner regression: {live}"
+        );
+        assert!(
+            !live.contains("dry-run"),
+            "live banner must not mention dry-run: {live}"
+        );
+
+        let mut dry_buf = Vec::new();
+        render_result_to(&result, true, &mut dry_buf).unwrap();
+        let dry = String::from_utf8(dry_buf).unwrap();
+        assert!(
+            dry.contains("Plan validated"),
+            "dry-run banner must use 'Plan validated' verb: {dry}"
+        );
+        assert!(
+            dry.contains("57 skills ready to migrate"),
+            "dry-run banner must report skill count: {dry}"
+        );
+        assert!(
+            dry.contains("(dry-run, no changes made)"),
+            "dry-run banner must explicitly disclaim mutation: {dry}"
+        );
+        assert!(
+            !dry.contains("migrated to v0.10 shape"),
+            "dry-run banner must not claim migration: {dry}"
         );
     }
 


### PR DESCRIPTION
Closes #526.

## Summary

`tome migrate-library --dry-run` was printing `✓ N skills migrated to v0.10 shape` at the end of its output even though no mutation occurred. Surfaced during the REL-04 smoke-test (transcript at `.planning/phases/17-migration-polish-uat-release/REL-04-smoke-test-transcript.md`).

`render_result_to` now takes a `dry_run: bool`:
- **Live** (unchanged): `✓ N skills migrated to v0.10 shape`
- **Dry-run** (new): `✓ Plan validated: N skills ready to migrate (dry-run, no changes made)`

Partial/failed banner is identical in both modes — the failure surface doesn't change.

`cmd_migrate_library` passes `dry_run` through to the renderer; that's the entire wiring change.

## Test

New unit test `render_result_to_dry_run_uses_validated_verb` pins both arms:
- live: contains `\"57 skills migrated to v0.10 shape\"`, doesn't mention dry-run
- dry-run: contains `\"Plan validated\"`, `\"57 skills ready to migrate\"`, `\"(dry-run, no changes made)\"`, doesn't claim migration

## Test plan

- [x] `cargo build -p tome` clean
- [x] `cargo test` 987 passed (was 986 + 1 new)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [ ] `make ci`