### PR TITLE
fix(reconcile): skip hash check when library copy missing on disk

### DIFF
--- a/crates/tome/src/reconcile.rs
+++ b/crates/tome/src/reconcile.rs
@@ -309,17 +309,26 @@ fn classify_lockfile(
         } else if !installed_ids.contains(registry_id.as_str()) {
             ReconcileClass::MissingFromMachine
         } else {
-            // Compute live hash from library copy.
+            // Compute live hash from library copy. If the library copy is
+            // missing on disk (manifest/lockfile stale, cleanup hasn't run
+            // yet), treat as MissingFromMachine — consolidate will recreate
+            // it from the marketplace-installed plugin on this same sync.
+            // Avoids the hash_directory walkdir ENOENT that would otherwise
+            // hard-fail sync before cleanup gets a chance.
             let skill_dir = library_dir.join(name.as_str());
-            let live_hash = manifest::hash_directory(&skill_dir)
-                .with_context(|| format!("failed to hash library copy of {name}"))?;
-            if live_hash == entry.content_hash {
-                ReconcileClass::Match
+            if !skill_dir.is_dir() {
+                ReconcileClass::MissingFromMachine
             } else {
-                let new_version = adapter.current_version(registry_id)?;
-                ReconcileClass::Drift {
-                    old_version: entry.version.clone(),
-                    new_version,
+                let live_hash = manifest::hash_directory(&skill_dir)
+                    .with_context(|| format!("failed to hash library copy of {name}"))?;
+                if live_hash == entry.content_hash {
+                    ReconcileClass::Match
+                } else {
+                    let new_version = adapter.current_version(registry_id)?;
+                    ReconcileClass::Drift {
+                        old_version: entry.version.clone(),
+                        new_version,
+                    }
                 }
             }
         };
@@ -358,7 +367,20 @@ fn detect_edited(
             continue;
         };
 
-        let live_hash = manifest::hash_directory(&library_dir.join(name.as_str()))
+        // Skip if the library copy doesn't exist on disk. This happens when
+        // the manifest is stale (skill was uninstalled / source dir gone)
+        // but cleanup hasn't run yet — sync runs reconcile BEFORE cleanup,
+        // so detect_edited would otherwise hard-fail on `hash_directory`'s
+        // walkdir (ENOENT). The downstream cleanup phase classifies these
+        // as Bucket B (missing-from-disk) and removes them. Edited-in-
+        // library detection is by definition impossible if the library
+        // copy doesn't exist.
+        let skill_dir = library_dir.join(name.as_str());
+        if !skill_dir.is_dir() {
+            continue;
+        }
+
+        let live_hash = manifest::hash_directory(&skill_dir)
             .with_context(|| format!("failed to hash library copy of {name}"))?;
 
         if live_hash != lock_entry.content_hash {
@@ -1055,6 +1077,47 @@ mod tests {
         assert!(
             result.is_empty(),
             "Unowned managed entries must not be edit-classified (D-14), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn detect_edited_skips_when_library_copy_missing() {
+        // Regression: stale manifest+lockfile entries for a skill whose
+        // library copy was deleted (plugin uninstalled, etc.) must not
+        // hard-fail reconcile with `failed to hash library copy`. Cleanup
+        // (which runs AFTER reconcile in sync) is responsible for these
+        // as Bucket B missing-from-disk.
+        let tmp = TempDir::new().unwrap();
+        let (_paths, lib) = paths_with_lib(tmp.path());
+        // Deliberately do NOT create a library directory for "ghost-skill".
+        let stale_hash = ContentHash::new("d".repeat(64)).unwrap();
+
+        let mut manifest = Manifest::default();
+        manifest.insert(
+            SkillName::new("ghost-skill").unwrap(),
+            SkillEntry::new(
+                PathBuf::from("/tmp/ghost-skill"),
+                DirectoryName::new("claude-plugins").unwrap(),
+                stale_hash.clone(),
+                true, // managed
+            ),
+        );
+
+        let lockfile = lockfile_with(vec![(
+            "ghost-skill",
+            lock_entry(
+                "claude-plugins",
+                stale_hash,
+                Some("ghost@mp"),
+                Some("1.0.0"),
+            ),
+        )]);
+
+        // Must succeed (skip the missing entry), not error.
+        let result = detect_edited(&manifest, &lib, &lockfile).unwrap();
+        assert!(
+            result.is_empty(),
+            "missing library copy must skip — cleanup handles it as Bucket B; got {result:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

`tome sync` hard-failed with `failed to hash library copy of <name>` on
any user whose manifest+lockfile referenced a skill whose library
directory was missing on disk.

Real-world trigger: surfaced today during the post-REL-04-migration
real-library run. The user had 8 stale manifest entries (n8n-* +
writing-rules) pointing at uninstalled claude plugins. Pre-fix, sync
exit code 1 with no way forward. Post-fix, those entries surface
correctly as Bucket B (missing-from-disk) in the cleanup phase.

## Root cause

`reconcile.rs::detect_edited` iterates the manifest and calls
`manifest::hash_directory()` on every managed entry that has a matching
lockfile entry — without checking whether the library directory still
exists. `hash_directory` uses walkdir, which errors on ENOENT.

Same shape exists in `classify_lockfile` but is gated by `registry_id`
being `Some(_)`, so not currently hit. Fixed defensively for parity.

Critically, `tome sync` calls reconcile **before** cleanup_library, so
cleanup (which is responsible for surfacing missing-from-disk as
Bucket B per UX-01) never gets a chance to act — sync bails first.

## Fix

Four-line existence check at each call site:

- `detect_edited`: `if !skill_dir.is_dir() { continue; }`. Edit-in-
  library detection is impossible if the library copy doesn't exist;
  cleanup classifies as Bucket B.
- `classify_lockfile`: `if !skill_dir.is_dir() { ReconcileClass::MissingFromMachine }`.
  Consolidate will recreate from the marketplace-installed plugin on the
  same sync, so missing-from-disk is semantically the same as
  missing-from-machine here.

## Test

New regression test `detect_edited_skips_when_library_copy_missing`:
constructs a manifest+lockfile entry for a skill with no library
directory, asserts reconcile succeeds and returns empty (no false
Edited detection, no hash-directory error).

## Test plan

- [x] `cargo build -p tome` clean
- [x] New unit test passes + all 5 existing `detect_edited_*` tests
- [x] `cargo test` no regressions
- [x] Manually verified against the user's real library — `tome sync`
      now completes successfully and surfaces the 8 stale entries as
      Bucket B with `tome remove skill <name>` hints
- [ ] `make ci` (pending CI run on this PR)

## Surfaced in

REL-04 real-library migration (post-smoke-test). Confirms the wisdom of
"smoke-test first" — this would have been a v0.10.0 release blocker if
shipped without the real-library run. The next-time lesson noted in the
smoke transcript: re-point ALL paths to `/tmp` for fuller smoke
coverage rather than only `library_dir`.