### PR TITLE
docs(changelog): stamp v0.10.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-11
+
 The **v0.10 Library-canonical Model + Cross-Machine Plugin Reconciliation**
 milestone. Makes tome's library a single source of truth — managed AND
 local skills are stored as real-directory copies — with a lockfile-


### PR DESCRIPTION
## Summary

The v0.10.0 release was tagged and published via cargo-dist on 2026-05-11 (commit `578f787`, GitHub Release with 11 assets), but the CHANGELOG `[Unreleased]` block wasn't moved to a versioned `[0.10.0]` header during the `make release` flow.

This adds:
- New `## [0.10.0] - 2026-05-11` header pointing at the published release
- Fresh empty `## [Unreleased]` block above for v0.11 work

## Follow-up

`make release` should stamp the CHANGELOG date automatically — will be filed as a v0.11 candidate so this gap doesn't recur on every future release.

## Test plan

- [x] CHANGELOG renders with both headers in correct order
- [x] No content dropped (the v0.10 release notes are unchanged, just under a versioned header now)