### PR TITLE
docs: README completions step + seed .planning/notes/ tracking

### DIFF
--- a/.planning/notes/2026-05-12-may-need-allow-exceptions.md
+++ b/.planning/notes/2026-05-12-may-need-allow-exceptions.md
@@ -1,0 +1,6 @@
+---
+date: "2026-05-12 14:30"
+promoted: false
+---
+
+may need to allow exceptions for the copy-instead-of-symlink logic for sources. e.g. company internally distributed skills/plugins/marketplaces should only be available on specified machines and not be commited to github repo as full-text files.

--- a/.planning/notes/2026-05-13-date-formatting-could-nicer.md
+++ b/.planning/notes/2026-05-13-date-formatting-could-nicer.md
@@ -1,0 +1,6 @@
+---
+date: "2026-05-13 16:38"
+promoted: false
+---
+
+date formatting could be nicer. currently tome status shows synced date as 2026-04-01T08:50:51Z

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ AI coding tools (Claude Code, Codex, Antigravity) each use SKILL.md packages to 
 brew install MartinP7r/tap/tome
 ```
 
+**Shell completions** (optional, recommended):
+```bash
+tome completions fish    # or: bash | zsh | elvish | powershell
+exec fish                 # reload your shell
+```
+
+Re-run after upgrading tome — completion definitions are regenerated, not auto-refreshed.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary

Two doc polish items surfaced during Phase 19 dogfooding, bundled together:

**README — Shell completions setup step**

- Adds a brief block under Install showing `tome completions <shell>` + reload, plus a one-liner that re-running is required after upgrades.
- Why: my own fish completions were stale (dated March 30) because `tome completions` is a manual step and doesn't auto-refresh on upgrade — so `tome remove dir` didn't show up in tab-completion even though it's been the canonical command since v0.10 / Phase 14.

**Planning — track `.planning/notes/` artifacts**

- Notes captured via `/gsd:note` land under `.planning/notes/` per the workflow spec — meant to be project-scoped scratchpads that can later graduate to roadmap items via `/gsd:note promote`.
- Tracking them so they travel with the repo and survive machine moves.
- Seed: 2 notes (copy-vs-symlink exceptions for company-internal sources; date-formatting UX in `tome status` — both candidates for v0.12 / future polish).

No code changes. Docs/planning only.

## Test plan

- [x] Visual inspection of README block
- [x] Notes render correctly via `/gsd:note list`
- [ ] N/A — no code; \`make ci\` unaffected