### PR TITLE
Bump version to 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.1] - 2026-05-15
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,7 +2272,7 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tome"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT"


### PR DESCRIPTION
## Summary

Cut **v0.11.1** patch release.

CHANGELOG.md `## [Unreleased]` renamed to `## [0.11.1] - 2026-05-15` (merged from #539). Cargo.toml + Cargo.lock bumped 0.11.0 → 0.11.1.

### What's in v0.11.1

- **Fixed**: \`make release\` recipe + FIX-06 regression tests now use cross-platform \`sed -i.bak\` instead of BSD-only \`sed -i ''\`. The v0.11.0 release was cut from macOS where this didn't surface — on Linux the recipe and tests both broke.
- **Changed**: CLI help-text vocabulary refresh (sources/targets → directories), README + docs/src drift cleanup, planning-artifact post-shipment sync.
- **Removed**: Unused \`tracing-error\` and \`tracing-appender\` workspace deps.

See CHANGELOG.md \`[0.11.1]\` for the full entry list.

## Test plan

- [ ] CI passes (fmt-check + clippy + tests + typos)
- [ ] After merge: \`git tag v0.11.1 && git push origin v0.11.1\` to trigger cargo-dist release workflow