### PR TITLE
Critical + Important fixes from pre-v1.0 codebase review

### DIFF
--- a/crates/tome/src/cleanup.rs
+++ b/crates/tome/src/cleanup.rs
@@ -437,6 +437,24 @@ pub fn cleanup_library(
             Vec::new()
         }
     } else if !case2_delete.is_empty() {
+        // Non-interactive mode auto-removes Case 2 entries (no TTY, --quiet,
+        // or --no-input). The architecture doc promises an "auto-removes
+        // with warning" semantic — the post-fact bucket renderer surfaces
+        // WHAT was deleted, but only if no stderr error fires before it
+        // reaches that point. A `warn!` here ensures the action is visible
+        // in `--verbose` / `TOME_LOG=warn` traces even if the renderer
+        // later errors out, so CI logs always show *something* before silent
+        // deletions in flaky-mount or transient-FS scenarios.
+        tracing::warn!(
+            "auto-removing {} library entry(s) whose source file vanished \
+             from disk (non-interactive mode): {}",
+            case2_delete.len(),
+            case2_delete
+                .iter()
+                .map(|e| e.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
         case2_delete.iter().map(|e| e.name.clone()).collect()
     } else {
         Vec::new()

--- a/crates/tome/src/cleanup.rs
+++ b/crates/tome/src/cleanup.rs
@@ -100,7 +100,9 @@ pub struct StaleSkill {
 /// Result of cleanup operation. Fields are `pub(crate)` because the renderer
 /// owns the user-facing surface — external callers should not mutate the
 /// bucket vecs directly (would break the "renderer reflects what cleanup
-/// detected" invariant).
+/// detected" invariant). For read-only access (e.g. the v1.0 Tauri GUI),
+/// use the accessor methods on `CleanupResult` instead — same shape as
+/// `Lockfile::skills()` / `Manifest::skills()`.
 #[derive(Debug, Default)]
 pub struct CleanupResult {
     pub(crate) removed_from_library: usize,
@@ -116,6 +118,36 @@ pub struct CleanupResult {
     /// three-bucket renderer (UX-01 D-UX01-1). Each carries the skill name
     /// and the **currently configured** source the file vanished from.
     pub(crate) bucket_b_missing_from_disk: Vec<StaleSkill>,
+}
+
+impl CleanupResult {
+    /// Total skill directories removed from the library this cleanup pass.
+    #[allow(dead_code)] // External-facing accessor for v1.0 GUI consumers
+    pub fn removed_from_library(&self) -> usize {
+        self.removed_from_library
+    }
+
+    /// Skills transitioned from owned -> Unowned (Bucket A semantics).
+    /// Library content for these skills was preserved per LIB-04.
+    #[allow(dead_code)] // External-facing accessor for v1.0 GUI consumers
+    pub fn transitioned_to_unowned(&self) -> usize {
+        self.transitioned_to_unowned
+    }
+
+    /// Bucket A entries — skills whose source directory was removed from
+    /// `tome.toml` between the previous sync and this one. Manifest entries
+    /// transitioned to Unowned; library content preserved.
+    #[allow(dead_code)] // External-facing accessor for v1.0 GUI consumers
+    pub fn bucket_a_removed_from_config(&self) -> &[StaleSkill] {
+        &self.bucket_a_removed_from_config
+    }
+
+    /// Bucket B entries — skills whose source directory is still configured
+    /// but the on-disk content vanished. Library copy removed.
+    #[allow(dead_code)] // External-facing accessor for v1.0 GUI consumers
+    pub fn bucket_b_missing_from_disk(&self) -> &[StaleSkill] {
+        &self.bucket_b_missing_from_disk
+    }
 }
 
 /// Render the three cleanup buckets to a writer. Used by `lib.rs::sync`

--- a/crates/tome/src/discover.rs
+++ b/crates/tome/src/discover.rs
@@ -120,9 +120,16 @@ pub struct SkillProvenance {
 /// How a skill was sourced — determines consolidation strategy.
 #[derive(Debug, Clone)]
 pub enum SkillOrigin {
-    /// Managed by a package manager; library entry is a symlink to source dir.
+    /// Managed by a package manager (v0.10+: stored as a real-directory
+    /// copy in the library, NOT a symlink). The `managed: true` manifest
+    /// flag marks the update channel — upstream sync feeds the copy via
+    /// `MarketplaceAdapter`. Pre-v0.10 stored managed skills as symlinks
+    /// into the source dir; that shape is now refused at the sync gate
+    /// (see `library::consolidate_managed` and `migration_v010`).
     Managed { provenance: Option<SkillProvenance> },
-    /// Local skill; library entry is a copy of the source.
+    /// Local skill; library entry is a real-directory copy of the source.
+    /// The library copy is editable in-place; `tome sync` detects drift
+    /// via content_hash comparison.
     Local,
 }
 

--- a/crates/tome/src/distribute.rs
+++ b/crates/tome/src/distribute.rs
@@ -61,7 +61,10 @@ pub fn distribute_to_directory(
         return Ok(result);
     }
 
-    // Read all entries in library (may be real directories for local skills or symlinks for managed skills)
+    // Read all entries in library — all are real directory copies since
+    // v0.10 (LIB-01). A symlink here indicates an un-migrated v0.9-shape
+    // library that should have been refused at the sync gate; see
+    // `library::consolidate_managed` for the refusal logic.
     let entries = std::fs::read_dir(library_dir)
         .with_context(|| format!("failed to read library dir {}", library_dir.display()))?;
 

--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -692,10 +692,15 @@ fn render_summary_json(report: &DoctorReport) -> serde_json::Value {
     let mut auto_fixable_by_category = Map::new();
     for c in IssueCategory::ALL {
         let n = report.count_by_category(c);
+        // `IssueCategory` derives `Serialize` and renders as a JSON string —
+        // any failure here is a programming error (e.g. a new variant added
+        // without `#[serde(rename_all = "snake_case")]`), not a runtime
+        // condition we should silently mask. Panicking with a clear message
+        // beats emitting `"": <count>` and corrupting machine-readable output.
         let key = serde_json::to_value(c)
             .ok()
             .and_then(|v| v.as_str().map(str::to_string))
-            .unwrap_or_default();
+            .expect("IssueCategory serializes to a JSON string");
         by_category.insert(key.clone(), Value::from(n));
         let nf = report.auto_fixable_count_by_category(c);
         if nf > 0 {

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -1406,17 +1406,31 @@ fn build_claude_adapter(config: &Config) -> Result<Option<marketplace::ClaudeMar
 ///   acceptable for v0.10).
 /// - Skip: emit nothing additional (the per-skill warning already fired in
 ///   `handle_edited`).
+/// Apply edit-in-library decisions to a manifest in-memory.
+///
+/// Returns `true` if any Fork mutation was applied (sync() should save the
+/// manifest in that case). Revert and Skip emit user-facing output but do
+/// not mutate.
+///
+/// Pre-refactor (v0.11.1 and earlier), this function did its own `manifest::
+/// load` + `manifest::save` round-trip, then `consolidate` did its own
+/// independent `manifest::load`. That double-disk-touch worked today (the
+/// operations were sequential and same-path) but the data flow had two
+/// readers and two writers of the same file with no shared in-memory
+/// state. Any future refactor that changed `consolidate` to skip the
+/// reload would silently lose Fork mutations. Now sync() owns the
+/// `Manifest` variable end-to-end through reconcile, so the mutation is
+/// visible in-memory and the save is centralized.
 fn apply_edit_decisions(
     report: &reconcile::ReconcileReport,
-    paths: &TomePaths,
+    manifest: &mut manifest::Manifest,
     dry_run: bool,
-) -> Result<()> {
+) -> bool {
     if report.edited.is_empty() || dry_run {
-        return Ok(());
+        return false;
     }
     debug_assert_eq!(report.edit_decisions.len(), report.edited.len());
 
-    let mut manifest = manifest::load(paths.config_dir())?;
     let mut mutated = false;
 
     for (edit, decision) in report.edited.iter().zip(report.edit_decisions.iter()) {
@@ -1432,6 +1446,12 @@ fn apply_edit_decisions(
                 }
             }
             reconcile::EditDecision::Revert => {
+                // v0.10 deferred stub: the Revert decision is a no-op — we
+                // warn the user that their choice was not applied and leave
+                // both the manifest and the library content untouched. Per
+                // D-16's "never silently overwrite" guarantee, opt-in revert
+                // gets a warn-and-skip until a future phase wires the
+                // actual upstream-copy restore path.
                 eprintln!(
                     "warning: revert chosen for {} but is not wired in v0.10 — \
                      left as-is. Re-run with `tome sync` after manually \
@@ -1444,11 +1464,7 @@ fn apply_edit_decisions(
         }
     }
 
-    if mutated {
-        manifest::save(&manifest, paths.config_dir())
-            .context("failed to save manifest after edit-in-library fork-in-place flip")?;
-    }
-    Ok(())
+    mutated
 }
 
 /// The core sync pipeline: discover → consolidate → distribute → cleanup.
@@ -1523,10 +1539,13 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
 
     // Load existing lockfile for diffing and reconciliation
     let old_lockfile = lockfile::load(paths.config_dir())?;
-    // Load manifest once for reconcile's edit-in-library detection. (sync()
-    // reloads it later post-consolidate; reading it twice is cheap and keeps
-    // reconcile's signature simple.)
-    let manifest_for_reconcile = manifest::load(paths.config_dir())?;
+    // Load manifest once for reconcile's edit-in-library detection. Held as
+    // `mut` so apply_edit_decisions can mutate it in-memory after reconcile
+    // returns — see Critical #1 refactor in the v0.11 review pass. The
+    // post-consolidate manifest reload happens inside `library::consolidate`;
+    // sync() is responsible for saving the fork-flipped state to disk here
+    // BEFORE consolidate's load, so the two stay coherent.
+    let mut manifest_for_reconcile = manifest::load(paths.config_dir())?;
 
     // v0.10 RECON-01..05: replaces the v0.9 reconcile_managed_plugins flow.
     // Adapter dispatch by DirectoryType (D-11); git stays separate (D-21).
@@ -1560,10 +1579,20 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
                 },
             )?;
 
-            // Apply edit-in-library decisions to the manifest. The manifest is
-            // owned by sync(); reconcile_lockfile only proposed the user's
-            // choice (RECON-05 D-13).
-            apply_edit_decisions(&report, paths, dry_run)?;
+            // Apply edit-in-library decisions to the manifest. The manifest
+            // is owned by sync(); reconcile_lockfile only proposed the user's
+            // choice (RECON-05 D-13). apply_edit_decisions mutates the
+            // in-memory `manifest_for_reconcile` and returns whether any Fork
+            // mutation landed; sync() saves the manifest to disk here so
+            // `library::consolidate` (which loads its own copy) observes the
+            // post-fork state. Centralizing the save here eliminates the
+            // pre-refactor "two writers, two readers, no shared state"
+            // pattern that risked silently losing Fork mutations under
+            // future consolidate refactors.
+            if apply_edit_decisions(&report, &mut manifest_for_reconcile, dry_run) {
+                manifest::save(&manifest_for_reconcile, paths.config_dir())
+                    .context("failed to save manifest after edit-in-library fork-in-place flip")?;
+            }
 
             // ADP-04: render grouped install failures. Sync exits non-zero at end
             // when this Vec is non-empty (RESEARCH OQ-6). Drain install_failures
@@ -2791,18 +2820,8 @@ mod tests {
 
     // -- apply_edit_decisions tests (Phase 14 / D-C1 transition site 3) --
 
-    #[test]
-    fn apply_edit_decisions_fork_records_previous_source() {
-        // Build a minimal manifest with one Owned managed skill and exercise
-        // apply_edit_decisions with EditDecision::Fork — verify the manifest
-        // entry transitions to Unowned (managed=false, source_name=None) AND
-        // captures previous_source per D-C1 / Phase 13 D-13 closure.
-        let tmp = TempDir::new().unwrap();
-        let library = tmp.path().join("library");
-        std::fs::create_dir_all(&library).unwrap();
-        let paths = TomePaths::new(tmp.path().to_path_buf(), library).unwrap();
-        std::fs::create_dir_all(paths.config_dir()).unwrap();
-
+    /// Build a one-skill managed manifest for the apply_edit_decisions tests.
+    fn fork_test_manifest() -> manifest::Manifest {
         let mut manifest = manifest::Manifest::default();
         manifest.insert(
             discover::SkillName::new("plug").unwrap(),
@@ -2813,29 +2832,108 @@ mod tests {
                 true, // managed
             ),
         );
-        manifest::save(&manifest, paths.config_dir()).unwrap();
+        manifest
+    }
 
-        // Build a ReconcileReport with one Edited entry and Fork decision.
-        let report = reconcile::ReconcileReport {
+    /// Build a one-skill ReconcileReport with the given decision.
+    fn fork_test_report(decision: reconcile::EditDecision) -> reconcile::ReconcileReport {
+        reconcile::ReconcileReport {
             edited: vec![reconcile::Edited {
                 name: discover::SkillName::new("plug").unwrap(),
                 old_source: config::DirectoryName::new("claude-plugins").unwrap(),
                 old_version: Some("1.0.0".to_string()),
             }],
-            edit_decisions: vec![reconcile::EditDecision::Fork],
+            edit_decisions: vec![decision],
             ..Default::default()
-        };
+        }
+    }
 
-        apply_edit_decisions(&report, &paths, false).unwrap();
+    #[test]
+    fn apply_edit_decisions_fork_records_previous_source() {
+        // EditDecision::Fork transitions the manifest entry to Unowned
+        // (managed=false, source_name=None) AND captures previous_source
+        // per D-C1 / Phase 13 D-13 closure.
+        let mut manifest = fork_test_manifest();
+        let report = fork_test_report(reconcile::EditDecision::Fork);
 
-        let reloaded = manifest::load(paths.config_dir()).unwrap();
-        let entry = reloaded.get("plug").unwrap();
+        let mutated = apply_edit_decisions(&report, &mut manifest, false);
+
+        assert!(mutated, "Fork must report mutated=true");
+        let entry = manifest.get("plug").unwrap();
         assert_eq!(entry.source_name, None, "fork-in-place clears source_name");
         assert!(!entry.managed, "fork-in-place clears managed");
         assert_eq!(
             entry.previous_source,
             Some(config::DirectoryName::new("claude-plugins").unwrap()),
             "fork-in-place must record previous_source per D-C1 / Phase 13 D-13 closure"
+        );
+    }
+
+    #[test]
+    fn apply_edit_decisions_revert_leaves_manifest_byte_for_byte_unchanged() {
+        // EditDecision::Revert is an explicit v0.10 deferred stub: emits a
+        // warning, mutates NOTHING. This regression test pins the no-op
+        // semantic so a future "completion" of the revert path that
+        // accidentally adds library-overwrite logic (data-loss class) fails
+        // here first. Closes the critical test gap surfaced in the v0.11
+        // codebase review.
+        let mut manifest = fork_test_manifest();
+        let serialized_before = serde_json::to_string(&manifest).unwrap();
+        let report = fork_test_report(reconcile::EditDecision::Revert);
+
+        let mutated = apply_edit_decisions(&report, &mut manifest, false);
+
+        assert!(!mutated, "Revert must not mutate the manifest");
+        let serialized_after = serde_json::to_string(&manifest).unwrap();
+        assert_eq!(
+            serialized_before, serialized_after,
+            "Revert is a stub — manifest must be byte-for-byte unchanged"
+        );
+        // Field-level assertions as belt-and-suspenders against future
+        // serialization changes that round-trip the bytes but mutate
+        // semantically. The entry's owned state must be preserved.
+        let entry = manifest.get("plug").unwrap();
+        assert_eq!(
+            entry.source_name,
+            Some(config::DirectoryName::new("claude-plugins").unwrap()),
+            "Revert must preserve source_name"
+        );
+        assert!(entry.managed, "Revert must preserve managed flag");
+        assert_eq!(entry.previous_source, None, "Revert must not set previous_source");
+    }
+
+    #[test]
+    fn apply_edit_decisions_skip_leaves_manifest_byte_for_byte_unchanged() {
+        // EditDecision::Skip emits nothing additional (handle_edited already
+        // warned during reconcile) and mutates nothing.
+        let mut manifest = fork_test_manifest();
+        let serialized_before = serde_json::to_string(&manifest).unwrap();
+        let report = fork_test_report(reconcile::EditDecision::Skip);
+
+        let mutated = apply_edit_decisions(&report, &mut manifest, false);
+
+        assert!(!mutated, "Skip must not mutate the manifest");
+        let serialized_after = serde_json::to_string(&manifest).unwrap();
+        assert_eq!(
+            serialized_before, serialized_after,
+            "Skip is a no-op — manifest must be byte-for-byte unchanged"
+        );
+    }
+
+    #[test]
+    fn apply_edit_decisions_dry_run_returns_false_without_mutating() {
+        // dry_run short-circuits before any mutation, even for Fork.
+        let mut manifest = fork_test_manifest();
+        let serialized_before = serde_json::to_string(&manifest).unwrap();
+        let report = fork_test_report(reconcile::EditDecision::Fork);
+
+        let mutated = apply_edit_decisions(&report, &mut manifest, true);
+
+        assert!(!mutated, "dry_run must not report mutated=true");
+        let serialized_after = serde_json::to_string(&manifest).unwrap();
+        assert_eq!(
+            serialized_before, serialized_after,
+            "dry_run must not mutate the manifest"
         );
     }
 

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -1013,10 +1013,17 @@ pub(crate) fn cmd_migrate_library(
     let manifest = manifest::load(paths.config_dir())?;
     let plan = migration_v010::plan(paths.library_dir(), &manifest)?;
     // HARD-15 stderr discipline: render directly to a locked stderr handle.
-    // Best-effort write — failure to render is non-fatal for the migration.
+    // Best-effort write — failure to render is non-fatal for the migration,
+    // but we route the I/O failure through `tracing::warn!` instead of
+    // dropping it silently so a broken stderr (broken pipe, /dev/full) is
+    // diagnosable in `--verbose` / `TOME_LOG=warn` runs. Without this, the
+    // user could land in the confirmation prompt below having seen no plan,
+    // and silently approve an unknown migration.
     {
         let mut stderr = std::io::stderr().lock();
-        let _ = migration_v010::render_plan_to(&plan, &mut stderr);
+        if let Err(e) = migration_v010::render_plan_to(&plan, &mut stderr) {
+            tracing::warn!("could not write migration plan to stderr: {e}");
+        }
     }
 
     // Empty plan — render_plan_to already printed the already-in-v0.10-shape
@@ -1038,7 +1045,9 @@ pub(crate) fn cmd_migrate_library(
     let result = migration_v010::execute(&plan, dry_run)?;
     {
         let mut stderr = std::io::stderr().lock();
-        let _ = migration_v010::render_result_to(&result, dry_run, &mut stderr);
+        if let Err(e) = migration_v010::render_result_to(&result, dry_run, &mut stderr) {
+            tracing::warn!("could not write migration result to stderr: {e}");
+        }
     }
 
     // HARD-04 sibling: bubble through anyhow rather than `process::exit(1)`.
@@ -1819,18 +1828,28 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
     //     buckets in the user's terminal.
     if !quiet {
         let mut stderr = std::io::stderr().lock();
-        // Best-effort: failure to write to stderr is non-fatal for sync
-        // (matches existing eprintln! semantics that ignore I/O errors).
-        let _ = cleanup::render_cleanup_buckets(
+        // Best-effort writes — failure to render is non-fatal for sync. The
+        // bucket renderer is the ONLY user notification for cleanup actions
+        // (stale-skill removals, foreign-symlink failures), so silently
+        // dropping I/O errors here would hide critical information; route
+        // through `tracing::warn!` so the failure is at least discoverable
+        // in `--verbose` / `TOME_LOG=warn` traces.
+        if let Err(e) = cleanup::render_cleanup_buckets(
             &mut stderr,
             &report.cleanup.bucket_a_removed_from_config,
             &report.cleanup.bucket_b_missing_from_disk,
             &excluded_skills,
-        );
-        let _ = cleanup::render_distribution_cleanup_failures(
+        ) {
+            tracing::warn!("could not render cleanup buckets to stderr: {e}");
+        }
+        if let Err(e) = cleanup::render_distribution_cleanup_failures(
             &mut stderr,
             &distribution_cleanup_failures,
-        );
+        ) {
+            tracing::warn!(
+                "could not render distribution cleanup failures to stderr: {e}"
+            );
+        }
     }
 
     // Post-sync health check

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -1422,26 +1422,23 @@ fn build_claude_adapter(config: &Config) -> Result<Option<marketplace::ClaudeMar
     Ok(Some(adapter))
 }
 
-/// Apply the user's edit-in-library decisions to the on-disk manifest.
-///
-/// Per RECON-05 D-13:
-/// - Fork: `managed: true → false`, `source_name: Some → None`. Library
-///   content stays in place. Provenance history is dropped (one-time UX gap;
-///   Phase 14 may add fields retroactively).
-/// - Revert: leave the manifest untouched here — the apply_drift loop in
-///   reconcile_lockfile would have applied an `adapter.update()` (revert
-///   degenerates to "force a drift apply"); if the user picked revert here,
-///   they're saying "I want the upstream copy" — emit a warning that revert
-///   is not yet wired (deferred to a follow-up; D-16's safety guarantee is
-///   "never silently overwrite", and revert is opt-in so a warn-and-skip is
-///   acceptable for v0.10).
-/// - Skip: emit nothing additional (the per-skill warning already fired in
-///   `handle_edited`).
-/// Apply edit-in-library decisions to a manifest in-memory.
+/// Apply the user's edit-in-library decisions to the manifest in-memory.
 ///
 /// Returns `true` if any Fork mutation was applied (sync() should save the
 /// manifest in that case). Revert and Skip emit user-facing output but do
 /// not mutate.
+///
+/// Per RECON-05 D-13:
+///
+/// - **Fork**: `managed: true → false`, `source_name: Some → None`. Library
+///   content stays in place. `previous_source` captures the old
+///   `source_name` per D-C1 (Phase 14, transition site 3).
+/// - **Revert**: emits a warning that revert is not yet wired (deferred to a
+///   follow-up; D-16's safety guarantee is "never silently overwrite", and
+///   revert is opt-in so a warn-and-skip is acceptable for v0.10). No
+///   mutation.
+/// - **Skip**: emits nothing additional (the per-skill warning already fired
+///   in `handle_edited`). No mutation.
 ///
 /// Pre-refactor (v0.11.1 and earlier), this function did its own `manifest::
 /// load` + `manifest::save` round-trip, then `consolidate` did its own
@@ -1906,9 +1903,7 @@ fn sync(config: &Config, paths: &TomePaths, opts: SyncOptions<'_>) -> Result<()>
             &mut stderr,
             &distribution_cleanup_failures,
         ) {
-            tracing::warn!(
-                "could not render distribution cleanup failures to stderr: {e}"
-            );
+            tracing::warn!("could not render distribution cleanup failures to stderr: {e}");
         }
     }
 
@@ -2930,7 +2925,10 @@ mod tests {
             "Revert must preserve source_name"
         );
         assert!(entry.managed, "Revert must preserve managed flag");
-        assert_eq!(entry.previous_source, None, "Revert must not set previous_source");
+        assert_eq!(
+            entry.previous_source, None,
+            "Revert must not set previous_source"
+        );
     }
 
     #[test]

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -7,12 +7,21 @@
 //!
 //! The `sync` function drives the main workflow:
 //!
-//! 1. **Discover** — scan configured sources for `*/SKILL.md` directories
-//! 2. **Consolidate** — copy or symlink discovered skills into the library
-//! 3. **Triage** — diff lockfile, surface changes, let user disable new skills
+//! 1. **Reconcile** — lockfile-authoritative drift detection for managed
+//!    skills via [`MarketplaceAdapter`](marketplace::MarketplaceAdapter)
+//!    (Phase 13: classify each managed skill as Match / Drift / Vanished,
+//!    apply updates per `auto_install_plugins` consent).
+//! 2. **Discover** — scan configured directories (role `managed`/`source`/
+//!    `synced`) for `*/SKILL.md` directories.
+//! 3. **Consolidate** — copy every discovered skill (managed AND local)
+//!    into the library as a real directory (v0.10 library-canonical model;
+//!    no symlinks).
 //! 4. **Distribute** — push library skills to target tools via symlinks
-//! 5. **Cleanup** — remove stale entries no longer in any source
-//! 6. **Save** — persist manifest, lockfile, and `.gitignore`
+//!    into `target` / `synced` directories.
+//! 5. **Cleanup** — three-bucket stale-skill report
+//!    (removed-from-config / missing-from-disk / now-in-exclude-list);
+//!    orphan transitions preserve library content per LIB-04.
+//! 6. **Save** — persist manifest, lockfile, and `.gitignore`.
 //!
 //! # Public API
 //!
@@ -101,7 +110,29 @@ pub use manifest::hash_directory;
 pub use lint::LintFailed;
 pub use migration_v010::MigrationPartialOrFailed;
 
-/// Summary of a complete sync operation.
+/// Summary of a complete sync operation — the return-shape of the full
+/// `sync()` pipeline (reconcile → discover → consolidate → distribute →
+/// cleanup → save). This is the primary data source for any consumer that
+/// wants to surface "what happened this sync" (the CLI's stdout summary
+/// block today; the v1.0 Tauri GUI's sync-result view tomorrow).
+///
+/// # Field ownership
+///
+/// - [`consolidate`](Self::consolidate) — always populated; counts skills
+///   created / unchanged / updated in the library this run.
+/// - [`distributions`](Self::distributions) — one entry per configured
+///   `target` / `synced` directory. Empty when no directories are
+///   configured (a config error surfaced separately).
+/// - [`cleanup`](Self::cleanup) — always populated; reflects the three
+///   stale-skill buckets (A: removed-from-config / B: missing-from-disk /
+///   C: now-in-exclude-list). Use the public accessors on
+///   [`CleanupResult`] for read-only access.
+/// - [`removed_from_targets`](Self::removed_from_targets) — total stale
+///   distribution symlinks pruned across all targets.
+/// - [`reconcile`](Self::reconcile) — `None` when sync ran without a
+///   `MarketplaceAdapter` (no `claude-plugins` directory configured).
+///   `Some(_)` when reconcile ran; counts may all be zero on a clean
+///   match. See [`reconcile::ReconcileReport`] for the inner shape.
 pub struct SyncReport {
     pub consolidate: ConsolidateResult,
     pub distributions: Vec<DistributeResult>,

--- a/crates/tome/src/lockfile.rs
+++ b/crates/tome/src/lockfile.rs
@@ -19,7 +19,7 @@ use crate::validation::ContentHash;
 pub(crate) const LOCKFILE_NAME: &str = "tome.lock";
 
 /// Top-level lockfile structure.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Lockfile {
     /// Schema version (currently 1).
     pub(crate) version: u32,

--- a/crates/tome/src/marketplace.rs
+++ b/crates/tome/src/marketplace.rs
@@ -29,8 +29,6 @@ use crate::paths::TomePaths;
 // dead_code allow: Phase 12 ships the trait + adapters + tests. The first
 // non-test consumer is Phase 13's sync dispatcher (RECON-*), which calls
 // `list_installed()` and stores `InstalledPlugin` values for drift detection.
-// Drop this attr when Phase 13 wires the call from `lib.rs::sync`.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct InstalledPlugin {
     /// Stable plugin identifier from the marketplace.
@@ -79,7 +77,6 @@ pub struct InstalledPlugin {
 // `GitAdapter` (Plan 12-03) and `MockMarketplaceAdapter` (Plan 12-01 tests),
 // but neither has a non-test caller yet. Drop when Phase 13's sync dispatcher
 // constructs `Box<dyn MarketplaceAdapter>` for each `DirectoryConfig`.
-#[allow(dead_code)]
 pub trait MarketplaceAdapter {
     /// Stable identifier for this adapter instance (e.g. git URL, or
     /// `"claude-plugins"` for the singleton Claude adapter).
@@ -121,8 +118,6 @@ pub trait MarketplaceAdapter {
 // dead_code allow: variants are constructed by Task 2's renderer tests in this
 // same plan; the production renderer formats them via `{:?}` (Debug derive).
 // First non-test producer arrives in Plan 12-04 (ClaudeMarketplaceAdapter).
-// Drop this attr when the first non-test caller lands.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstallOp {
     Install,
@@ -146,7 +141,6 @@ pub enum InstallOp {
 // from production code in Task 2. First non-test producer arrives in Plan
 // 12-04 (ClaudeMarketplaceAdapter heuristic stderr -> kind mapper). Drop this
 // attr when the first non-test caller lands.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstallFailureKind {
     /// Plugin / URL not in marketplace or not reachable.
@@ -178,7 +172,6 @@ impl InstallFailureKind {
     // dead_code allow: Task 2 of this plan adds the production renderer that
     // calls `kind.label()`; once that lands, this attr is dropped. The method
     // is also exercised by the `install_failure_kind_label_coverage` test.
-    #[allow(dead_code)]
     pub fn label(self) -> &'static str {
         match self {
             InstallFailureKind::NotFound => "Not found",
@@ -200,7 +193,6 @@ impl InstallFailureKind {
 /// exhaustiveness check. The `const _: () = ...` block below additionally
 /// pins `ALL.len() == 4` at compile time so a hand-edit that adds a match
 /// arm here without growing `ALL` (or vice versa) also fails.
-#[allow(dead_code)]
 const fn _ensure_install_failure_kind_all_exhaustive(k: InstallFailureKind) -> usize {
     match k {
         InstallFailureKind::NotFound => 0,
@@ -237,7 +229,6 @@ const _: () = {
 // constructs `InstallFailure` from upstream stderr); Phase 13 aggregates the
 // `Vec<InstallFailure>` across adapter calls. Drop this attr when the first
 // non-test caller lands.
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct InstallFailure {
     /// Adapter that produced the failure — typically the adapter's
@@ -274,7 +265,6 @@ pub struct InstallFailure {
 // Plan 12-02 ships only the renderer + tests; the wrapper [`render_install_failures`]
 // and the renderer tests in this file exercise both functions. Drop this attr
 // when Phase 13 wires the call from `lib.rs::sync`.
-#[allow(dead_code)]
 pub(crate) fn format_install_failures(failures: &[InstallFailure]) -> String {
     if failures.is_empty() {
         return String::new();
@@ -332,14 +322,12 @@ pub fn render_install_failures(failures: &[InstallFailure]) {
 // `GitAdapter::for_directory(...)` for each `DirectoryType::Git` entry. Drop
 // this attr (and the `#[allow]`s on the inherent methods below) when Phase 13
 // wires the dispatch.
-#[allow(dead_code)]
 pub struct GitAdapter {
     url: String,
     cache_dir: PathBuf,
     git_ref: Option<GitRef>,
 }
 
-#[allow(dead_code)]
 impl GitAdapter {
     /// Construct a `GitAdapter` from a git-type [`DirectoryConfig`].
     ///
@@ -501,10 +489,11 @@ pub(crate) fn parse_claude_plugin_list_json(input: &str) -> Result<Vec<Installed
 /// once empirical evidence surfaces; they exist in the enum so the renderer's
 /// grouped output is forward-compatible.
 //
-// dead_code allow: only producer is `ClaudeMarketplaceAdapter::build_install_failure`,
-// which is itself only consumed from tests until Phase 13's sync flow wraps
-// adapter `install`/`update` errors into `Vec<InstallFailure>`. Drop this
-// attr when Phase 13's first non-test caller lands.
+// Currently exercised only via tests; production callers will land when
+// `lib.rs::sync` wraps adapter `install`/`update` errors into
+// `Vec<InstallFailure>` (tracked separately — see #518 ClaudeMarketplaceAdapter
+// error-chain capture). The `_coverage` and `_basic` unit tests pin the
+// behavior so callers can rely on it when they come online.
 #[allow(dead_code)]
 pub(crate) fn classify_claude_install_stderr(stderr: &str) -> InstallFailureKind {
     // Both "not found in marketplace" and bare "not found" map to NotFound,
@@ -533,7 +522,6 @@ pub(crate) fn classify_claude_install_stderr(stderr: &str) -> InstallFailureKind
 // itself has no non-test consumer until Phase 13's D-11 dispatcher constructs
 // the adapter. Smoke tests in this module also call this directly. Drop this
 // attr when the dispatcher lands.
-#[allow(dead_code)]
 pub fn is_claude_available() -> bool {
     std::process::Command::new("claude")
         .arg("--version")
@@ -592,12 +580,10 @@ fn run_claude_subcommand(args: &[&str]) -> Result<std::process::Output> {
 // directories. Drop this attr (and the `#[allow]` on the inherent impl block
 // below) when the dispatcher lands. The trait impl block follows the trait's
 // reachability and does not need its own attr.
-#[allow(dead_code)]
 pub struct ClaudeMarketplaceAdapter {
     cache: RefCell<Option<Vec<InstalledPlugin>>>,
 }
 
-#[allow(dead_code)]
 impl ClaudeMarketplaceAdapter {
     /// Construct a `ClaudeMarketplaceAdapter`, probing `claude --version` to
     /// fail fast if the binary is missing.
@@ -669,9 +655,10 @@ impl ClaudeMarketplaceAdapter {
     ///
     /// Pulled out as a testable `pub(crate)` helper so the stderr-to-failure
     /// conversion can be exercised in unit tests without spawning a
-    /// subprocess. Phase 13's sync flow may also call this helper directly
+    /// subprocess. The production sync flow may call this helper directly
     /// when it wraps adapter `install`/`update` errors into
-    /// `Vec<InstallFailure>` for the grouped renderer.
+    /// `Vec<InstallFailure>` for the grouped renderer (tracked separately).
+    #[allow(dead_code)]
     pub(crate) fn build_install_failure(
         adapter_id: &str,
         plugin_id: &str,

--- a/crates/tome/src/marketplace.rs
+++ b/crates/tome/src/marketplace.rs
@@ -72,11 +72,64 @@ pub struct InstalledPlugin {
 /// All methods return `anyhow::Result`. `plugin_id` is `&str` (not a newtype)
 /// because marketplace identifiers carry an `@marketplace` suffix that's
 /// incompatible with `SkillName` validation (e.g. `"axiom@axiom-marketplace"`).
-//
-// dead_code allow: see InstalledPlugin above. The trait is implemented by
-// `GitAdapter` (Plan 12-03) and `MockMarketplaceAdapter` (Plan 12-01 tests),
-// but neither has a non-test caller yet. Drop when Phase 13's sync dispatcher
-// constructs `Box<dyn MarketplaceAdapter>` for each `DirectoryConfig`.
+/// Marketplace-specific install / update / availability operations for
+/// managed skills. Implemented per marketplace; reconcile picks the right
+/// implementation by `DirectoryType` (D-11).
+///
+/// # Implementations
+///
+/// Two production adapters ship with tome:
+/// - [`ClaudeMarketplaceAdapter`] — shells out to the `claude plugin`
+///   subcommands and parses `claude plugin list --json`.
+/// - [`GitAdapter`] — thin shim over [`crate::git`] for `type = "git"`
+///   directories. Behavior preserved byte-for-byte from v0.9.
+///
+/// A test mock [`testing::MockMarketplaceAdapter`] lives behind the
+/// `test-support` feature for unit tests; production code never sees it.
+///
+/// # Example: implementing a new adapter
+///
+/// ```ignore
+/// use anyhow::Result;
+/// use tome::marketplace::{InstalledPlugin, InstallOp, MarketplaceAdapter};
+///
+/// struct NpmAdapter;
+///
+/// impl MarketplaceAdapter for NpmAdapter {
+///     fn id(&self) -> &str { "npm" }
+///     fn current_version(&self, plugin_id: &str) -> Result<Option<String>> {
+///         // Query the npm registry; return version or None
+///         Ok(None)
+///     }
+///     fn install(&self, plugin_id: &str) -> Result<()> {
+///         // Shell out to `npm install -g ...`
+///         Ok(())
+///     }
+///     fn update(&self, plugin_id: &str) -> Result<()> {
+///         // Shell out to `npm update -g ...`
+///         Ok(())
+///     }
+///     fn list_installed(&self) -> Result<Vec<InstalledPlugin>> {
+///         // Parse `npm list -g --json`
+///         Ok(vec![])
+///     }
+///     fn available(&self, plugin_id: &str) -> Result<bool> {
+///         Ok(true)
+///     }
+/// }
+/// ```
+///
+/// # Cache invariants
+///
+/// Adapters that cache `list_installed()` output MUST auto-invalidate
+/// the cache on `Ok` from `install()` / `update()` (D-04). The
+/// [`ClaudeMarketplaceAdapter`] implementation does this via
+/// `*self.cache.borrow_mut() = None` on success.
+///
+/// # Sealing
+///
+/// The trait is currently not sealed — third-party crates can implement
+/// it. Sealing it is tracked as a v1.0 prep item (#518).
 pub trait MarketplaceAdapter {
     /// Stable identifier for this adapter instance (e.g. git URL, or
     /// `"claude-plugins"` for the singleton Claude adapter).

--- a/crates/tome/src/marketplace.rs
+++ b/crates/tome/src/marketplace.rs
@@ -714,7 +714,23 @@ impl MarketplaceAdapter for ClaudeMarketplaceAdapter {
 
     fn list_installed(&self) -> Result<Vec<InstalledPlugin>> {
         self.populate_cache()?;
-        Ok(self.cache.borrow().clone().unwrap_or_default())
+        let cache = self.cache.borrow();
+        // populate_cache()? returning Ok() should always leave cache as
+        // Some(_) — if it doesn't, a downstream caller (reconcile) would
+        // treat empty as "no plugins installed" and silently skip every
+        // managed update. Per #514 we don't panic from trait methods, but
+        // we DO surface the invariant violation as a warn-level event so
+        // it's visible in `--verbose` / `TOME_LOG=warn` runs instead of
+        // disappearing entirely.
+        if cache.is_none() {
+            tracing::warn!(
+                "ClaudeMarketplaceAdapter::list_installed: populate_cache() \
+                 succeeded but cache is None — returning empty list. This is \
+                 a programming-error invariant violation; reconcile may skip \
+                 managed-plugin updates this sync."
+            );
+        }
+        Ok(cache.clone().unwrap_or_default())
     }
 
     fn available(&self, plugin_id: &str) -> Result<bool> {

--- a/crates/tome/src/reconcile.rs
+++ b/crates/tome/src/reconcile.rs
@@ -97,7 +97,41 @@ pub struct Edited {
 
 /// Aggregate report returned to `lib.rs::sync` for stdout/stderr rendering
 /// + exit-code decisions. The summary line `✓ N match · ⚠ N drift · ⚠ N
-/// vanished` is computed from the counts here (D-02/D-04).
+/// Outcome of one reconcile pass over the lockfile (Phase 13 / RECON-01..05).
+///
+/// Produced by [`reconcile_lockfile`] and threaded into [`crate::SyncReport`].
+/// Surfaces both the **classification** of every managed lockfile entry
+/// (Match / Drift / Vanished / Missing) and the **user-decision artifacts**
+/// for skills detected as edit-in-library.
+///
+/// # Lifecycle
+///
+/// - On a sync with no [`crate::marketplace::MarketplaceAdapter`]
+///   configured (no `claude-plugins` directory), this struct is never
+///   created — `SyncReport.reconcile` is `None`.
+/// - On a sync with an adapter, all vec fields are `Vec::default()` and
+///   `matches` starts at `0`; they're populated as `reconcile_lockfile`
+///   walks the lockfile.
+/// - `vanished` is computed from the count returned by
+///   `adapter.available() == false` (D-02 / D-04).
+/// - `drift` entries may have an `install_failures` corresponding entry
+///   appended if the apply step's `adapter.install`/`update` call failed.
+///
+/// # Vec lengths
+///
+/// `edited` and `edit_decisions` are parallel vectors in the same order
+/// (one decision per edited skill). The invariant is asserted in
+/// [`reconcile_lockfile`]'s final `debug_assert_eq!`. Consumers must NOT
+/// re-order or filter one without the other. **Note:** tracked as a
+/// type-design improvement in issue #519 — a single `Vec<EditOutcome>`
+/// would make the lockstep relationship structural.
+///
+/// # OBS-05 summary line
+///
+/// The `reconcile: ✓ N match · ⚠ M drift · ⚠ K vanished · ⚠ L
+/// missing-from-machine` summary line emitted by
+/// `render_sync_report` is computed from `matches`, `drift.len()`,
+/// `vanished.len()`, and `missing.len()`.
 #[derive(Debug, Default)]
 pub struct ReconcileReport {
     pub matches: usize,

--- a/crates/tome/src/reconcile.rs
+++ b/crates/tome/src/reconcile.rs
@@ -95,14 +95,13 @@ pub struct Edited {
     pub old_version: Option<String>,
 }
 
-/// Aggregate report returned to `lib.rs::sync` for stdout/stderr rendering
-/// + exit-code decisions. The summary line `✓ N match · ⚠ N drift · ⚠ N
 /// Outcome of one reconcile pass over the lockfile (Phase 13 / RECON-01..05).
 ///
-/// Produced by [`reconcile_lockfile`] and threaded into [`crate::SyncReport`].
-/// Surfaces both the **classification** of every managed lockfile entry
-/// (Match / Drift / Vanished / Missing) and the **user-decision artifacts**
-/// for skills detected as edit-in-library.
+/// Aggregate report returned to `lib.rs::sync` for stdout/stderr rendering
+/// and exit-code decisions. Produced by [`reconcile_lockfile`] and threaded
+/// into [`crate::SyncReport`]. Surfaces both the **classification** of every
+/// managed lockfile entry (Match / Drift / Vanished / Missing) and the
+/// **user-decision artifacts** for skills detected as edit-in-library.
 ///
 /// # Lifecycle
 ///

--- a/crates/tome/src/reconcile.rs
+++ b/crates/tome/src/reconcile.rs
@@ -225,7 +225,7 @@ pub fn reconcile_lockfile(
     };
 
     // 5. Apply if consent allows.
-    let mut working_lockfile = clone_lockfile(lockfile);
+    let mut working_lockfile = lockfile.clone();
     let apply_should_run = matches!(consent, ConsentDecision::Apply) && !opts.no_install;
     if apply_should_run {
         apply_drift_and_missing(
@@ -256,21 +256,6 @@ pub fn reconcile_lockfile(
     }
 
     Ok(report)
-}
-
-/// Clone a `Lockfile` field-by-field. `Lockfile` does not derive `Clone`
-/// (touching its derives is out of scope for Phase 13 — see HARD-06), but
-/// `LockEntry` does, so this helper rebuilds the BTreeMap manually.
-fn clone_lockfile(src: &Lockfile) -> Lockfile {
-    let skills = src
-        .skills
-        .iter()
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect();
-    Lockfile {
-        version: src.version,
-        skills,
-    }
 }
 
 /// Classify every managed lockfile entry against the live marketplace.

--- a/crates/tome/src/reconcile.rs
+++ b/crates/tome/src/reconcile.rs
@@ -522,14 +522,26 @@ fn apply_drift_and_missing(
     dry_run: bool,
 ) -> Result<()> {
     // Render diff lines (D-05) before applying so the user sees what's about
-    // to happen — applies even when consent was Always (silently).
+    // to happen — applies even when consent was Always (silently). Routed
+    // through stderr (not stdout) to match the rest of the sync pipeline's
+    // output discipline: cleanup buckets, dry-run banner, and warnings all
+    // emit on stderr. Stdout stays reserved for the structured summary
+    // block (`render_sync_report`) that GUI consumers will parse.
+    //
+    // NOTE: A future v1.0 Phase 10 (CORE extraction) pass should surface
+    // these per-skill events through `ReconcileReport.drift` /
+    // `ReconcileReport.missing` fields and let the GUI render them from
+    // structured data instead of intercepting stderr. The data is already
+    // captured in those vecs; what's missing is a post-apply outcome
+    // marker (success vs install-failure) so the renderer can show
+    // accurate "updated" vs "attempted" status.
     for c in drift {
         if let ReconcileClass::Drift {
             old_version,
             new_version,
         } = &c.class
         {
-            println!(
+            eprintln!(
                 "  • {}: {} → {}",
                 c.name.as_str(),
                 old_version.as_deref().unwrap_or("unknown"),
@@ -538,7 +550,7 @@ fn apply_drift_and_missing(
         }
     }
     for c in missing {
-        println!("  • {} (missing — installing)", c.name.as_str());
+        eprintln!("  • {} (missing — installing)", c.name.as_str());
     }
 
     if dry_run {

--- a/crates/tome/src/relocate.rs
+++ b/crates/tome/src/relocate.rs
@@ -32,9 +32,11 @@ pub(crate) struct RelocatePlan {
 #[derive(Debug)]
 pub(crate) struct SkillMoveEntry {
     pub name: SkillName,
-    /// True for managed skills (library symlink → external source dir).
-    /// Used by `copy_library` to preserve the symlink shape during the
-    /// move (lines ~419–424).
+    /// `true` for managed skills (v0.10+: real directory copy with
+    /// `manifest.managed == true`). The pre-v0.10 "library symlink → external
+    /// source dir" shape is no longer expected; if `copy_library` encounters
+    /// a symlink during the move, it warns via `warn_if_unreadable_symlink`
+    /// rather than preserving the symlink (HARD-16).
     pub is_managed: bool,
 }
 

--- a/crates/tome/src/status.rs
+++ b/crates/tome/src/status.rs
@@ -318,7 +318,10 @@ fn render_status(report: &StatusReport) {
     println!("{} {}", style("Health:").bold(), health);
 }
 
-/// Count skill entries in the library (directories or symlinks-to-dirs), excluding hidden entries.
+/// Count skill directory entries in the library, excluding hidden entries.
+/// Since v0.10 (LIB-01) all library entries are real directory copies;
+/// symlinks-to-dirs are still counted via `path.is_dir()` to support
+/// reading un-migrated v0.9-shape libraries from `tome status`.
 fn count_entries(dir: &Path) -> Result<usize> {
     let mut count = 0;
     for entry in std::fs::read_dir(dir)
@@ -330,7 +333,9 @@ fn count_entries(dir: &Path) -> Result<usize> {
             continue;
         }
         let path = entry.path();
-        // Count real directories (local skills) and symlinks-to-dirs (managed skills)
+        // `is_dir()` follows symlinks, so it counts both real directories
+        // (the v0.10+ canonical shape) and symlinks-to-dirs (v0.9-shape
+        // libraries that haven't run `tome migrate-library` yet).
         if path.is_dir() {
             count += 1;
         }

--- a/crates/tome/src/status.rs
+++ b/crates/tome/src/status.rs
@@ -35,11 +35,25 @@ impl From<Result<usize, String>> for CountOrError {
 }
 
 /// Status of a single configured directory.
+///
+/// **JSON shape change (v0.11+):** `role` is now the typed
+/// `DirectoryRole` enum (serializes as `"managed"` / `"synced"` /
+/// `"source"` / `"target"`) so GUI consumers can branch on the role
+/// without parsing prose. The human-readable description previously
+/// in `role` (e.g. `"Synced (skills discovered here AND distributed
+/// here)"`) moved to `role_description`. Per the project's
+/// `Backward compat: None` policy, JSON consumers that read `role` as
+/// a description string need to switch to `role_description` or to the
+/// enum-aware reader.
 #[derive(serde::Serialize)]
 pub struct DirectoryStatus {
     pub name: String,
     pub directory_type: String,
-    pub role: String,
+    pub role: crate::config::DirectoryRole,
+    /// Human-readable description of the role (e.g. `"Synced (skills
+    /// discovered here AND distributed here)"`). Display-only — GUI
+    /// consumers should branch on [`role`](Self::role) instead.
+    pub role_description: String,
     pub path: String,
     /// Number of skills discovered (for discovery dirs) or symlinks present (for target dirs),
     /// or an error message if counting failed.
@@ -103,7 +117,8 @@ pub fn gather(config: &Config, paths: &TomePaths) -> Result<StatusReport> {
             DirectoryStatus {
                 name: name.as_str().to_string(),
                 directory_type: dir_config.directory_type.to_string(),
-                role: role.description().to_string(),
+                role_description: role.description().to_string(),
+                role,
                 path: dir_config.path.display().to_string(),
                 skill_count: skill_count.into(),
                 warnings,
@@ -273,7 +288,7 @@ fn render_status(report: &StatusReport) {
             rows.push([
                 dir.name.clone(),
                 dir.directory_type.clone(),
-                dir.role.clone(),
+                dir.role_description.clone(),
                 format_dir_path_column(&dir.path, dir.override_applied),
                 count,
             ]);
@@ -519,7 +534,8 @@ mod tests {
         .unwrap();
         assert_eq!(report.directories.len(), 1);
         assert_eq!(report.directories[0].name, "claude");
-        assert!(report.directories[0].role.contains("Target"));
+        assert_eq!(report.directories[0].role, DirectoryRole::Target);
+        assert!(report.directories[0].role_description.contains("Target"));
     }
 
     #[test]
@@ -549,17 +565,22 @@ mod tests {
         )
         .unwrap();
         assert_eq!(report.directories.len(), 1);
+        assert_eq!(
+            report.directories[0].role,
+            DirectoryRole::Synced,
+            "typed role field must be Synced"
+        );
         assert!(
-            report.directories[0].role.contains("Synced"),
-            "role should contain Synced, got: {}",
-            report.directories[0].role
+            report.directories[0].role_description.contains("Synced"),
+            "role_description should contain Synced, got: {}",
+            report.directories[0].role_description
         );
         assert!(
             report.directories[0]
-                .role
+                .role_description
                 .contains("discovered here AND distributed here"),
-            "role should include description, got: {}",
-            report.directories[0].role
+            "role_description should include human-readable expansion, got: {}",
+            report.directories[0].role_description
         );
     }
 
@@ -864,7 +885,8 @@ mod tests {
         let ds = DirectoryStatus {
             name: "work".to_string(),
             directory_type: "directory".to_string(),
-            role: "Source".to_string(),
+            role: DirectoryRole::Source,
+            role_description: "Source (discovery only)".to_string(),
             path: "/some/path".to_string(),
             skill_count: CountOrError {
                 count: Some(0),

--- a/crates/tome/tests/cli_doctor.rs
+++ b/crates/tome/tests/cli_doctor.rs
@@ -87,6 +87,62 @@ fn doctor_with_no_input_skips_repair() {
 }
 
 #[test]
+fn doctor_dry_run_reports_issues_without_filesystem_mutation() {
+    // Pre-v1.0 review pass Important #14: pin the dry-run + no-input behavior
+    // of the doctor auto-fix path at the binary level.
+    //
+    // Setup:
+    //   - Plant a broken symlink in the library (auto-fixable issue
+    //     surfaces as RemoveBrokenLibrarySymlink repair).
+    //
+    // Assertions:
+    //   1. `tome doctor --dry-run` reports issues to stdout and exits
+    //      successfully.
+    //   2. The broken symlink is STILL present after the dry-run pass
+    //      (no filesystem mutation).
+    //   3. `tome doctor --no-input` (without --dry-run) exits successfully
+    //      and ALSO leaves the symlink in place (the global repair prompt
+    //      requires a TTY; --no-input suppresses it).
+    use std::os::unix::fs as unix_fs;
+
+    let tmp = TempDir::new().unwrap();
+    let library = tmp.path().join("library");
+    std::fs::create_dir_all(&library).unwrap();
+    let broken_link = library.join("broken-skill");
+    unix_fs::symlink("/nonexistent/path/that/does/not/exist", &broken_link).unwrap();
+
+    let config = write_config(tmp.path(), "");
+
+    // Step 1: --dry-run reports issues without mutation
+    tome()
+        .args(["--config", config.to_str().unwrap(), "--dry-run", "doctor"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("issue(s)"));
+
+    assert!(
+        broken_link.is_symlink(),
+        "dry-run must NOT remove the broken symlink \
+         (filesystem mutation in --dry-run is a contract violation)"
+    );
+
+    // Step 2: --no-input (no --dry-run) suppresses the repair prompt;
+    // the symlink survives because the auto-fix path requires interactive
+    // confirmation.
+    tome()
+        .args(["--config", config.to_str().unwrap(), "--no-input", "doctor"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("issue(s)"));
+
+    assert!(
+        broken_link.is_symlink(),
+        "--no-input must skip the interactive repair prompt; \
+         the broken symlink should still be present after the doctor run"
+    );
+}
+
+#[test]
 fn doctor_json_output() {
     let env = TestEnvBuilder::new()
         .source("local", "directory")


### PR DESCRIPTION
## Summary

Implements 15 of 16 findings from the pre-v1.0 codebase review (5 specialist agents, whole-codebase scope). Holds the 16th (Critical #3 — Owned/Unowned enum migration) for v1.0 Phase 10 where the IPC contract is being redesigned anyway. See companion issue for the Suggestions + the deferred Critical #3.

## Critical fixes (5 of 6)

- **#1 — `apply_edit_decisions` manifest reload race** (\`lib.rs\`). Refactored to take \`&mut Manifest\`; sync() owns the manifest end-to-end through reconcile. Eliminates the double-disk-touch pattern that risked silently losing Fork mutations under future consolidate refactors.
- **#2 — \`Lockfile\` missing \`Clone\` derive** (\`lockfile.rs\`). Derived; deleted the brittle manual \`clone_lockfile\` helper in \`reconcile.rs\`.
- **#4 — \`list_installed\` cache-miss silent return** (\`marketplace.rs\`). Added \`warn!\` for the unreachable-but-not-impossible \`populate_cache()? Ok but cache None\` case so reconcile-skipping-all-managed-updates is at least diagnosable.
- **#5 — \`apply_edit_decisions::Revert\` zero test coverage** (\`lib.rs\` tests). Added 3 new unit tests (\`revert_leaves_manifest_byte_for_byte_unchanged\`, \`skip_leaves_manifest_byte_for_byte_unchanged\`, \`dry_run_returns_false_without_mutating\`) pinning the stub semantic with byte-level + field-level assertions.
- **#6 — Migration render errors silently dropped** (\`lib.rs\`). \`let _ = render_plan_to(...)\` → \`if let Err(e) = ... { warn!(...) }\` so a broken stderr during the migration confirmation prompt is diagnosable.

## Important fixes (10 of 10)

- **#7 — \`apply_drift_and_missing\` stdout writes** (\`reconcile.rs\`). \`println!\` → \`eprintln!\` matches the rest of the sync pipeline's stderr discipline. Full structured-event surfacing deferred to Phase 10 (noted in code comment).
- **#8 — Stale \`#[allow(dead_code)]\` suppressions** (\`marketplace.rs\`). Stripped 13 of 15; only \`classify_claude_install_stderr\` and \`build_install_failure\` remain (with updated comments referencing #518 follow-up rather than the now-shipped Phase 13).
- **#9 — Non-interactive Case 2 cleanup deletes silently** (\`cleanup.rs\`). \`warn!\` listing every skill name + count before non-interactive deletion. Visible in CI logs / \`--verbose\`.
- **#10 — \`DirectoryStatus.role\` typed** (\`status.rs\`). Now \`DirectoryRole\` enum (serializes snake_case); description moved to new \`role_description: String\` field. **BREAKING JSON shape change** acknowledged per project's \`Backward compat: None\` policy.
- **#11 — \`CleanupResult\` public accessors** (\`cleanup.rs\`). Added 4 \`pub fn\` accessors (\`removed_from_library\`, \`transitioned_to_unowned\`, \`bucket_a_removed_from_config\`, \`bucket_b_missing_from_disk\`) matching the \`Lockfile::skills()\` pattern. Lets v1.0 GUI read bucket counts without mutating internal state.
- **#12 — Cleanup render errors silently dropped** (\`lib.rs\`). Same fix as Critical #6, applied to \`render_cleanup_buckets\` + \`render_distribution_cleanup_failures\`.
- **#13 — Doctor JSON empty-string fallback** (\`doctor.rs\`). \`.ok().unwrap_or_default()\` on IssueCategory serialization → \`.expect(...)\`. A future \`Serialize\` break is a programming error, not a recoverable runtime condition.
- **#14 — Doctor auto-fix integration test** (\`cli_doctor.rs\`). New \`doctor_dry_run_reports_issues_without_filesystem_mutation\` test plants a broken symlink and asserts \`--dry-run\` + \`--no-input\` both report issues AND leave the filesystem untouched.
- **#15 — Comment drift across 5+ files**. Fixed pre-v0.10 "managed = symlink" wording in \`discover.rs\`, \`distribute.rs\`, \`status.rs\` (×2), \`relocate.rs\`, and the crate-root \`lib.rs\` pipeline doc.
- **#16 — Missing doc comments on v1.0-IPC types**. Added thorough docs to \`SyncReport\` (lib.rs), \`ReconcileReport\` (reconcile.rs), and \`MarketplaceAdapter\` trait (marketplace.rs, with \`# Example\` showing npm adapter shape).

## Held for v1.0 Phase 10 (companion issue)

**Critical #3 — Owned/Unowned encoded via \`Option<DirectoryName>\`** (manifest.rs / lockfile.rs). The review's specialist agent specifically recommended absorbing this into Phase 10 since the IPC contract is being redesigned. Scope confirmed: 266 references across 21 files. Custom serde adapter required to preserve flat JSON wire shape. Right work, wrong time for a "before v1.0" cleanup PR.

Tracked in companion issue alongside the 6 Suggestions from the review.

## Test plan

- [x] \`make ci\` green locally (fmt-check + clippy \`-D warnings\` + tests + typos)
- [x] All previously-passing tests still pass
- [x] 4 new \`apply_edit_decisions\` tests (Fork + Revert + Skip + dry_run)
- [x] 1 new doctor integration test
- [x] Status tests updated for the typed \`role\` field
- [ ] CI passes on ubuntu-latest + macos-latest

## Trace

Pre-v1.0 codebase review pass (this session), 5 specialist agents:
\`pr-review-toolkit:code-reviewer\`, \`type-design-analyzer\`,
\`silent-failure-hunter\`, \`pr-test-analyzer\`, \`comment-analyzer\`.