### PR TITLE
feat(config): allow Directory + Managed combo (Phase 22 / v0.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Generic managed source directory** (Phase 22 / v0.15). The
+  `Managed` role is no longer restricted to `claude-plugins` type
+  directories — `[directories.<name>] type = "directory" role =
+  "managed"` is now valid, opening up flat-directory package managers
+  (pfw and successors) as first-class managed sources instead of the
+  v0.14 `--role source` workaround. Discovery + consolidate already
+  routed `role() == Managed` end-to-end, so library entries from a
+  Directory + Managed source now correctly carry `managed: true` in
+  the manifest. Use case: `tome add ~/.pfw/skills --role managed`.
+
+### Changed
+
+- **`validate.rs` reject rule for `Directory + Managed` removed.** The
+  catch-all `valid_roles()` check still rejects `Git + Managed`
+  (Managed not in Git's valid_roles set) with the generic role/type-
+  conflict message.
+- **`DirectoryType::Directory::valid_roles()` includes `Managed`.**
+  The wizard's role-picker now offers `Managed` as a fourth option
+  for `directory`-type entries.
+
+### Docs
+
+- **`docs/src/commands.md` "source vs managed" comparison table.**
+  Spells out the subtle-but-material differences for flat-directory
+  package managers: both keep the source dir clean, but `managed`
+  carries the package-manager-owned semantic forward (manifest
+  `managed: true`, future MarketplaceAdapter integration eligibility,
+  future foreign-symlink legitimate-origin recognition).
+
+### Out of scope (deferred)
+
+Two follow-ups intentionally not in v0.15:
+
+- `is_foreign_symlink` refinement to recognize managed-source paths
+  as legitimate-origin. Today, configuring pfw as `--role managed`
+  still leaves the 18 `pfw-*` symlinks in `~/.claude/skills/`
+  flagged as foreign by `tome doctor` (because they point to
+  `~/.pfw/skills/` which is outside `library_dir`). Closing this
+  requires teaching `is_foreign_symlink` about configured
+  managed-source paths.
+- Detect-and-warn for "upstream package manager's own distribution
+  is fighting tome's" (the open question from the original 999.4
+  backlog entry — pfw shouldn't be configured to distribute its own
+  symlinks if tome is taking over).
+
 ## [0.14.0] - 2026-05-20
 
 ### Added

--- a/crates/tome/src/config/overrides.rs
+++ b/crates/tome/src/config/overrides.rs
@@ -409,9 +409,16 @@ mod tests {
 
     #[test]
     fn load_with_overrides_validate_failure_propagates() {
-        // Build a config with an invalid role/type combo (Managed on a
-        // Directory type — only ClaudePlugins permits Managed).
+        // Build a config with an invalid role/type combo (Target on a Git
+        // type — git directories can only be Source per valid_roles()).
         // load_with_overrides must run validate() and surface the error.
+        //
+        // Phase 22 / v0.15 note: this test previously used
+        // `Directory + Managed` as the invalid combo, but that pairing is
+        // now valid (generalized for pfw-style flat-directory package
+        // managers). Switched to `Git + Target` which remains
+        // structurally invalid (git is a remote-clone source — tome
+        // cannot write distribution symlinks into a working tree).
         let tmp = tempfile::TempDir::new().unwrap();
         let cfg_path = tmp.path().join("tome.toml");
         let lib_dir = tmp.path().join("library");
@@ -421,9 +428,9 @@ mod tests {
                 "library_dir = \"{}\"\n\
                  \n\
                  [directories.x]\n\
-                 path = \"/some/path\"\n\
-                 type = \"directory\"\n\
-                 role = \"managed\"\n",
+                 path = \"https://github.com/owner/repo\"\n\
+                 type = \"git\"\n\
+                 role = \"target\"\n",
                 lib_dir.display(),
             ),
         )

--- a/crates/tome/src/config/types.rs
+++ b/crates/tome/src/config/types.rs
@@ -126,7 +126,15 @@ impl DirectoryType {
         match self {
             DirectoryType::ClaudePlugins => vec![DirectoryRole::Managed],
             DirectoryType::Directory => {
+                // Phase 22 / v0.15: Managed is now valid for `directory`
+                // type, opening up flat-directory package managers
+                // (pfw, etc.) as first-class. Discovery + consolidate
+                // already key on `role() == Managed` end-to-end (the
+                // `is_managed: bool` flag flows through to manifest
+                // entries), so allowing the combo here lets the rest
+                // of the pipeline do the right thing.
                 vec![
+                    DirectoryRole::Managed,
                     DirectoryRole::Synced,
                     DirectoryRole::Source,
                     DirectoryRole::Target,
@@ -502,6 +510,10 @@ mod tests {
         assert_eq!(
             DirectoryType::Directory.valid_roles(),
             vec![
+                // Phase 22 / v0.15 added Managed (pfw and other flat-
+                // directory package managers — generalized from
+                // ClaudePlugins-only).
+                DirectoryRole::Managed,
                 DirectoryRole::Synced,
                 DirectoryRole::Source,
                 DirectoryRole::Target,

--- a/crates/tome/src/config/validate.rs
+++ b/crates/tome/src/config/validate.rs
@@ -33,20 +33,12 @@ impl Config {
         for (name, dir) in &self.directories {
             let role = dir.role();
 
-            // Managed role only valid with ClaudePlugins type
-            if role == DirectoryRole::Managed && dir.directory_type != DirectoryType::ClaudePlugins
-            {
-                anyhow::bail!(
-                    "directory '{name}': role/type conflict\n\
-                     Conflict: role is {} but type is '{}'\n\
-                     Why: the Managed role means skills are owned by a package manager; only the claude-plugins type is known to behave this way, so any other type with Managed would be sync'd incorrectly.\n\
-                     hint: either change type to 'claude-plugins', or change role to {} or {}.",
-                    DirectoryRole::Managed.description(),
-                    dir.directory_type,
-                    DirectoryRole::Synced.description(),
-                    DirectoryRole::Source.description(),
-                );
-            }
+            // Phase 22 / v0.15: the explicit Managed-with-non-ClaudePlugins
+            // reject rule is gone. `Directory + Managed` is now valid (pfw
+            // and other flat-directory package managers). The catch-all
+            // `valid_roles()` check below still catches `Git + Managed`
+            // (Managed is not in Git's valid_roles set) with a generic
+            // role/type-conflict message.
 
             // Target role invalid with Git type
             if role == DirectoryRole::Target && dir.directory_type == DirectoryType::Git {
@@ -198,10 +190,15 @@ mod tests {
     // --- Config validation tests ---
 
     #[test]
-    fn validate_rejects_managed_with_directory_type() {
+    fn validate_accepts_managed_with_directory_type() {
+        // Phase 22 / v0.15: Directory + Managed is now valid. This test
+        // replaces the prior `validate_rejects_managed_with_directory_type`
+        // which pinned the old reject behavior. Generalizing the Managed
+        // role to flat-directory package managers (pfw, etc.) is the whole
+        // point of Phase 22.
         let config = Config {
             directories: BTreeMap::from([(
-                DirectoryName::new("bad").unwrap(),
+                DirectoryName::new("pfw").unwrap(),
                 DirectoryConfig {
                     path: PathBuf::from("/tmp"),
                     directory_type: DirectoryType::Directory,
@@ -213,14 +210,37 @@ mod tests {
             )]),
             ..Default::default()
         };
+        config
+            .validate()
+            .expect("Directory + Managed must validate (Phase 22)");
+    }
+
+    #[test]
+    fn validate_still_rejects_managed_with_git_type() {
+        // Phase 22 / v0.15 doesn't open Managed to Git type — Git is a
+        // remote-clone source, not a package-manager-managed dir. The
+        // catch-all valid_roles() check should bail with the generic
+        // role/type-conflict message.
+        let config = Config {
+            directories: BTreeMap::from([(
+                DirectoryName::new("bad-git").unwrap(),
+                DirectoryConfig {
+                    path: PathBuf::from("https://github.com/owner/repo"),
+                    directory_type: DirectoryType::Git,
+                    role: Some(DirectoryRole::Managed),
+                    git_ref: None,
+                    subdir: None,
+                    override_applied: false,
+                },
+            )]),
+            ..Default::default()
+        };
         let err = config.validate().unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("Managed (read-only, owned by package manager)"),
-            "missing role description: {msg}"
+            msg.contains("Managed") && msg.contains("git"),
+            "error should name both the role and the rejected type: {msg}"
         );
-        assert!(msg.contains("directory"), "missing type name: {msg}");
-        assert!(msg.contains("hint:"), "missing hint line: {msg}");
     }
 
     #[test]

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -96,15 +96,35 @@ The `role` field decides what tome does with a configured directory:
 - `directory` → `synced`
 - `git` → `source`
 
-The `directory → synced` default is the one that surprises people. If you `tome add` a local directory owned by a package manager (e.g. `~/.pfw/skills/`), the `synced` default writes ~170 distribution symlinks INTO that source directory — polluting it with content tome propagated from other configured directories. **Use `--role source` for read-only package manager directories** to keep them clean.
+The `directory → synced` default is the one that surprises people. If you `tome add` a local directory owned by a package manager (e.g. `~/.pfw/skills/`), the `synced` default writes ~170 distribution symlinks INTO that source directory — polluting it with content tome propagated from other configured directories. **Use `--role source` or `--role managed` for read-only package manager directories** to keep them clean.
 
 ```bash
 # WRONG (default role = synced; tome writes BACK into ~/.pfw/skills/)
 tome add ~/.pfw/skills
 
-# RIGHT (explicit source; tome only reads from ~/.pfw/skills/)
+# OK — discovery only, no write-back, but library entries get
+# `managed: false` (treated as a generic local source).
 tome add ~/.pfw/skills --role source
+
+# BEST (v0.15+) — Managed semantic: library entries get `managed: true`,
+# so reconcile + foreign-symlink protection recognize this as an
+# external-package-manager-owned source.
+tome add ~/.pfw/skills --role managed
 ```
+
+#### `source` vs `managed` for flat-directory package managers (v0.15+)
+
+Both refuse to write back into the source dir, so either keeps `~/.pfw/skills/` clean. The differences are subtle but material if you care about upstream-update semantics down the line:
+
+| Aspect | `source` | `managed` |
+|---|---|---|
+| tome writes to the source dir | Never | Never |
+| Manifest `managed: bool` flag | `false` (local skill) | `true` (package-manager-owned) |
+| Future reconcile / `MarketplaceAdapter` integration | Not eligible | Eligible (when adapters are added per upstream) |
+| Foreign-symlink protection treats source path as legitimate-origin | Not yet | Not yet (separate follow-up) |
+| Semantic accuracy for pfw / npm / etc. | "It's just a local source" | "It's owned by a specific package manager" |
+
+For today's needs (just propagating pfw skills to your other tools), both work equivalently. For longer-term integration with pfw's own update lifecycle, prefer `managed`.
 
 The success message now echoes the resolved role so you see what you got:
 


### PR DESCRIPTION
Closes Phase 22 of v0.15 (promoted from backlog 999.4 on 2026-05-20). Closes [#542](https://github.com/MartinP7r/tome/issues/542)-adjacent architectural debt: generalizes the \`Managed\` role beyond \`claude-plugins\` so any flat-directory package manager (pfw, etc.) can be a first-class managed source.

## Summary

\`[directories.<name>] type = "directory" role = "managed"\` is now valid. Before this PR, \`validate.rs:36-44\` rejected the combo outright with a Why-line that cited "only claude-plugins is *known* to behave this way." pfw was the second known case (dogfooded during v0.12-v0.14 sessions). This PR opens up the model.

## Architecture

The change is small because discovery + consolidate already cooperate:

- \`discover::discover_all\` derives \`is_managed: bool\` from \`dir_config.role() == DirectoryRole::Managed\` regardless of \`directory_type\`.
- \`library::record_in_manifest\` writes \`managed: true\` to the \`SkillEntry\` based on \`SkillOrigin::Managed\`.
- Distribute treats library entries the same way regardless of the managed flag.

So three surface edits:

1. \`DirectoryType::Directory::valid_roles()\` adds \`Managed\` as the 4th valid role.
2. \`validate.rs\` reject rule for \`Directory + Managed\` removed (catch-all \`valid_roles()\` check still rejects \`Git + Managed\` with the generic message).
3. Tests updated to pin the new contract.

## Out of scope (deferred follow-ups)

Two intentionally deferred — called out in CHANGELOG [Unreleased] "Out of scope" section + ROADMAP v0.15 milestone note:

1. **\`is_foreign_symlink\` refinement** to recognize managed-source paths as legitimate-origin. The 18 \`pfw-*\` symlinks in \`~/.claude/skills/\` will still flag as foreign until this lands.
2. **Detect-and-warn for "upstream's own distribution is fighting tome's"** (the open question from the original 999.4 backlog entry — pfw shouldn't be configured to distribute its own symlinks if tome is taking over).

## Tests

- \`validate_accepts_managed_with_directory_type\` replaces the prior \`_rejects_\` test (pins the new behavior)
- \`validate_still_rejects_managed_with_git_type\` added (pins the residual reject)
- \`directory_type_valid_roles\` updated to expect 4 roles for Directory
- \`load_with_overrides_validate_failure_propagates\` switched to \`Git + Target\` (was using the now-valid \`Directory + Managed\` as the invalid combo)

855 tests pass. \`make ci\` green.

## Docs

- \`docs/src/commands.md\`: extended the role-defaults section with a "source vs managed" comparison table for flat-directory package managers.
- \`CHANGELOG.md [Unreleased]\`: Added + Changed + Docs + Out-of-scope sections.

## Test plan

- [x] \`make ci\` green locally (fmt + clippy \`-D warnings\` + tests + typos)
- [ ] CI passes on ubuntu-latest + macos-latest

## After this lands

v0.15.0 release cut — single-phase milestone (the two deferred follow-ups can be a v0.15.1 or v0.16.x).