### PR TITLE
docs: ratify v1.0 milestone (Tauri Desktop GUI)

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -124,45 +124,51 @@ The wizard-surface work below shipped in v0.6 (as WIZ-01–05) but lacked valida
 
 ## Current State
 
-**Shipped:** v0.10.0 (2026-05-11)
+**Shipped:** v0.16.0 (2026-05-20)
 
-v0.10 milestone complete — Library-canonical Model + Cross-Machine Plugin Reconciliation. **49 requirements shipped** across 7 phases (LIB-01..05 + ADP-01..04 + RECON-01..05 + UNOWN-01..03 + HARD-01..22 + UX-01..02 + DOC-01..03 + REL-01..05). Archive: [`milestones/v0.10-ROADMAP.md`](milestones/v0.10-ROADMAP.md).
+After v0.10 (library-canonical model) shipped 2026-05-11, the project entered a 9-day polish sprint that produced six minor releases:
 
-**Headline transformation:**
-- The library moved from "two-tier symlink cache" (managed = symlink into machine-specific cache) to **library-canonical real-directory copies** for both managed and local skills. Plugin uninstall, version churn, and cross-machine sync now all preserve library content.
-- `tome sync` is now **lockfile-authoritative** — reconciles installed plugins against `tome.lock` via marketplace adapters (Cargo.lock-shaped). Match/Drift/Vanished classification + interactive consent + edit-in-library detection.
-- `MarketplaceAdapter` trait + `ClaudeMarketplaceAdapter` (subprocess to `claude plugin install/update/list --json`) + `GitAdapter` (thin shim over `git.rs`).
-- **Unowned-library lifecycle** is first-class — source removal preserves library content; `tome reassign --to <dir>` re-anchors Unowned skills; `tome remove skill <name>` deletes them. The originally-proposed `tome adopt`/`forget` verbs were merged into existing commands per Phase 14 D-API-1/-2.
-- One-shot `tome migrate-library` converts v0.9-shape libraries to v0.10 shape with confirmation, summary table, and `--yes` bypass. Idempotent on re-run.
-- Three-bucket cleanup output (UX-01) — `removed-from-config` / `missing-from-disk` / `now-in-exclude-list` — with per-skill actionable hints. The "no longer configured" trigger phrase that motivated this milestone is gone.
-- Major hardening pass: 22 review-followup + older-bug fixes (HARD-01..22), test count 662 → 987 (+325, +49%), `lib.rs::run` decomposed into 16 `cmd_<name>` helpers, `config.rs` split into a 4-file module, `tests/cli.rs` (6,703 LOC) split into 16 per-domain files.
-- Documentation: `architecture.md` rewritten 60→254 lines; new `cross-machine-sync.md` (259 lines); CHANGELOG `[Unreleased]` rewritten 22→209 lines with full migration walkthrough.
+- **v0.11** (2026-05-14) — Polish + Observability. Adopted `tracing` (OBS-01..05) with `--verbose`/`--quiet` flag wiring; sync diagnostics + change-cause attribution; doctor categorization (`IssueCategory` Library / Directory / Config / Foreign-symlink); typed `RepairKind` enum dispatch; OBS-07 last-sync stamping; FIX-01..06 bundle (doctor auto-fix UX, browse timing flake bound, managed-symlinks-in-git false-positive deletion, wizard polish, Makefile CHANGELOG date stamp).
+- **v0.12.x** (2026-05-17) — Pre-v1.0 review polish. Whole-codebase audit fix bundle from 5 specialist review agents; 15/16 findings shipped (the 16th — Owned/Unowned enum migration — tracked in [#542](https://github.com/MartinP7r/tome/issues/542) for v1.0 Phase 25 absorption). Includes the `DirectoryRole` JSON shape change in `tome status --json`. v0.12.1 = trivial version-bump-only patch.
+- **v0.13** (2026-05-19) — `tome add` UX. `/tree/<ref>/<subdir>` URL form, `--subdir` flag, auto-detect Claude plugin layouts with hint-on-zero (PR #547). Open follow-up [#548](https://github.com/MartinP7r/tome/issues/548) tracks the role-transition cleanup gap from dogfooding.
+- **v0.14** (2026-05-20) — Type+role UX + claim-orphan. `--role` override flag for `tome add`; `tome doctor` `claim` orphan-to-Unowned option closing the dead-end where library-canonical orphans had no recovery path.
+- **v0.15** (2026-05-20) — Generic managed source directory. `[directories.<name>] type = "directory" role = "managed"` first-class for flat-directory package managers (pfw, etc.); valid_roles surface relaxed; v0.14 `--role source` workaround retired.
+- **v0.16** (2026-05-20) — Doctor diagnostics expansion. Broken-frontmatter Warning (Phase 23, no auto-fix) and `ConsolidateTargetRealDirToSymlink` auto-repair (Phase 24, target real-dir → symlink when byte-identical to library).
 
-**Released as:** v0.10.0 via cargo-dist (tag `578f787`, GitHub Release with 11 macOS + Linux artifacts, Homebrew formula updated). Real-library migration smoke-test (REL-04) executed on Martin's `~/dev/coding-agent-files` with 57/57 SHA-256 hashes byte-identical pre/post; one mid-stream bug found and fixed (PR #528 — reconcile hard-fail on stale manifest entries).
+**Released:** v0.11.0 → v0.16.0 via cargo-dist, with Homebrew formula updated on every release.
 
-**Carry-over:** 2 Linux-runtime UAT items in `08-HUMAN-UAT.md` (clipboard / xdg-open) **formally deferred to v1.0** (Tauri Desktop GUI) — fifth consecutive milestone, written rationale in the UAT frontmatter. Will be naturally exercised when v1.0's GUI build target requires Linux hardware.
+**Carry-over:** 2 Linux-runtime UAT items in `08-HUMAN-UAT.md` (clipboard / xdg-open) **formally deferred to v1.0** (Tauri Desktop GUI) — sixth consecutive milestone, written rationale in the UAT frontmatter. Will be naturally exercised when v1.0's GUI build target requires Linux hardware.
 
-## Current Milestone: v0.11 Polish + Observability
+**Open follow-ups:** [#542](https://github.com/MartinP7r/tome/issues/542) Owned/Unowned enum migration (v1.0 Phase 25 absorption); [#548](https://github.com/MartinP7r/tome/issues/548) role-transition cleanup gap; two Phase 22 deferrals (`is_foreign_symlink` managed-source recognition + detect-and-warn for upstream-own-distribution conflict).
 
-**Goal:** Ship the v0.10-surfaced bugs and adopt structured logging across the codebase so `tome sync`/`doctor`/`status` give clearer signal — laying groundwork for the v1.0 GUI's IPC + log-capture needs.
+## Current Milestone: v1.0 tome Desktop (Tauri GUI)
+
+**Ratified:** 2026-05-23 via `/gsd-new-milestone` after v0.16 shipped. Drafted 2026-04-28 in [`milestones/v1.0-REQUIREMENTS.md`](milestones/v1.0-REQUIREMENTS.md).
+
+**Goal:** Make the skill library *visible* — directories, skills, sync state, and conflicts observed and managed from a desktop app rather than a terminal. Tauri 2 GUI over the existing CLI library; CLI ships unchanged.
 
 **Target features:**
 
-- **Structured logging foundation** — adopt `tracing` (default; `log` reconsidered if cost shows up), map existing `eprintln!`/`println!` to log levels, wire `--verbose`/`--quiet` to subscriber filter. Single-pass instrumentation, no output rewrite.
-- **Sync diagnostics surface** — per-step timing in `--verbose`, change-cause attribution ("why did this skill re-copy?"), reconcile classification breakdown in summary.
-- **Doctor / status richer surface** — better counts, categories, actionable hints in both text and JSON.
-- **Bugfix bundle** — #530 doctor auto-fixable UX, #511 timing flake (folds in HARD-14 `backup::push_and_pull_roundtrip` carry-over), managed-symlinks-in-git false positive, wizard polish (#453, #454, #456), `make release` CHANGELOG date stamp.
+- **Rust core extraction** — reshape `crates/tome` so domain operations return structured types callable from any front-end; `lib.rs::run` becomes a CLI presenter over those calls. New `crates/tome-desktop` workspace member hosts the Tauri app.
+- **Type bridge** — `specta` + `tauri-specta` generate `bindings.ts` at build time; no hand-rolled JS-side types.
+- **Read-only views** — status dashboard, virtualised skill list (2000 skills @ 60fps on M1), detail pane + markdown preview, doctor health pane with one-click fixes, file watcher for auto-refresh.
+- **Sync + triage UI** — visual sync with per-stage progress, lockfile diff with per-skill triage decisions, previewable `machine.toml` diff, cancellation, retry.
+- **Configuration UI** — first-run wizard, directory editor with live validation, `tome add` form, machine prefs editor. All writes through `Config::save_checked`.
+- **Mutating operations UI** — remove / reassign / fork / relocate / eject with plan-preview-confirm flows. Partial-failure aggregation (SAFE-01 semantics).
+- **Backup UI** — history view, snapshot, diff, restore with automatic post-restore sync.
+- **Distribution** — code sign + notarize + DMG (aarch64 + x86_64), `tauri-plugin-updater` auto-update, first-launch UX, embedded CLI for "Show in terminal" affordances.
 
 **Key context:**
 
-- **Scope discipline:** observability is "instrument existing output" — not "redesign output." New JSON-by-default streams, OpenTelemetry, etc. stay out of scope.
-- **`tracing` is the default** structured-logging crate (spans, structured fields, async-aware; aligns with what v1.0 Tauri IPC will need). `log` is the cheaper fallback if adoption cost shows up during planning.
-- **Linux UAT carry-overs** (clipboard + xdg-open from v0.8 `08-HUMAN-UAT.md`) — fifth milestone without Linux hardware. Formally deferred to **v1.0** where the Tauri build forces Linux access.
-- **Backward compat:** None (per project policy). Log-level flag changes will be release-noted but not gated on a migration shim.
-- **TS migration parked.** `docs/migration/rust-to-typescript-feature-inventory.md` stays an untracked exploration artifact; v1.0 (Tauri GUI) remains the milestone after v0.11.
-- **Sized at ~2 phases, ~12–15 requirements, 2–4 weeks of focused work.** Phase numbering continues from 17 → starts at Phase 18.
+- **Tauri 2 over Electron + napi-rs** (D-GUI-01) — existing Rust core, ~8 MB vs ~150 MB bundle, no N-API ABI layer, built-in code-signed auto-update, reuses Developer ID flow we already need for the CLI.
+- **macOS-only for v1.0** (D-GUI-06) — Linux deferred to v2 (still missing v0.8 UAT hardware); Windows out of scope.
+- **No CLI regression** — `crates/tome` ships unchanged via cargo-dist. The GUI is additive — both share the same library, manifest, lockfile (D-GUI-07).
+- **No JS-side business logic** — frontend renders Tauri-command results and dispatches commands. Validation, planning, side effects all in Rust.
+- **Frontend framework TBD** in the Phase 25 spike (D-GUI-04) — shortlist React / Solid / Svelte.
+- **Sized at ~7 phases, 15–22 weeks single-dev** (calendar 4–6 months with overhead). Phase numbering continues from v0.16 (last phase: 24) → v1.0 starts at **Phase 25**.
+- **Cuts** along the way: alpha (Phases 25–26), beta (27–28), rc (29–30), v1.0 (31).
 
-Run `/gsd:plan-phase 18` after roadmap approval to start execution. **v1.0 (Tauri Desktop GUI)** remains the milestone after v0.11 — drafted in [`milestones/v1.0-{REQUIREMENTS,ROADMAP}.md`](milestones/v1.0-REQUIREMENTS.md).
+Run `/gsd:plan-phase 25` after this milestone ratification to start execution.
 
 <details>
 <summary>v0.10 milestone details (archive recap)</summary>
@@ -210,6 +216,13 @@ Run `/gsd:plan-phase 18` after roadmap approval to start execution. **v1.0 (Taur
 - v0.7 Wizard Hardening (Phases 4-6, shipped 2026-04-22) — `Config::validate()` Conflict+Why+Suggestion errors, `Config::save_checked` round-trip, `--no-input` plumbing, 12-combo matrix test, `tabled` summary
 - v0.8 Wizard UX & Safety Hardening (Phases 7-8 + 8.1 hotfix, shipped 2026-04-27) — wizard greenfield/brownfield/legacy flows, partial-failure visibility, cross-platform browse, lockfile regen safety
 - v0.9 Cross-Machine Config Portability & Polish (Phases 9-10, shipped 2026-04-29) — `[directory_overrides.<name>]` schema, override surfacing, Phase 8 review tail (StatusMessage redesign, FailureKind compile-enforcement, RemoveFailure invariant, arboard patch-pin)
+- v0.10 Library-canonical Model + Cross-Machine Plugin Reconciliation (Phases 11-17, shipped 2026-05-11) — 49 requirements; managed-as-real-dir, MarketplaceAdapter trait, Unowned lifecycle, three-bucket cleanup, `tome migrate-library`, 22-item CLI hardening bundle
+- v0.11 Polish + Observability (Phases 18-19, shipped 2026-05-14, v0.11.1 patch 2026-05-15) — `tracing` substrate, sync diagnostics, doctor categorization, OBS-07 last-sync stamping, FIX-01..06 bundle
+- v0.12 Pre-v1.0 Review Polish (shipped 2026-05-17 + v0.12.1 same day) — whole-codebase audit fix bundle from 5 review agents; 15/16 findings shipped (#542 deferred to v1.0 Phase 25)
+- v0.13 `tome add` UX (shipped 2026-05-19; PR #547) — `/tree/<ref>/<subdir>` URL form, `--subdir`, auto-detect Claude plugin layouts
+- v0.14 Type+role UX + claim-orphan (Phases 20-21, shipped 2026-05-20; PR #550 + #551) — `--role` override, doctor `claim` orphan-to-Unowned
+- v0.15 Generic managed source directory (Phase 22, shipped 2026-05-20; PR #553) — `Directory + Managed` role combo for flat-directory package managers
+- v0.16 Doctor diagnostics expansion (Phases 23-24, shipped 2026-05-20; PR #555) — broken-frontmatter Warning + real-dir → symlink auto-repair
 
 </details>
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,77 +1,191 @@
-# Requirements: tome v0.11 — Polish + Observability
+# Requirements: tome v1.0 — tome Desktop (Tauri GUI)
 
-**Defined:** 2026-05-12
-**Source:** Milestone discussion (no formal research; polish-heavy milestone against existing codebase)
-**Predecessor:** [`milestones/v0.10-REQUIREMENTS.md`](milestones/v0.10-REQUIREMENTS.md) (SHIPPED 2026-05-11)
+**Defined:** 2026-04-28 (drafted as `milestones/v1.0-REQUIREMENTS.md`)
+**Ratified:** 2026-05-23 (promoted to active `REQUIREMENTS.md` via `/gsd-new-milestone` after v0.16 shipped)
+**Status:** Active milestone — Phases 25–31
+**Scope anchor:** Epic to be filed (`tome Desktop — Tauri 2 GUI`)
+**Core Value:** Every AI coding tool on a developer's machine shares the same skill library without manual copying or per-tool configuration. v1.0 makes that library *visible* — directories, skills, sync state, and conflicts are observed and managed from a desktop app rather than a terminal.
 
-## v0.11 Requirements
+## Milestone context
 
-Requirements for the v0.11 release. Grouped by category; each will map to one or more roadmap phases. Phase numbering continues from v0.10 → starts at Phase 18.
+v0.6–v0.16 hardened the CLI in 11 minor releases: unified directory model (v0.6), wizard UX hardening (v0.7), cross-platform safety (v0.8), cross-machine config portability (v0.9), library-canonical model + marketplace adapter (v0.10), observability foundation (v0.11), pre-v1.0 review polish (v0.12), `tome add` UX (v0.13), type+role UX + claim-orphan (v0.14), generic managed source directory (v0.15), doctor diagnostics expansion (v0.16). v1.0 is the inflection point where tome stops being CLI-only.
 
-### Observability (OBS)
+**Why now:**
 
-Adopt structured logging across the codebase so `tome sync`/`doctor`/`status` give clearer signal. Lays groundwork for v1.0 GUI's IPC + log-capture needs. Scope discipline: "instrument existing output" — not "redesign output."
+- Mental model is mature. Directories/library/distribution/lockfile have been stable since v0.6 — the GUI can model them rather than chase them.
+- The CLI surface is already structured around plan/render/execute (remove, reassign, fork). Adding a GUI render layer is incremental.
+- Sync triage and the wizard are the two remaining "TUI-shaped" surfaces. Both are better as proper GUI flows.
 
-- [x] **OBS-01**: Adopt `tracing` + `tracing-subscriber` crates. Replace internal `eprintln!`/`println!` chatter with `tracing::{info,warn,debug}!` calls. Wizard prompts, TUI browse output, and user-facing summary tables (status/list/doctor) stay as direct stdout — instrument only the *log-like* output (sync progress, cleanup actions, diagnostic warnings).
-- [x] **OBS-02**: Wire `--verbose`/`--quiet` global flags + `TOME_LOG` env var to `tracing_subscriber::EnvFilter`. Default level `info`; `--verbose` → `debug`; `--quiet` → `warn`. Existing `LogLevel` enum (HARD-07) wraps the subscriber configuration; behavior preserved for users who only use the flags.
-- [x] **OBS-03**: `tome sync` emits per-pipeline-step spans (discover, reconcile, consolidate, distribute, cleanup) with elapsed-ms attached. Visible in `--verbose` text output and reachable via `TOME_LOG=tome::sync=debug`.
-- [x] **OBS-04**: Change-cause attribution — when consolidate or distribute re-emits a skill, the reason ("hash changed", "previously failed", "newly added", "directory now allowed") is logged at `info!` for user visibility.
-- [x] **OBS-05**: Reconcile classification breakdown surfaced in `tome sync` summary — show counts of Match / Drift / Vanished / MissingFromMachine in the final summary block (not only the consolidated outcome).
-- [x] **OBS-06**: `tome doctor` richer surface — categorize issues (Library / Directory / Config / Foreign-symlink) with per-category counts in text output; JSON shape gains `category` field per issue. Implementation overlaps with FIX-01 (#530); single change closes both.
-- [x] **OBS-07**: `tome status` richer surface — surface per-directory skill counts, override status (already present in v0.9), and a "last sync" timestamp; JSON shape parity with text output.
+**Why Tauri 2 (not Electron):**
 
-### Bugfixes (FIX)
+The Rust core already exists. Electron + napi-rs would impose an N-API shim, ABI rebuilds, native-module signing, and ~150 MB Node runtime — all in service of letting JS call Rust. Tauri 2 calls Rust directly via `#[tauri::command]`, ships the OS webview (~3–10 MB bundle), has built-in code-signed auto-update, and reuses the same Developer ID + notarization flow we already need for the CLI. Decision recorded as **D-GUI-01** below.
 
-The v0.10-surfaced bug bundle and the older wizard-polish backlog. Each requirement closes one or more existing GitHub issues; full mapping in Traceability.
+## v1 Requirements
 
-- [x] **FIX-01**: `tome doctor` "auto-fixable" count and prompt exclude items with no auto-repair available — the current "N auto-fixable issues" then "(no auto-repair available)" UX is a contradiction. Closes [#530](https://github.com/MartinP7r/tome/issues/530).
-- [x] **FIX-02**: `browse::app::tests::copy_path_retry_helper_returns_within_bound` timing flake fixed — diagnose root cause (timing-based assertion under parallel contention) and replace with deterministic clock injection or relaxed bound with explicit comment. Closes [#511](https://github.com/MartinP7r/tome/issues/511).
-- [x] **FIX-03**: `tome doctor` "N managed symlink(s) tracked in git" check removed or rewritten — v0.10 made managed skills real directory copies, so the check is stale (false-positive count post-migration). Closes [#532](https://github.com/MartinP7r/tome/issues/532).
-- [x] **FIX-04**: Wizard summary table column misalignment — ANSI bold escapes are miscounted as visible width by `tabled` in interactive TTY mode. Use ANSI-aware width measurement (or strip ANSI before measuring). Closes [#454](https://github.com/MartinP7r/tome/issues/454).
-- [x] **FIX-05**: Wizard `configure_library` and library-default derivation follow the resolved `tome_home` instead of hardcoding `~/.tome/skills` — when a user customizes `tome_home`, the library default should follow. Single fix closes both linked issues. Closes [#453](https://github.com/MartinP7r/tome/issues/453) + [#456](https://github.com/MartinP7r/tome/issues/456).
-- [x] **FIX-06**: `make release` automatically stamps the release date in `CHANGELOG.md` — replaces `[Unreleased]` with `[X.Y.Z] - YYYY-MM-DD` during the version-bump PR. Closes [#533](https://github.com/MartinP7r/tome/issues/533).
+Requirements for the v1.0 release. Grouped by category; each maps to a roadmap phase.
 
-## Future Requirements
+### Core architecture (CORE)
 
-Deferred from v0.11 scoping; surface as candidates for v0.12 / v1.0 / v2.
+The Rust crate must be reshaped to support both the existing CLI and the new GUI without duplicating domain logic. This is the foundation; every other GUI requirement depends on it.
 
-- **OBS-FUTURE-01**: JSON-by-default streaming log output (`--log-format json` or `TOME_LOG_FORMAT=json`) for machine consumers / future Tauri IPC. Tracing subscriber already supports this; flag-level integration deferred until a real consumer exists.
-- **OBS-FUTURE-02**: OpenTelemetry export (`tracing-opentelemetry`) — not justified at single-user scale; surface again if multi-machine telemetry becomes a need.
-- **FIX-FUTURE-01**: `Lockfile::version` silently accepts unknown values — future-compat time bomb ([#426](https://github.com/MartinP7r/tome/issues/426)). Small fix but not anchored to a v0.11 user-visible outcome; defer to v0.12 or fold into v1.0 prep.
-- **FIX-FUTURE-02**: Selective items from Phase 11/12/13 review followup bundles ([#517](https://github.com/MartinP7r/tome/issues/517), [#518](https://github.com/MartinP7r/tome/issues/518), [#519](https://github.com/MartinP7r/tome/issues/519)) — bundle-level decisions, evaluate per-item during v1.0 prep.
-- **WATCH-FUTURE-01**: File watcher for auto-sync ([#59](https://github.com/MartinP7r/tome/issues/59)) — carried from v0.10. Orthogonal product direction; v1.x or v2.
+- [ ] **CORE-01**: Domain operations (`sync`, `status::collect`, `list::collect`, `lint::run`, `doctor::diagnose`, `remove::plan`, `reassign::plan`, `fork::plan`, `relocate::plan`, `eject::plan`, `backup::*`) return structured Rust types — not formatted strings — and are callable from any front-end. Existing `lib.rs::run` is decomposed into a thin CLI wrapper that calls these and formats output; the GUI calls them directly.
+- [ ] **CORE-02**: A new crate `crates/tome-desktop` is added to the workspace alongside `crates/tome` and depends on it as a path dependency. The Tauri app lives in this crate. The CLI continues to ship from `crates/tome` unchanged.
+- [ ] **CORE-03**: All structured types crossing the Rust↔JS boundary (`StatusReport`, `SkillSummary`, `LockfileDiff`, `RemovePlan`, `Config`, `MachinePrefs`, etc.) generate matching TypeScript types via `specta` + `tauri-specta`, exposed to the front-end as a generated `bindings.ts`. No hand-rolled type definitions on the JS side.
+- [ ] **CORE-04**: Long-running operations (`sync`, git clone in `add`, backup snapshot/restore) emit progress events via Tauri's event system; the front-end subscribes and renders progress without blocking the IPC reply.
+- [ ] **CORE-05**: All Rust errors crossing into the front-end carry a stable `code` (enum) and `message` (`anyhow` chain) — the GUI can render targeted error UI ("permissions" / "not found" / "validation") without string-matching messages.
 
-## Out of Scope (v0.11)
+### Read-only views (VIEW)
 
-| Item | Reason |
-|------|--------|
-| Output redesign (new table layouts, JSON-by-default streams, OpenTelemetry export) | Observability scope is "instrument existing output" only. Output-shape changes belong in v1.0 GUI prep or a later polish milestone. |
-| Tauri Desktop GUI | Deferred to v1.0 — drafted in `milestones/v1.0-{REQUIREMENTS,ROADMAP}.md`. v0.11 lays the logging substrate that v1.0's IPC + log capture will consume. |
-| Linux runtime UAT (clipboard + xdg-open carry-over from v0.8) | Sixth consecutive milestone without Linux hardware. Formally deferred to **v1.0** where the Tauri build forces Linux access. Written rationale in `08-HUMAN-UAT.md` frontmatter. |
-| Rust → TypeScript rewrite | Explored in untracked `docs/migration/rust-to-typescript-feature-inventory.md` (snapshot 2026-04-27 @ v0.8.2). Parked. v1.0 continues on Rust + Tauri. |
-| Backward-compat shim for log flag changes | Per project policy (Backward compat: None). Flag changes will be release-noted; users adapt at the v0.11 boundary. |
-| New marketplace adapters (npm, generic URL) | Carried from v0.10 future requirements. Trait shape designed for extensibility; ADP-FUTURE-01/02 defer indefinitely until a real consumer exists. |
+Replacement for `tome status` + `tome list` + `tome browse`. First user-visible value; ships in the alpha cut.
+
+- [ ] **VIEW-01**: Status dashboard window shows: resolved `tome_home`, library directory, configured directories (with role/type badges), skill count, last sync time, lockfile state, and machine pref summary — equivalent to `tome status --json` rendered as a UI.
+- [ ] **VIEW-02**: Skill list view with virtualised rendering (handles ≥2000 skills at 60 fps), fuzzy search (matches `nucleo`-style ranking from the CLI), sort modes (name / source / recent), and group-by (none / source / role).
+- [ ] **VIEW-03**: Skill detail pane shows frontmatter (parsed via existing `lint.rs` logic), source directory path, content hash, last sync timestamp, managed/local status, and disabled state — clicking actions (open source dir / copy path / disable on this machine) match the existing browse TUI.
+- [ ] **VIEW-04**: Markdown preview pane renders SKILL.md body (post-frontmatter) with the same Markdown subset the existing `browse/markdown.rs` supports.
+- [ ] **VIEW-05**: Health pane surfaces `tome doctor` findings (orphan dirs, broken symlinks, missing manifest entries, missing source paths) with one-click "fix" actions that call into the same repair handlers used by the CLI's interactive `tome doctor`.
+- [ ] **VIEW-06**: All read-only views auto-refresh when the file watcher (CORE-04 event channel) detects manifest, lockfile, or library changes — the GUI cannot drift from on-disk state.
+
+### Sync + triage (SYNC)
+
+Replacement for `tome sync` and its interactive triage flow. Highest-UX-risk surface; warrants its own phase.
+
+- [ ] **SYNC-01**: A "Sync" action runs the same pipeline as `tome sync` (discover → consolidate → distribute → cleanup → save) and renders progress per stage; the user sees what stage is running and which directory is currently being processed.
+- [ ] **SYNC-02**: When the lockfile diff produces new/changed/removed skills, a triage panel lists them with diff metadata (source, hash, timestamp) and per-skill actions: keep (default), disable on this machine, or for git-sourced skills view-source. Bulk actions (disable all new from `<directory>`) supported.
+- [ ] **SYNC-03**: Triage decisions are previewable: the user sees the resulting `machine.toml` diff before applying. No silent writes.
+- [ ] **SYNC-04**: Sync runs are cancellable. The user can abort discovery or consolidation in progress; the cancel leaves the library in a consistent state (no half-written manifest, no partial lockfile).
+- [ ] **SYNC-05**: Failed sync surfaces a per-stage failure summary (matching CLI's `⚠ K operations failed` semantics shipped in SAFE-01) with a retry action that resumes from the failed stage where possible.
+
+### Configuration UI (CFG)
+
+Replacement for `tome init` + `tome add` + hand-edited `tome.toml` / `machine.toml`.
+
+- [ ] **CFG-01**: First-run experience launches when no `tome.toml` exists at the resolved `tome_home`. Wizard flow mirrors `tome init`: pick `tome_home`, auto-discovered directories presented with checkboxes, custom directories addable inline. Greenfield/brownfield/legacy logic from WUX-01..05 applies.
+- [ ] **CFG-02**: Directory editor lets the user add, edit, remove, and reorder directories. Type/role combos validated live against `valid_roles()` (the same 12-combo matrix WHARD-06 covers). Path validation runs `Config::validate()` before save and surfaces overlap errors inline.
+- [ ] **CFG-03**: `tome add <git url>` is replaced by an "Add git repository" form that captures URL, optional name, and ref pinning (branch/tag/rev — same `clap` choices). Clone progress streams via the SYNC-01 event channel.
+- [ ] **CFG-04**: Machine preferences editor exposes per-machine `disabled` skills, `disabled_directories`, and per-directory `enabled`/`disabled` lists. Changes are previewed as a `machine.toml` diff before save.
+- [ ] **CFG-05**: All config writes go through `Config::save_checked` (expand → validate → TOML round-trip → write) — the GUI cannot produce a config the CLI would reject.
+
+### Mutating operations (OPS)
+
+Replacement for `tome remove`, `tome reassign`, `tome fork`, `tome relocate`, `tome eject`.
+
+- [ ] **OPS-01**: Removing a directory shows a `RemovePlan` preview (which symlinks, library dirs, manifest entries, lockfile entries are affected) and requires explicit confirmation before execute. Partial-failure aggregation (SAFE-01 semantics) renders failures in the result UI with retry-per-item.
+- [ ] **OPS-02**: Reassigning or forking a skill shows the same plan/render/execute flow used by the CLI commands. The destination directory is picked from a dropdown of compatible directories.
+- [ ] **OPS-03**: Relocating the library shows a preview (target path, count of symlinks to rewrite) and runs atomically; failure leaves the library at the original path (matches existing `relocate.rs` semantics).
+- [ ] **OPS-04**: Ejecting (removing all symlinks from distribution directories) shows the count and a confirmation; the action is reversible by re-running sync.
+
+### Backup UI (BAK)
+
+Replacement for `tome backup init/snapshot/list/restore/diff`.
+
+- [ ] **BAK-01**: Backup history view shows a table of git commits in the library: timestamp, message, commit SHA. Equivalent to `tome backup list` rendered as a list view.
+- [ ] **BAK-02**: Snapshot action prompts for a message (default: timestamp) and runs `git add . && git commit`; success/failure surfaces as a toast.
+- [ ] **BAK-03**: Diff view (against a selected commit, default `HEAD`) shows changed skills with per-file diff rendering — replaces `tome backup diff`.
+- [ ] **BAK-04**: Restore flow shows a preview of what will change (skills affected, lockfile state) and requires explicit confirmation. After restore, sync is re-run automatically to reconcile distribution targets.
+
+### Distribution (DIST)
+
+Code signing, notarization, auto-update, and packaging required for a shippable v1.0.
+
+- [ ] **DIST-01**: macOS bundle is signed with the existing Developer ID, notarized via `notarytool`, stapled, and packaged as a DMG. CI builds for both `aarch64-apple-darwin` and `x86_64-apple-darwin` (universal binary preferred if Tauri/Apple recommend it at the time).
+- [ ] **DIST-02**: Auto-update is wired via `tauri-plugin-updater` against a signed update manifest hosted on GitHub Releases; updates are gated on user opt-in (no silent updates).
+- [ ] **DIST-03**: GitHub Actions release workflow produces signed/notarized DMGs alongside the existing CLI cargo-dist artifacts. CLI release flow is not regressed.
+- [ ] **DIST-04**: First-launch UX surfaces a "this is what tome does" overview, links to the docs, and offers to either run the CFG-01 wizard or import an existing `tome.toml`. Hardened runtime is enabled with the minimum entitlements required (no library validation disable).
+- [ ] **DIST-05**: The desktop app embeds (or shells out to) the `tome` CLI binary so users can copy a "show in terminal" command from any view. The CLI continues to be installable independently via Homebrew / cargo-dist.
+
+### Non-functional (NF)
+
+Cross-cutting requirements that apply to multiple phases.
+
+- [ ] **NF-01**: Skill list with 2000 skills renders search-as-you-type at 60 fps on M1 (8 GB) — chosen as the perf budget; verified via a synthetic-skills bench.
+- [ ] **NF-02**: All views are keyboard-navigable; primary actions have keyboard shortcuts (matching macOS HIG conventions: ⌘N add, ⌘R sync, ⌘F search, etc.). VoiceOver labels on every interactive element.
+- [ ] **NF-03**: Native macOS menu bar with File / Edit / View / Library / Help menus. App responds to system appearance changes (light/dark) — no in-app theme switcher initially.
+- [ ] **NF-04**: All destructive operations surface their plan and require explicit confirmation (no "always confirm" toggle that bypasses this in v1.0). Undo via `tome backup restore` is documented in confirmations where relevant.
+- [ ] **NF-05**: The desktop app and CLI share a single `tome.lock` and `.tome-manifest.json`. Concurrent CLI usage while the app is open does not corrupt either file (file watcher reloads on external change).
+
+## v2 Requirements
+
+Deferred to post-v1.0.
+
+- **GUI-EDIT-01**: SKILL.md editor with markdown preview and frontmatter form. Save through the same `Config::save_checked`-style validation pipeline.
+- **GUI-WATCH-01**: Real-time file watcher with auto-sync when source directories change.
+- **GUI-CONFLICT-01**: Visual merge tool for `git pull` conflicts in git-sourced directories.
+- **GUI-LINUX-01**: Linux build via `webkit2gtk` (Tauri's Linux backend). Out of v1.0 scope because the v0.8 Linux UAT items are still carry-over.
+- **GUI-WIN-01**: Windows build. Blocked on whole-project Windows support (currently out of scope).
+- **GUI-STATS-01**: Library analytics — most-used skills, by-tool distribution, last-touched timestamps in aggregate.
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Mac App Store distribution | App Sandbox would block tome's symlink-into-`~/.claude`/`~/.codex`/`~/.gemini` model. Direct distribution (Developer ID + notarization) is the only viable path in v1.0. |
+| Windows / Linux GUI on day 1 | Project is currently Unix-only; Linux GUI lives behind the v0.8 Linux UAT carry-over. |
+| Mobile / iPad app | Different distribution, different sandboxing, no symlinks. |
+| Web / remote access | tome is a local-machine tool. No server component planned. |
+| Skill content authoring (markdown editor) | Read-only viewing in v1.0 (VIEW-04); editing deferred to GUI-EDIT-01. |
+| Replacing the CLI | The CLI ships unchanged. The GUI is additive — both share the same library. |
+| Real-time auto-sync on file change | Manual sync only in v1.0 (deferred to GUI-WATCH-01). |
+| Plug-in / extension system for the GUI | Not enough variation in user requirements to justify the architecture cost in v1.0. |
+
+## Constraints
+
+- **Single-user product**. No accounts, no sync, no telemetry.
+- **macOS-first**. v1.0 ships macOS only; Linux deferred (v2). Windows out of scope.
+- **No regression of the CLI**. The CLI ships from `crates/tome` unchanged. cargo-dist release flow continues.
+- **Strict Tauri 2.x**. Pin Tauri major version; upgrade only at milestone boundaries.
+- **No JS-side business logic**. The frontend renders Tauri-command results and dispatches commands. Validation, planning, and side effects all live in Rust.
+- **Hardened runtime + notarization**. Required for direct-distribution UX; rules out features needing `disable-library-validation` or arbitrary code execution.
+
+## Key Decisions
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| **D-GUI-01** | Tauri 2 over Electron + napi-rs | Existing Rust core; ~8 MB vs ~150 MB bundle; no N-API ABI layer; built-in code-signed auto-update; reuses Developer ID flow. |
+| **D-GUI-02** | New `crates/tome-desktop` workspace member, not a feature flag in `crates/tome` | Isolates Tauri / webview deps from the CLI; CLI binary stays slim; CI can build either independently. |
+| **D-GUI-03** | `specta` + `tauri-specta` for TS type generation | First-class Tauri 2 integration; generates `bindings.ts` at build time; eliminates JS-side type drift. |
+| **D-GUI-04** | Frontend framework: **TBD in Phase 25 spike** — shortlist React, Solid, Svelte | Decision deferred to spike: React for ecosystem, Solid for performance/size, Svelte for ergonomics. Pick one and commit; no multi-framework UI. |
+| **D-GUI-05** | Auto-update via `tauri-plugin-updater` + GitHub Releases manifest | Built into Tauri 2; signed updates; no third-party service dependency. |
+| **D-GUI-06** | macOS only for v1.0; Linux behind v0.8 carry-over | Linux runtime UAT items still pending hardware; GUI adds the same surface. Defer to v2. |
+| **D-GUI-07** | App and CLI share `tome.lock` + `.tome-manifest.json`; file watcher in app reloads on external change | Single source of truth; no GUI-private state files. |
+| **D-GUI-08** | Tauri commands return structured types; CLI continues to format strings | Domain logic returns `StatusReport` etc.; CLI's `lib.rs::run` is decomposed into a presenter layer over the same domain calls. |
+| **D-GUI-09** | Sequence v0.9 → v1.0 (default) but allow swap | v0.9 cross-machine portability is small; landing it first means GUI inherits stable `machine.toml` semantics. Swappable if priorities shift. |
+
+## Non-Goals (clarifying)
+
+- **Not** a wrapper around the CLI binary. The GUI talks to the Rust library directly via Tauri commands; the CLI is referenced only for "show in terminal" UX (DIST-05).
+- **Not** a config editor that bypasses validation. CFG-05 routes all writes through `Config::save_checked`.
+- **Not** a feature-parity guarantee for niche CLI behaviour. `tome completions <shell>` and `tome version` stay CLI-only — they have no GUI surface.
 
 ## Traceability
 
-Filled by `gsd-roadmapper` 2026-05-12. 13 requirements mapped across 2 phases (18–19), 100% coverage.
-
 | Requirement | Phase | GitHub Issue | Status |
 |-------------|-------|--------------|--------|
-| OBS-01 | Phase 18 | — | Done |
-| OBS-02 | Phase 18 | — | Done |
-| OBS-03 | Phase 18 | — | Done |
-| OBS-04 | Phase 18 | — | Done |
-| OBS-05 | Phase 18 | — | Done |
-| OBS-06 | Phase 19 | — | Done |
-| OBS-07 | Phase 19 | — | Done |
-| FIX-01 | Phase 19 | [#530](https://github.com/MartinP7r/tome/issues/530) | Done |
-| FIX-02 | Phase 19 | [#511](https://github.com/MartinP7r/tome/issues/511) | Done |
-| FIX-03 | Phase 19 | [#532](https://github.com/MartinP7r/tome/issues/532) | Done |
-| FIX-04 | Phase 19 | [#454](https://github.com/MartinP7r/tome/issues/454) | Done |
-| FIX-05 | Phase 19 | [#453](https://github.com/MartinP7r/tome/issues/453) + [#456](https://github.com/MartinP7r/tome/issues/456) | Done |
-| FIX-06 | Phase 19 | [#533](https://github.com/MartinP7r/tome/issues/533) | Done |
+| CORE-01..05 | Phase 25 | TBD | Pending |
+| VIEW-01..06 | Phase 26 | TBD | Pending |
+| SYNC-01..05 | Phase 27 | TBD | Pending |
+| CFG-01..05 | Phase 28 | TBD | Pending |
+| OPS-01..04 | Phase 29 | TBD | Pending |
+| BAK-01..04 | Phase 30 | TBD | Pending |
+| DIST-01..05 | Phase 31 | TBD | Pending |
+| NF-01..05 | Cross-phase | — | Pending |
 
 **Coverage:**
-- v0.11 requirements: 13 total (7 OBS + 6 FIX)
-- Mapped to phases: 13 / 13 ✓
+- v1 requirements: 32 total
+- Mapped to phases: 32 / 32 ✓
+- Cross-phase non-functional: 5 / 5 (verified at phase boundaries + final pre-ship audit)
+
+## Release cuts (suggested)
+
+These are non-binding suggestions to give a sense of intermediate ship points. Final cut decisions happen at phase-completion checkpoints.
+
+| Cut | Phases | Capability |
+|-----|--------|------------|
+| **v1.0-alpha** | 25 + 26 | Read-only desktop client. Status, list, browse-replacement, doctor. No mutating actions in the GUI; CLI still required for sync/edit. |
+| **v1.0-beta** | + 27 + 28 | Sync + config UI. Daily-driver capable for the primary user. |
+| **v1.0-rc** | + 29 + 30 | All mutating commands available in the GUI. CLI is functionally optional for steady-state use. |
+| **v1.0** | + 31 | Signed, notarized, auto-updating DMG. Public-shippable. |
+
+---
+
+*Requirements defined: 2026-04-28 in response to user request to scope a Tauri 2 GUI milestone after exploring Rust→TS migration costs and Electron+napi-rs alternatives.*
+*Ratified into active planning: 2026-05-23 via `/gsd-new-milestone` after v0.16 shipped. Phase numbering continued from v0.16 (last phase: 24) → v1.0 starts at Phase 25.*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -13,7 +13,7 @@
 - ✅ **v0.14 Polish: type+role UX + doctor claim-orphan** — Phases 20-21 (shipped 2026-05-20; promoted from backlog 999.5 + 999.2 on 2026-05-19; PR #550 + PR #551)
 - ✅ **v0.15 Generic managed source directory** — Phase 22 (shipped 2026-05-20; promoted from backlog 999.4 on 2026-05-20; PR #553). Allows `[directories.<name>] type = "directory" role = "managed"` so pfw-style package managers are first-class. Two deferred follow-ups: `is_foreign_symlink` managed-source recognition + detect-and-warn for upstream-own-distribution conflict.
 - ✅ **v0.16 Doctor diagnostics expansion** — Phases 23-24 (shipped 2026-05-20; promoted from backlog 999.1 + 999.3 on 2026-05-20; PR #555). Phase 23: `tome doctor` surfaces skills with unparsable SKILL.md frontmatter as Library Warnings (no auto-fix). Phase 24: `tome doctor` consolidates target real-dirs into symlinks when content matches the library byte-for-byte; diverging content surfaces as no-repair Warning. New `RepairKind::ConsolidateTargetRealDirToSymlink` variant.
-- 📋 **v1.0 tome Desktop (Tauri GUI)** — drafted, next milestone — see [milestones/v1.0-REQUIREMENTS.md](milestones/v1.0-REQUIREMENTS.md) and [milestones/v1.0-ROADMAP.md](milestones/v1.0-ROADMAP.md)
+- 🚧 **v1.0 tome Desktop (Tauri GUI)** — Phases 25–31 (ratified 2026-05-23 via `/gsd-new-milestone`; drafted 2026-04-28 in [milestones/v1.0-REQUIREMENTS.md](milestones/v1.0-REQUIREMENTS.md) and [milestones/v1.0-ROADMAP.md](milestones/v1.0-ROADMAP.md)). Tauri 2 desktop GUI over the existing CLI library. 32 requirements across 8 categories (CORE / VIEW / SYNC / CFG / OPS / BAK / DIST / NF). macOS-only for v1.0 (Linux deferred to v2). Cuts: alpha (Phases 25–26) → beta (27–28) → rc (29–30) → v1.0 (31).
 
 ## Phases
 
@@ -244,26 +244,47 @@ Full archive: [milestones/v0.10-ROADMAP.md](milestones/v0.10-ROADMAP.md). Closes
 - [x] 19-06-wizard-library-default-pinning-test-PLAN.md — Wave 2D: integration test pinning wizard.rs:637 existing TOME_HOME-following behavior — FIX-05
 - [x] 19-07-changelog-and-phase-verification-PLAN.md — Wave 3: CHANGELOG [Unreleased] Phase 19 entries + REQUIREMENTS.md Traceability flip Pending→Done + make ci + human checkpoint against ROADMAP success criteria 1-4 (approved 2026-05-15, retrospective — v0.11 shipped 2026-05-14 via PR #534 + #535)
 
-### 🚧 v0.14 Polish: type+role UX + doctor claim-orphan (In Progress)
+### ✅ v0.14 Polish: type+role UX + doctor claim-orphan (Shipped 2026-05-20)
 
-**Milestone Goal:** Speedrun two backlog items surfaced by post-v0.13 dogfooding. Both are small, well-scoped UX fixes that close real user-friction surfaces — neither needs the v1.0 Phase 10 IPC redesign context. Promoted from backlog (999.5 + 999.2) on 2026-05-19.
+**Milestone Goal:** Speedrun two backlog items surfaced by post-v0.13 dogfooding. Both are small, well-scoped UX fixes that close real user-friction surfaces. Promoted from backlog (999.5 + 999.2) on 2026-05-19. Shipped via PR #550 + PR #551.
 
-- [ ] **Phase 20: Type+role explanation in `tome add`** (promoted from 999.5) — Surface what `type` and `role` mean + their defaults at the moments users are choosing them. Five candidate surfaces (CLI `--role` flag, `tome add` success message echoing role, `tome init` wizard hint, `tome status` table already-good, `commands.md` "Choosing the right role" section). Speedrun: ship CLI flag + success message + docs section.
-- [ ] **Phase 21: Doctor repair — claim orphan into manifest** (promoted from 999.2) — Add a `tome doctor` repair option that registers an orphan library directory into the manifest as Unowned, instead of only offering "delete" or "skip with sync hint". Closes the dead-end where sync can't re-discover orphans.
+- [x] **Phase 20: Type+role explanation in `tome add`** (promoted from 999.5) — Surface what `type` and `role` mean + their defaults at the moments users are choosing them. Shipped: CLI `--role` flag + `tome add` success message echoing role + docs section in `commands.md` ("Choosing the right role").
+- [x] **Phase 21: Doctor repair — claim orphan into manifest** (promoted from 999.2) — `tome doctor` now offers a `claim` option that registers an orphan library directory into the manifest as Unowned. Closes the dead-end where library-canonical orphans with no upstream source had no recovery path.
 
 ### ✅ v0.15 Generic managed source directory (Shipped 2026-05-20)
 
 **Milestone Goal:** Make the `Managed` role first-class for any flat-directory package manager (pfw, etc.), not just `claude-plugins`. Shipped via PR #553.
 
+- [x] **Phase 22: Generic managed source directory** (promoted from 999.4) — Relaxed `valid_roles()` for `DirectoryType::Directory` to include `Managed`. Dropped the `validate.rs` reject rule. Discovery + consolidate already keyed on `role() == Managed` end-to-end, so the change was small: validation surface + tests + docs. **Out of scope (deferred to follow-ups):** (a) `is_foreign_symlink` refinement to recognize managed-source paths as legitimate-origin; (b) detect-and-warn for "pfw's own distribution is fighting tome".
+
 ### ✅ v0.16 Doctor diagnostics expansion (SHIPPED 2026-05-20)
 
 **Milestone Goal:** Two doctor improvements promoted from backlog. Phase 23 surfaces skills with broken SKILL.md frontmatter (the original 999.1 framing about "discover drops them" was wrong — they pass through; the real gap was doctor didn't surface them post-sync). Phase 24 turns the existing `sync` real-dir-collision warning into an actionable doctor repair. Shipped via PR #555.
 
-- [x] **Phase 23: Loosen frontmatter cascade** (promoted from 999.1) — `tome doctor` now walks every manifest-tracked library skill and parses its SKILL.md. YAML/delimiter errors and missing files surface as Library Warnings (`'<skill>' has unparseable SKILL.md frontmatter: …`). Not auto-repairable — the user must edit the file. The "loosen" framing was based on a misread of `discover.rs`: skills with broken frontmatter ALREADY pass through to library + distribution today (no filter drops them). The actionable bit is the doctor diagnostic.
+- [x] **Phase 23: Loosen frontmatter cascade** (promoted from 999.1) — `tome doctor` now walks every manifest-tracked library skill and parses its SKILL.md. YAML/delimiter errors and missing files surface as Library Warnings (`'<skill>' has unparsable SKILL.md frontmatter: …`). Not auto-repairable — the user must edit the file. The "loosen" framing was based on a misread of `discover.rs`: skills with broken frontmatter ALREADY pass through to library + distribution today (no filter drops them). The actionable bit is the doctor diagnostic.
 - [x] **Phase 24: Doctor repair — consolidate target real-dir into symlink** (promoted from 999.3) — Extended `check_distribution_dir` to detect non-symlink entries whose contents are byte-identical to a library skill, and offers an auto-repair (`RepairKind::ConsolidateTargetRealDirToSymlink`) to delete the real dir + replace with a symlink. Diverging-content real dirs surface as a no-repair Warning so the user can reconcile manually.
 
-- [ ] **Phase 22: Generic managed source directory** (promoted from 999.4) — Relax `valid_roles()` for `DirectoryType::Directory` to include `Managed`. Drop the `validate.rs` reject rule. Discovery + consolidate already key on `role() == Managed` end-to-end (the `is_managed` flag flows through), so the change is small: validation surface + tests + docs. **Out of scope (deferred):** (a) `is_foreign_symlink` refinement to recognize managed-source paths as legitimate-origin (the 18 pfw-* symlinks in claude-skills would still flag as foreign — separate follow-up); (b) detect-and-warn for "pfw's own distribution is fighting tome" (the open question from the 999.4 entry).
+### 🚧 v1.0 tome Desktop (Tauri GUI) — Phases 25–31 (Ratified 2026-05-23)
 
+**Milestone Goal:** Make the skill library *visible*. Tauri 2 desktop GUI over the existing CLI library; the Rust core is reshaped to return structured types callable from any front-end. CLI continues to ship unchanged from `crates/tome`; new `crates/tome-desktop` workspace member hosts the app. macOS-only for v1.0 (Linux deferred to v2). Cuts: alpha (Phases 25–26) → beta (27–28) → rc (29–30) → v1.0 (31). Full requirements in [`REQUIREMENTS.md`](REQUIREMENTS.md); full per-phase plan in [`milestones/v1.0-ROADMAP.md`](milestones/v1.0-ROADMAP.md).
+
+- [ ] **Phase 25: Rust core extraction + Tauri integration spike** (CORE-01..05) — Decompose `lib.rs::run` into CLI presenter + structured-type domain calls; add `crates/tome-desktop` Tauri 2 scaffold; wire `specta` + `tauri-specta` for `bindings.ts` generation; Tauri event channel for progress; `TomeError` enum with stable codes. Frontend framework decided via spike (D-GUI-04). **No production UI in this phase.**
+- [ ] **Phase 26: Read-only views — alpha cut** (VIEW-01..06 + NF-01..03, NF-05) — Status dashboard, virtualised skill list (2000 skills @ 60fps on M1), detail pane + markdown preview, doctor health pane with one-click fixes, file watcher auto-refresh. Keyboard + VoiceOver. **v1.0-alpha cut.**
+- [ ] **Phase 27: Sync + triage UI** (SYNC-01..05) — Per-stage progress, lockfile diff with per-skill triage decisions, previewable `machine.toml` diff, cancellable sync, per-stage failure summary + retry. Highest-UX-risk phase.
+- [ ] **Phase 28: Configuration UI — beta cut** (CFG-01..05 + NF-04) — First-run wizard (greenfield/brownfield/legacy), directory editor with live validation, add-git-repo form, machine prefs editor with diff preview. All writes route through `Config::save_checked`. **v1.0-beta cut.**
+- [ ] **Phase 29: Mutating operations UI** (OPS-01..04 + NF-04) — Remove/reassign/fork/relocate/eject with plan-preview-confirm flows. Partial-failure aggregation (SAFE-01 semantics) with retry-per-item.
+- [ ] **Phase 30: Backup UI — rc cut** (BAK-01..04 + NF-04) — Backup history view, snapshot action, diff view, restore flow with automatic post-restore sync. **v1.0-rc cut.**
+- [ ] **Phase 31: Distribution — v1.0 ship** (DIST-01..05) — Sign + notarize + DMG (aarch64 + x86_64), `tauri-plugin-updater` auto-update with signed manifest, combined GitHub Actions release workflow (CLI cargo-dist outputs preserved), first-launch UX, embedded CLI with "Show in terminal" affordances. **v1.0 ship.**
+
+**Open questions (Q1–Q7 from `milestones/v1.0-ROADMAP.md`):**
+
+- Q1: Frontend framework choice — resolve in Phase 25 spike (D-GUI-04)
+- Q2: Tauri minor-version pinning policy
+- Q3: How `tome lint` failures surface (separate view / integrated into doctor / both)
+- Q4: Tray-icon presence (default: no, launch on demand)
+- Q5: Linux as stretch goal vs strict v2 (default: strict v2)
+- Q6: Sparkle vs `tauri-plugin-updater` (default Tauri; revisit in Phase 31)
+- Q7: Telemetry / crash reporting (out of scope v1.0; flag for v2)
 
 ## Backlog
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,53 +1,57 @@
 ---
 gsd_state_version: 1.0
-milestone: v0.16
-milestone_name: Doctor diagnostics expansion
-status: shipped
-stopped_at: v0.16.0 released 2026-05-20 (Phases 23+24 — PR #555 added two `tome doctor` diagnostics: broken-frontmatter cascade (backlog 999.1, Library Warning, no auto-fix) and real-dir-in-target repair (backlog 999.3, auto-fixable when target content matches library byte-for-byte; no-repair Warning when diverging). New `RepairKind::ConsolidateTargetRealDirToSymlink` variant. Single-day double-ship after v0.15.0 same morning. v0.14.0 + v0.13.0 + v0.12.x in the preceding three days. Backlog parking lot now empty of v0.12-dogfooding items (999.1–999.5 all promoted + shipped). Open follow-ups #542 (v1.0 Phase 10 deferred), #548 (role-transition cleanup), plus two new in-flight from Phase 22 deferral: is_foreign_symlink managed-source recognition + detect-and-warn for upstream's own distribution fighting tome's. Next milestone v1.0 Tauri GUI drafted — pending /gsd-new-milestone ratification.
-last_updated: "2026-05-20T00:00:00.000Z"
-last_activity: 2026-05-20
+milestone: v1.0
+milestone_name: tome Desktop (Tauri GUI)
+status: planning
+stopped_at: v1.0 ratified 2026-05-23 via /gsd-new-milestone after v0.16 shipped. Phases 25–31 (32 reqs across 8 categories: CORE/VIEW/SYNC/CFG/OPS/BAK/DIST/NF). Cuts: alpha (25–26) → beta (27–28) → rc (29–30) → v1.0 (31). macOS-only for v1.0; Linux deferred to v2 per D-GUI-06. Ready for /gsd:plan-phase 25 (or /gsd:discuss-phase 25 first to clarify approach).
+last_updated: "2026-05-23T00:00:00.000Z"
+last_activity: 2026-05-23
 progress:
-  total_phases: 9
-  completed_phases: 8
-  total_plans: 43
-  completed_plans: 43
+  total_phases: 7
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
 ---
 
 # Project State
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated after v0.10; v0.11 milestone now active)
+See: .planning/PROJECT.md (updated 2026-05-23 with v1.0 Current Milestone section)
 
-**Core value:** Every AI coding tool on a developer's machine shares the same skill library without manual copying or per-tool configuration.
-**Current focus:** Phase 19 — doctor-status-surface-bugfix-bundle
+**Core value:** Every AI coding tool on a developer's machine shares the same skill library without manual copying or per-tool configuration. v1.0 makes that library *visible* — directories, skills, sync state, and conflicts are observed and managed from a desktop app rather than a terminal.
+**Current focus:** Phase 25 — Rust core extraction + Tauri integration spike (not started)
 
 ## Current Position
 
-Milestone: v0.11 Polish + Observability — SHIPPED 2026-05-14
-Phase: 19 (doctor-status-surface-bugfix-bundle) — COMPLETED 2026-05-13, verified retrospectively 2026-05-15
-Plan: 7/7 complete (verified 8/8 must-haves passed)
-Status: v0.11.0 released; Cargo.toml = 0.11.0; CHANGELOG.md = [0.11.0] - 2026-05-14
-Last activity: 2026-05-15
+Phase: Not started (defining requirements complete; phase 25 awaits `/gsd:plan-phase 25`)
+Plan: —
+Status: Defining requirements complete; ratified via `/gsd-new-milestone`
+Last activity: 2026-05-23 — Milestone v1.0 ratified, drafts promoted
 
-**v0.11 phase shape (Phases 18–19):**
-
-| Phase | Goal | Reqs | Cut |
-|------:|------|------|-----|
-| 18 | Observability foundation + sync diagnostics | OBS-01..05 (5) | — |
-| 19 | Doctor/status surface + bugfix bundle | OBS-06..07 + FIX-01..06 (8) | **v0.11 final** |
-
-**v0.10 phase shape (Phases 11–17, SHIPPED 2026-05-11):**
+**v1.0 phase shape (Phases 25–31):**
 
 | Phase | Goal | Reqs | Cut |
 |------:|------|------|-----|
-| 11 | Library-canonical core | LIB-01..05 (5) | — |
-| 12 | Marketplace adapter | ADP-01..04 (4) | — |
-| 13 | Lockfile-authoritative sync | RECON-01..05 (5) | **alpha** |
-| 14 | Unowned-library lifecycle | UNOWN-01..03 (3) | — |
-| 15 | CLI hardening | HARD-01..22 (22) | **beta** |
-| 16 | Cleanup-message UX + docs | UX-01..02 + DOC-01..03 (5) | **rc** |
-| 17 | Migration polish + UAT + release | REL-01..05 (5) | **v0.10 final** |
+| 25 | Rust core extraction + Tauri integration spike | CORE-01..05 (5) | — |
+| 26 | Read-only views | VIEW-01..06 (6) + NF-01..03, NF-05 | **alpha** |
+| 27 | Sync + triage UI | SYNC-01..05 (5) | — |
+| 28 | Configuration UI | CFG-01..05 (5) + NF-04 | **beta** |
+| 29 | Mutating operations UI | OPS-01..04 (4) + NF-04 | — |
+| 30 | Backup UI | BAK-01..04 (4) + NF-04 | **rc** |
+| 31 | Distribution: sign, notarize, auto-update, DMG, first-run UX | DIST-01..05 (5) | **v1.0** |
+
+**Last 6 milestones (recap):**
+
+| Milestone | Phases | Shipped |
+|-----------|--------|---------|
+| v0.10 Library-canonical Model | 11–17 | 2026-05-11 |
+| v0.11 Polish + Observability | 18–19 | 2026-05-14 (+ v0.11.1 2026-05-15) |
+| v0.12 Pre-v1.0 Review Polish | — (no-phase bundle) | 2026-05-17 (+ v0.12.1 same day) |
+| v0.13 `tome add` UX | — | 2026-05-19 |
+| v0.14 Type+role UX + claim-orphan | 20–21 | 2026-05-20 |
+| v0.15 Generic managed source directory | 22 | 2026-05-20 |
+| v0.16 Doctor diagnostics expansion | 23–24 | 2026-05-20 |
 
 ## Accumulated Context
 
@@ -62,50 +66,51 @@ Historical decisions are archived in:
 - `.planning/milestones/v0.8-ROADMAP.md` — per-phase decisions for v0.8
 - `.planning/milestones/v0.7-ROADMAP.md` — per-phase decisions for v0.7
 - `.planning/milestones/v0.6-ROADMAP.md` — per-phase decisions for v0.6
-- `.planning/milestones/v1.0-{REQUIREMENTS,ROADMAP}.md` — Tauri GUI milestone (drafted, deferred to after v0.11 ships)
-- [Phase 18-observability-foundation-sync-diagnostics]: tracing substrate landed via tracing_init::install(LogLevel); TOME_LOG env > LogLevel directive precedence (D-ENV-1); reconcile.rs warnings routed through tracing::warn! as locked proof module (D-SUB-2)
-- [Phase 18]: Plan 18-02: 5 step spans + top-level sync span via lexical info_span!(...).entered() blocks; ChangeCause enum with four locked vocabulary strings; OBS-05 reconcile classification line in render_sync_report; DirectoryNowAllowed false-positive accepted, PreviouslyFailed deferred to v0.12 schema bump.
-- [Phase 18]: Plan 18-03: OBS-03 span emission pinned by sync_verbose_emits_step_spans_on_stderr regression test asserting on the 3 always-firing step span names + time.busy auto-field; CHANGELOG [Unreleased] documents OBS-01..05, D-ENV-1 trade-off, and PreviouslyFailed + DirectoryNowAllowed deferrals.
-- [Phase 19]: Plan 19-01: RepairKind has 3 variants (RemoveStaleManifestEntry, RemoveBrokenLibrarySymlink, RemoveStaleTargetSymlink) — one per real auto-repair handler. Orphan directories stay interactive-only (repair_kind: None).
-- [Phase 19]: Plan 19-01: Per-category DiagnosticIssue constructors (library/library_repairable/directory/directory_repairable/directory_foreign_symlink/config) replace untyped/typed shims; D-CAT-1 ForeignSymlink promotion happens at construction time. Dispatcher matches exhaustively on Option<RepairKind> — substring matching anti-pattern eliminated.
-- [Phase 19]: Plan 19-01 / FIX-03 (#532): 'managed symlink(s) tracked in git' check, render+Confirm flow, and tracked_managed_symlinks helper deleted wholesale — v0.10's library-canonical model made the check incapable of firing on clean libraries. D-FIX03-2 integration test pins the absence of the warning.
-- [Phase 19]: Plan 19-02 / FIX-06 (#533): Makefile `release` recipe now stamps CHANGELOG release date via inline `sed -i ''` between `cargo check` and branch creation; CHANGELOG.md added to the version-bump `git add`; 3 regression tests in `crates/tome/tests/cli_make_release.rs` pin sed substitution + idempotency + silent-noop. Inline shell comments inside `\`-continuation recipe blocks rejected (Make joins lines before shell parsing — `#` would comment out trailing commands); all docs live above the `release:` target.
-- [Phase 19]: OBS-07: stamp_last_synced_at() placed at lib.rs:1789, inside the !dry_run guard, immediately before manifest::save — D-LSYNC-3 honored. JSON last_sync emits literal null for fresh manifests (no skip_serializing_if), matching the stable-shape pattern used by unowned: [].
-- [Phase 19]: Plan 19-04: Outcome C selected for backup test flake — defensive FLAKE-WATCH comment shipped (50/50 isolated + 10/10 module + 5/5 lib-suite runs all pass locally on M1 macOS); browse-test bound relaxed 600ms→2000ms with arboard-rooted FLAKE-FIX comment (100/100 stability)
-- [Phase 19]: FIX-04 (#454) closes administratively: reproduce-first proved tabled[ansi] fix from 0803afb is sufficient; no strip-ansi-escapes dep added; snapshot test render_directory_summary_table pins header/body alignment as regression guard
-- [Phase 19]: Plan 19-06 / FIX-05 (#453 + #456): Two regression tests in `crates/tome/tests/cli_init.rs` pin the wizard library-default derivation against `TOME_HOME` env (positive D-FIX05-1: library_dir == `<TOME_HOME>/skills`; negative D-FIX05-2: no fallback to `<HOME>/.tome/skills`). `wizard.rs:637` already derived `<resolved_tome_home>/skills` correctly per RESEARCH; this plan is test-only. Sensitivity verified — replacing :637 with hardcoded `~/.tome/skills` makes both tests fail.
+- `.planning/milestones/v1.0-{REQUIREMENTS,ROADMAP}.md` — v1.0 source drafts (ratified into top-level REQUIREMENTS.md + ROADMAP.md on 2026-05-23)
+- `.planning/milestones/v0.11-REQUIREMENTS.md` — v0.11 archived requirements (REQUIREMENTS.md overwritten with v1.0 content on ratification)
+- [Phase 18..24]: decisions logged historically here; see archived `.planning/STATE.md` history in git for full list
 
-### v0.11 design context (consume during planning)
+### v1.0 design context (consume during phase planning)
 
-- **Scope discipline:** observability is "instrument existing output" — not "redesign output." Wizard prompts, TUI browse output, and user-facing summary tables (`tome status`/`list`/`doctor` tables, `tome sync` final summary) stay on direct stdout. Only the *log-like* output (sync progress, cleanup actions, diagnostic warnings) gets routed through `tracing`.
-- **`tracing` is the default** structured-logging crate (spans, structured fields, async-aware; aligns with what v1.0 Tauri IPC will need). `log` is the cheaper fallback if adoption cost shows up during Phase 18 planning.
-- **HARD-07 substrate:** Phase 15's `LogLevel` enum already exists and wraps `(verbose, quiet)` at the CLI boundary. OBS-02 extends this enum to also produce a `tracing_subscriber::EnvFilter`; no new public flags.
-- **OBS-06 + FIX-01 fold together:** the doctor categorization work (Library / Directory / Config / Foreign-symlink) is the same code change that splits "auto-fixable" from "all issues" — one implementation closes [#530](https://github.com/MartinP7r/tome/issues/530) and delivers OBS-06.
-- **Phase 19 internal parallelism:** the 5 FIX items (FIX-02..06) are independent of each other and of the OBS-06/07 surface work. They can ship in any order or in parallel waves once Phase 18's logging substrate is in place.
-- **Linux UAT carry-over (v0.8):** still pending. Formally deferred to v1.0 (Tauri build forces Linux access). Sixth consecutive milestone without Linux hardware; written rationale in `08-HUMAN-UAT.md` frontmatter.
-- **Backward compat:** none. Flag/env-var behavior changes (e.g., `TOME_LOG` semantics, default log level) will be release-noted but not gated on a migration shim.
+- **No CLI regression.** `crates/tome` ships unchanged via cargo-dist. The CLI must work the same end-to-end after every v1.0 phase. Integration tests in `crates/tome/tests/cli*.rs` are the regression suite.
+- **Library-canonical types are the contract.** v0.10's library-canonical model + v0.11–v0.16 polish stabilized `SkillEntry`, `LockEntry`, `RemovePlan`, `StatusReport`, `DirectoryRole`, etc. v1.0 wraps these as Tauri commands; do not change their shape mid-milestone without explicit decision.
+- **CORE-01 is foundational.** Decomposing `lib.rs::run` into CLI presenter + structured-type domain calls is Phase 25's central task. The frontend framework spike (D-GUI-04) happens *after* the domain functions exist — picking the framework against fake data would burn the decision.
+- **`specta` + `tauri-specta` for bindings** (D-GUI-03). No hand-rolled TS types. CI should fail if generated `bindings.ts` is out of date.
+- **macOS only v1.0** (D-GUI-06). Linux deferred to v2. The two pending Linux UAT items from v0.8 stay deferred; they don't block v1.0 ship.
+- **#542 absorption.** Owned/Unowned enum migration (deferred from v0.12 review) is folded into Phase 25 CORE-01 work — the structured types the GUI needs are exactly where the enum belongs. Plan must explicitly call this out.
+- **Backward compat:** none (per project policy). New `tome-desktop` crate, new `TomeError` enum with stable codes, new event channel — all additive at the CLI layer, no compat shim for old library shape.
 
-### Phase dependency graph (v0.11)
+### Phase dependency graph (v1.0)
 
 ```
-18 (Observability foundation + sync diagnostics)
- └── 19 (Doctor/status surface + bugfix bundle) ── v0.11 FINAL
+25 (Rust core extraction + Tauri integration spike)
+ ├── 26 (Read-only views) ── alpha cut
+ │    └── 27 (Sync + triage UI)
+ │         └── 28 (Configuration UI) ── beta cut
+ │              └── 29 (Mutating operations UI)
+ │                   └── 30 (Backup UI) ── rc cut
+ │                        └── 31 (Distribution) ── v1.0 ship
+ └── (NF-01..05 verified at cut boundaries — alpha + beta + rc + final)
 ```
 
-Phase 19 depends on Phase 18 for the logging substrate (doctor/status warnings route through `tracing` consistently). The FIX bundle inside Phase 19 is internally parallelizable.
+Phases 26–31 form a strict linear chain; each depends on the previous. NF gates (perf, a11y, HIG, safety, concurrency) are verified at the indicated cuts, not as their own phase.
 
 ### Pending Todos / Carry-over
 
-- **Linux UAT (carry-over from v0.8):** 2 pending items in `.planning/phases/08-*/08-HUMAN-UAT.md` (clipboard runtime + xdg-open runtime tests). Pending Linux desktop hardware. Carried over for the sixth consecutive milestone — formally deferred to **v1.0** where the Tauri build target forces Linux access.
-- **Pre-existing flake (RESOLVED via Plan 19-04, Outcome C):** `backup::tests::push_and_pull_roundtrip` — historically intermittent. HARD-14 in Phase 15 addressed signing; Phase 19 Plan 04 / FIX-02 paired this with the browse copy-path flake per D-FLAKE-2 and concluded with Outcome C (flake NOT reproducible locally on M1 macOS; 50/50 isolated + 10/10 module + 5/5 lib-suite runs all clean). Defensive FLAKE-WATCH comment shipped at `backup.rs::push_and_pull_roundtrip` documenting flake history + next-mitigation retry-wrapper pattern for future-phase pickup if it recurs in CI. The browse flake ([#511](https://github.com/MartinP7r/tome/issues/511)) bound was relaxed 600ms→2000ms with the canonical FLAKE-FIX comment (arboard contention root cause).
+- **Linux UAT (carry-over from v0.8):** 2 pending items in `.planning/phases/08-*/08-HUMAN-UAT.md` (clipboard runtime + xdg-open runtime tests). Pending Linux desktop hardware. Carried over for the sixth+ consecutive milestone — formally deferred to **v2 (post-v1.0)** when Linux GUI build hardware lands.
+- **#542 Owned/Unowned enum migration** — deferred from v0.12 whole-codebase review; absorbed into Phase 25 CORE-01 scope.
+- **#548 role-transition cleanup gap** — surfaced during v0.13 dogfooding (when a directory's role transitions synced→source, ~171 stale tome symlinks linger). Standalone follow-up; not v1.0-blocking but should land before the alpha cut so dogfooding sessions don't repeat the manual cleanup.
+- **Phase 22 deferrals** — two in-flight items: (a) `is_foreign_symlink` managed-source recognition (managed-source paths flag as foreign currently); (b) detect-and-warn for upstream's own distribution fighting tome's. Both have v0.15 dogfooding rationale; absorb into Phase 27 (Sync + triage UI) where foreign-symlink discipline matters most.
 
 ### Blockers/Concerns
 
-- **`tracing` adoption cost (open question for Phase 18 planning):** the codebase currently has ~50+ `eprintln!`/`println!` call sites in sync/reconcile/consolidate/distribute/cleanup. Phase 18 planning should sample the call sites and decide whether the full migration is one plan or split into a substrate plan + a migration plan. If cost looks high, `log` (simpler, no spans) is the documented fallback.
-- **Output discipline boundary:** OBS-01 explicitly excludes wizard prompts, TUI browse output, and summary tables from the migration. Plan 18 must enumerate which modules ARE in scope (sync, reconcile, consolidate, distribute, cleanup, doctor diagnostics) versus which are NOT (wizard, browse, status/list/doctor table renderers, lint frontmatter output) to avoid drift during execution.
+- **Tauri 2 cross-platform code-signing on CI** (Phase 31) — first time the project will need a Developer ID for non-CLI artifacts. cargo-dist's existing macOS signing flow may need extension or replacement. Plan should enumerate the certificate, notarization, and `tauri-plugin-updater` signing requirements before Phase 31 starts.
+- **Frontend framework decision is load-bearing** (D-GUI-04). All UI phases (26–31) depend on it. Phase 25's spike must produce a defensible pick (React / Solid / Svelte) and lock it in writing. Mid-milestone framework swap is not acceptable.
+- **`crates/tome-desktop` as a workspace member** — adds Tauri + webview deps to the workspace. Verify cargo-dist's CLI artifact build does not start pulling Tauri deps unintentionally. Workspace-level feature flags or per-crate build matrices may be needed.
+- **CLI snapshot tests** — the v0.10–v0.16 hardening pass landed many `insta` snapshots of CLI output. Decomposing `lib.rs::run` into presenter + domain calls must preserve these snapshots byte-for-byte unless the change is explicitly intended.
 
 ## Session Continuity
 
-Last session: 2026-05-13T08:00:00.000Z
-Stopped at: Completed Wave 2 (19-03 + 19-04 + 19-05 + 19-06)
+Last session: 2026-05-23T00:00:00.000Z
+Stopped at: v1.0 ratification complete — PROJECT.md/REQUIREMENTS.md/ROADMAP.md/STATE.md updated; phases 25–31 reflected; ready for `/gsd:plan-phase 25`.
 Resume file: None

--- a/.planning/milestones/v0.11-REQUIREMENTS.md
+++ b/.planning/milestones/v0.11-REQUIREMENTS.md
@@ -1,0 +1,77 @@
+# Requirements: tome v0.11 — Polish + Observability
+
+**Defined:** 2026-05-12
+**Source:** Milestone discussion (no formal research; polish-heavy milestone against existing codebase)
+**Predecessor:** [`milestones/v0.10-REQUIREMENTS.md`](milestones/v0.10-REQUIREMENTS.md) (SHIPPED 2026-05-11)
+
+## v0.11 Requirements
+
+Requirements for the v0.11 release. Grouped by category; each will map to one or more roadmap phases. Phase numbering continues from v0.10 → starts at Phase 18.
+
+### Observability (OBS)
+
+Adopt structured logging across the codebase so `tome sync`/`doctor`/`status` give clearer signal. Lays groundwork for v1.0 GUI's IPC + log-capture needs. Scope discipline: "instrument existing output" — not "redesign output."
+
+- [x] **OBS-01**: Adopt `tracing` + `tracing-subscriber` crates. Replace internal `eprintln!`/`println!` chatter with `tracing::{info,warn,debug}!` calls. Wizard prompts, TUI browse output, and user-facing summary tables (status/list/doctor) stay as direct stdout — instrument only the *log-like* output (sync progress, cleanup actions, diagnostic warnings).
+- [x] **OBS-02**: Wire `--verbose`/`--quiet` global flags + `TOME_LOG` env var to `tracing_subscriber::EnvFilter`. Default level `info`; `--verbose` → `debug`; `--quiet` → `warn`. Existing `LogLevel` enum (HARD-07) wraps the subscriber configuration; behavior preserved for users who only use the flags.
+- [x] **OBS-03**: `tome sync` emits per-pipeline-step spans (discover, reconcile, consolidate, distribute, cleanup) with elapsed-ms attached. Visible in `--verbose` text output and reachable via `TOME_LOG=tome::sync=debug`.
+- [x] **OBS-04**: Change-cause attribution — when consolidate or distribute re-emits a skill, the reason ("hash changed", "previously failed", "newly added", "directory now allowed") is logged at `info!` for user visibility.
+- [x] **OBS-05**: Reconcile classification breakdown surfaced in `tome sync` summary — show counts of Match / Drift / Vanished / MissingFromMachine in the final summary block (not only the consolidated outcome).
+- [x] **OBS-06**: `tome doctor` richer surface — categorize issues (Library / Directory / Config / Foreign-symlink) with per-category counts in text output; JSON shape gains `category` field per issue. Implementation overlaps with FIX-01 (#530); single change closes both.
+- [x] **OBS-07**: `tome status` richer surface — surface per-directory skill counts, override status (already present in v0.9), and a "last sync" timestamp; JSON shape parity with text output.
+
+### Bugfixes (FIX)
+
+The v0.10-surfaced bug bundle and the older wizard-polish backlog. Each requirement closes one or more existing GitHub issues; full mapping in Traceability.
+
+- [x] **FIX-01**: `tome doctor` "auto-fixable" count and prompt exclude items with no auto-repair available — the current "N auto-fixable issues" then "(no auto-repair available)" UX is a contradiction. Closes [#530](https://github.com/MartinP7r/tome/issues/530).
+- [x] **FIX-02**: `browse::app::tests::copy_path_retry_helper_returns_within_bound` timing flake fixed — diagnose root cause (timing-based assertion under parallel contention) and replace with deterministic clock injection or relaxed bound with explicit comment. Closes [#511](https://github.com/MartinP7r/tome/issues/511).
+- [x] **FIX-03**: `tome doctor` "N managed symlink(s) tracked in git" check removed or rewritten — v0.10 made managed skills real directory copies, so the check is stale (false-positive count post-migration). Closes [#532](https://github.com/MartinP7r/tome/issues/532).
+- [x] **FIX-04**: Wizard summary table column misalignment — ANSI bold escapes are miscounted as visible width by `tabled` in interactive TTY mode. Use ANSI-aware width measurement (or strip ANSI before measuring). Closes [#454](https://github.com/MartinP7r/tome/issues/454).
+- [x] **FIX-05**: Wizard `configure_library` and library-default derivation follow the resolved `tome_home` instead of hardcoding `~/.tome/skills` — when a user customizes `tome_home`, the library default should follow. Single fix closes both linked issues. Closes [#453](https://github.com/MartinP7r/tome/issues/453) + [#456](https://github.com/MartinP7r/tome/issues/456).
+- [x] **FIX-06**: `make release` automatically stamps the release date in `CHANGELOG.md` — replaces `[Unreleased]` with `[X.Y.Z] - YYYY-MM-DD` during the version-bump PR. Closes [#533](https://github.com/MartinP7r/tome/issues/533).
+
+## Future Requirements
+
+Deferred from v0.11 scoping; surface as candidates for v0.12 / v1.0 / v2.
+
+- **OBS-FUTURE-01**: JSON-by-default streaming log output (`--log-format json` or `TOME_LOG_FORMAT=json`) for machine consumers / future Tauri IPC. Tracing subscriber already supports this; flag-level integration deferred until a real consumer exists.
+- **OBS-FUTURE-02**: OpenTelemetry export (`tracing-opentelemetry`) — not justified at single-user scale; surface again if multi-machine telemetry becomes a need.
+- **FIX-FUTURE-01**: `Lockfile::version` silently accepts unknown values — future-compat time bomb ([#426](https://github.com/MartinP7r/tome/issues/426)). Small fix but not anchored to a v0.11 user-visible outcome; defer to v0.12 or fold into v1.0 prep.
+- **FIX-FUTURE-02**: Selective items from Phase 11/12/13 review followup bundles ([#517](https://github.com/MartinP7r/tome/issues/517), [#518](https://github.com/MartinP7r/tome/issues/518), [#519](https://github.com/MartinP7r/tome/issues/519)) — bundle-level decisions, evaluate per-item during v1.0 prep.
+- **WATCH-FUTURE-01**: File watcher for auto-sync ([#59](https://github.com/MartinP7r/tome/issues/59)) — carried from v0.10. Orthogonal product direction; v1.x or v2.
+
+## Out of Scope (v0.11)
+
+| Item | Reason |
+|------|--------|
+| Output redesign (new table layouts, JSON-by-default streams, OpenTelemetry export) | Observability scope is "instrument existing output" only. Output-shape changes belong in v1.0 GUI prep or a later polish milestone. |
+| Tauri Desktop GUI | Deferred to v1.0 — drafted in `milestones/v1.0-{REQUIREMENTS,ROADMAP}.md`. v0.11 lays the logging substrate that v1.0's IPC + log capture will consume. |
+| Linux runtime UAT (clipboard + xdg-open carry-over from v0.8) | Sixth consecutive milestone without Linux hardware. Formally deferred to **v1.0** where the Tauri build forces Linux access. Written rationale in `08-HUMAN-UAT.md` frontmatter. |
+| Rust → TypeScript rewrite | Explored in untracked `docs/migration/rust-to-typescript-feature-inventory.md` (snapshot 2026-04-27 @ v0.8.2). Parked. v1.0 continues on Rust + Tauri. |
+| Backward-compat shim for log flag changes | Per project policy (Backward compat: None). Flag changes will be release-noted; users adapt at the v0.11 boundary. |
+| New marketplace adapters (npm, generic URL) | Carried from v0.10 future requirements. Trait shape designed for extensibility; ADP-FUTURE-01/02 defer indefinitely until a real consumer exists. |
+
+## Traceability
+
+Filled by `gsd-roadmapper` 2026-05-12. 13 requirements mapped across 2 phases (18–19), 100% coverage.
+
+| Requirement | Phase | GitHub Issue | Status |
+|-------------|-------|--------------|--------|
+| OBS-01 | Phase 18 | — | Done |
+| OBS-02 | Phase 18 | — | Done |
+| OBS-03 | Phase 18 | — | Done |
+| OBS-04 | Phase 18 | — | Done |
+| OBS-05 | Phase 18 | — | Done |
+| OBS-06 | Phase 19 | — | Done |
+| OBS-07 | Phase 19 | — | Done |
+| FIX-01 | Phase 19 | [#530](https://github.com/MartinP7r/tome/issues/530) | Done |
+| FIX-02 | Phase 19 | [#511](https://github.com/MartinP7r/tome/issues/511) | Done |
+| FIX-03 | Phase 19 | [#532](https://github.com/MartinP7r/tome/issues/532) | Done |
+| FIX-04 | Phase 19 | [#454](https://github.com/MartinP7r/tome/issues/454) | Done |
+| FIX-05 | Phase 19 | [#453](https://github.com/MartinP7r/tome/issues/453) + [#456](https://github.com/MartinP7r/tome/issues/456) | Done |
+| FIX-06 | Phase 19 | [#533](https://github.com/MartinP7r/tome/issues/533) | Done |
+
+**Coverage:**
+- v0.11 requirements: 13 total (7 OBS + 6 FIX)
+- Mapped to phases: 13 / 13 ✓


### PR DESCRIPTION
## Summary

Promote drafted v1.0 milestone from `milestones/v1.0-{REQUIREMENTS,ROADMAP}.md` into active planning artifacts via `/gsd-new-milestone` after v0.16 shipped. Docs-only PR; no code changes.

### Scope

32 requirements across 8 categories, **Phases 25–31** (continued from v0.16's last phase 24):

| Phase | Goal | Reqs | Cut |
|------:|------|------|-----|
| 25 | Rust core extraction + Tauri integration spike | CORE-01..05 | — |
| 26 | Read-only views | VIEW-01..06 + NF | **alpha** |
| 27 | Sync + triage UI | SYNC-01..05 | — |
| 28 | Configuration UI | CFG-01..05 + NF | **beta** |
| 29 | Mutating operations UI | OPS-01..04 + NF | — |
| 30 | Backup UI | BAK-01..04 + NF | **rc** |
| 31 | Distribution (sign, notarize, DMG, auto-update) | DIST-01..05 | **v1.0** |

### Key decisions (already drafted as D-GUI-01..09)

Tauri 2 over Electron+napi-rs · new `crates/tome-desktop` workspace member · `specta`+`tauri-specta` for TS bindings · frontend framework TBD in Phase 25 spike · `tauri-plugin-updater` for updates · macOS-only v1.0 (Linux deferred to v2) · shared lockfile/manifest with file watcher · Tauri commands return structured types while CLI continues to format strings.

### Files

- `.planning/REQUIREMENTS.md` — bootstrapped from v1.0 draft; FORWARD-PLANNING DRAFT header stripped, phase numbers renumbered (10→25, 11→26, …, 16→31), ratification date stamped
- `.planning/ROADMAP.md` — v1.0 flipped 📋 → 🚧; full v1.0 section added with all 7 phases + open questions Q1–Q7. **Bonus cleanup**: v0.14 was still marked 🚧 In Progress (now ✅ Shipped + boxes checked); v0.15's Phase 22 bullet was orphaned inside v0.16's section (now correctly nested under v0.15)
- `.planning/PROJECT.md` — Current State was stuck on v0.10; now reflects v0.10–v0.16 ship history. Current Milestone replaced (v0.11 → v1.0). Previous Milestones recap extended through v0.16
- `.planning/STATE.md` — frontmatter reset (milestone v0.16 → v1.0, status shipped → planning, progress 8/9 → 0/7); Current Position rewritten; design context / phase dep graph / pending todos / blockers all refreshed for v1.0
- `.planning/milestones/v0.11-REQUIREMENTS.md` — archived from previous active `REQUIREMENTS.md` content

## Test plan

- [x] `typos` clean on edited files
- [x] No code changes — no cargo gates needed
- [ ] CI green (lint + typos + build still run on docs-only PRs)

## Next step after merge

`/gsd:plan-phase 25` (or `/gsd:discuss-phase 25` first to clarify approach) to start the Rust core extraction work.