### PR TITLE
ci(deny): ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -34,9 +34,14 @@ ignore = [
     { id = "RUSTSEC-2024-0420", reason = "gtk-rs (transitive via tauri/wry, Linux-only target)" },
 
     # --- Singletons ---
-    # `proc-macro-error` — replacement `proc-macro-error2` is already in the
-    # tree but the older crate co-exists until dialoguer/console upgrade.
+    # `proc-macro-error` — and its fork `proc-macro-error2`. The original was
+    # flagged unmaintained (RUSTSEC-2024-0370); the fork that was meant to
+    # replace it has since gone unmaintained too (RUSTSEC-2026-0173). Both
+    # co-exist in the tree transitively until dialoguer/console (orig) and the
+    # tauri-specta macro stack (fork) drop them. No exploitable surface — both
+    # are proc-macro build-time deps.
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error (transitive via dialoguer/console)" },
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 — fork of proc-macro-error, also now unmaintained (transitive via tauri-specta macro stack)" },
     # `paste` — transitive via ratatui macro expansion.
     { id = "RUSTSEC-2024-0436", reason = "paste (transitive via ratatui macros)" },
 


### PR DESCRIPTION
## Summary

A new RustSec advisory **RUSTSEC-2026-0173** (published 2026-06-10) flags `proc-macro-error2` as unmaintained. This is the fork that was created to replace `proc-macro-error` (RUSTSEC-2024-0370, already carved out in #560) — and now the fork itself is unmaintained.

Both crates are build-time proc-macro dependencies with no exploitable runtime surface. They enter the tree transitively and can't be removed without upstream upgrades:
- `proc-macro-error` — via `dialoguer`/`console`
- `proc-macro-error2` — via the `tauri-specta` macro stack

## Why this matters now

The advisory fails `cargo-deny` on **every** branch built against `main`. This is already blocking:
- **#568** (mdBook docs) — its only red check is this advisory
- Any future PR, including the **in-flight Phase 27 PR** when it opens

Carving it out here unblocks all of them in one place.

## Verification

- [x] `cargo deny check advisories` → `advisories ok` locally
- [ ] CI cargo-deny green

## Traceability

Follows the same pattern as #560's CI hardening (Tauri/GTK3 transitive unmaintained carve-outs). Each entry carries a `reason` documenting where it enters the dep graph, so the list can be triaged when the upstreams upgrade.
