### PR TITLE
docs: capture agent-skills follow-up

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -102,6 +102,8 @@ Phases 26–31 form a strict linear chain; each depends on the previous. NF gate
 
 ### Pending Todos / Carry-over
 
+- **Structured todos:** 2 pending items in `.planning/todos/pending/`; latest capture is
+  `2026-07-15-define-agent-skills-for-tome.md` ("Define agent skills for tome").
 - **Linux UAT (carry-over from v0.8):** 2 pending items in `.planning/phases/08-*/08-HUMAN-UAT.md` (clipboard runtime + xdg-open runtime tests). Pending Linux desktop hardware. Carried over for the sixth+ consecutive milestone — formally deferred to **v2 (post-v1.0)** when Linux GUI build hardware lands.
 - **#542 Owned/Unowned enum migration** — deferred from v0.12 whole-codebase review; absorbed into Phase 25 CORE-01 scope.
 - **#548 role-transition cleanup gap** — surfaced during v0.13 dogfooding (when a directory's role transitions synced→source, ~171 stale tome symlinks linger). Standalone follow-up; not v1.0-blocking but should land before the alpha cut so dogfooding sessions don't repeat the manual cleanup.

--- a/.planning/todos/pending/2026-07-15-define-agent-skills-for-tome.md
+++ b/.planning/todos/pending/2026-07-15-define-agent-skills-for-tome.md
@@ -1,0 +1,29 @@
+---
+created: 2026-07-15T01:10:16.896Z
+title: Define agent skills for tome
+area: planning
+files:
+  - AGENTS.md
+  - .planning/PROJECT.md
+  - .planning/ROADMAP.md
+---
+
+## Problem
+
+The repository has strong AGENTS.md and GSD workflow guidance, but there is not yet a
+captured work item for what repo-specific agent skills `tome` itself should expose or
+standardize. That leaves future work under-specified when deciding whether the project
+needs dedicated skills, clearer capture/debug/release flows, or repo-scoped guidance for
+AI agents working in this codebase.
+
+## Solution
+
+Review the existing agent-facing surface area in this repo and decide what should become
+explicit `tome` agent skills or supporting workflow docs. At minimum:
+
+1. Inventory the current repo instructions, GSD commands, and repeated agent tasks.
+2. Identify gaps where a dedicated skill would reduce ambiguity or duplicated guidance.
+3. Define the minimal set of repo-specific skills, their responsibilities, and where they
+   should live.
+4. Capture any follow-up implementation or documentation work needed to make those skills
+   usable in practice.


### PR DESCRIPTION
## Summary

Records the pending follow-up to define and document tome-specific agent skills.

## Validation

Documentation-only change; verified the commit applies cleanly on current main.