### PR TITLE
fix: stop sync resetting the library repo and duplicating plugin skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`tome sync` could `git reset --hard` the user's library repository,
+  discarding local commits and uncommitted edits** (#585). Git-source
+  cache directories live under `<library>/repos/<sha256>/`, and the
+  clone-vs-update decision tested only `cache_dir.is_dir()`. A clone
+  that failed part-way leaves that directory present but without
+  `.git`, so the update path ran `git fetch && git reset --hard
+  FETCH_HEAD` inside it; git's repository discovery then walked *up*,
+  found the enclosing library repo, and reset that instead. Two
+  independent guards now apply: `update_repo` refuses a directory that
+  is not itself a repository (the caller re-clones, clearing the stale
+  directory first), and every git subprocess sets
+  `GIT_CEILING_DIRECTORIES` to the cache directory's parent so
+  discovery cannot escape upward. The variable must name the *parent* —
+  listing the directory itself still permits the first upward step.
+- **Git sources were dropped from `tome.toml` on the next sync** (#585).
+  A consequence of the reset above rather than a separate defect: the
+  config file is tracked in the library repo, so resetting it reverted
+  the entry `tome add` had just written. The source then resolved to
+  nothing and its skills were reclassified as Unowned.
+- **`tome doctor` reported every git source as a missing directory**
+  (#585). For `type = "git"` entries `path` holds a clone URL, so the
+  filesystem existence check always failed and printed the URL as a
+  nonexistent path. The check is now skipped for git directories. The
+  spurious warning actively obscured the bug above by looking like a
+  config typo.
+- **Plugin-owned skills were symlinked back into the tool that already
+  loads them, so every one loaded twice** (#586). A skill discovered
+  from `~/.claude/plugins` was distributed into `~/.claude/skills`,
+  making it visible both as `plugin:name` and as bare `name` —
+  redundant description tokens in every session, and ambiguity between
+  the live plugin and the library snapshot. Distribution now skips a
+  skill whose source is a `claude-plugins` directory when the target is
+  that same tool's sibling `skills/` directory. Redistribution to other
+  tools is unaffected, since reaching tools without a plugin manager is
+  the point of consolidating managed skills. Existing duplicate
+  symlinks are removed on the next sync.
+
 ## [0.16.1] - 2026-06-29
 
 ## [0.16.0] - 2026-05-20

--- a/crates/tome/src/distribute.rs
+++ b/crates/tome/src/distribute.rs
@@ -1,15 +1,38 @@
 //! Distribute library skills to configured directories via symlinks.
 
 use anyhow::{Context, Result};
+use std::collections::BTreeMap;
 use std::os::unix::fs as unix_fs;
 use std::path::Path;
 use tracing::{info, warn};
 
 use crate::change_cause::ChangeCause;
-use crate::config::{DirectoryConfig, DirectoryName};
+use crate::config::{DirectoryConfig, DirectoryName, DirectoryType};
 use crate::machine::MachinePrefs;
 use crate::manifest::Manifest;
 use crate::paths::symlink_points_to;
+
+/// Whether `target` is the personal skills directory of the same tool whose
+/// package manager owns `source`.
+///
+/// True only when `source` is a [`DirectoryType::ClaudePlugins`] directory and
+/// `target` is exactly its sibling `skills/` directory — `~/.claude/plugins`
+/// paired with `~/.claude/skills`. That is the layout Claude Code uses: the tool
+/// home holds both `plugins/` and `skills/`.
+///
+/// Deliberately *not* "the two paths share a parent". Sibling directories are not
+/// necessarily the same tool — two unrelated configured directories can sit side
+/// by side under one root (as they do in this crate's own integration fixtures),
+/// and suppressing distribution there would silently break a legitimate target.
+fn owns_same_tool_as(source: &DirectoryConfig, target: &DirectoryConfig) -> bool {
+    if source.directory_type != DirectoryType::ClaudePlugins {
+        return false;
+    }
+    source
+        .path
+        .parent()
+        .is_some_and(|tool_home| target.path == tool_home.join("skills"))
+}
 
 /// Result of distributing skills to a single directory.
 #[derive(Debug)]
@@ -25,18 +48,63 @@ pub struct DistributeResult {
     pub directory_name: DirectoryName,
 }
 
-/// Distribute skills from the library to a configured directory.
+/// Distribute skills without a directory set — no package-manager de-duplication.
 ///
-/// Creates symlinks in `dir_config.path` pointing to library entries.
-/// When `force` is true, all symlinks are recreated even if they already point to the correct target.
-/// The `manifest` is used to check whether a skill's source originated from this directory
-/// (to prevent circular symlinks when a directory is both a source and target).
-pub fn distribute_to_directory(
+/// Test-only convenience over [`distribute_to_directory_with_sources`]. Production
+/// callers must pass the configured directories so plugin-owned skills are not
+/// duplicated into the tool that already loads them.
+#[cfg(test)]
+fn distribute_to_directory(
     library_dir: &Path,
     dir_name: &DirectoryName,
     dir_config: &DirectoryConfig,
     manifest: &Manifest,
     machine_prefs: &MachinePrefs,
+    dry_run: bool,
+    force: bool,
+) -> Result<DistributeResult> {
+    distribute_to_directory_with_sources(
+        library_dir,
+        dir_name,
+        dir_config,
+        manifest,
+        machine_prefs,
+        &BTreeMap::new(),
+        dry_run,
+        force,
+    )
+}
+
+/// Distribute skills, additionally suppressing skills the target tool already
+/// loads through its own package manager.
+///
+/// `all_directories` is the full configured directory set, used to resolve each
+/// skill's *source* directory. Without it a skill discovered from a tool's plugin
+/// manager is symlinked back into that same tool's personal skills directory, so
+/// the tool loads it twice — once as `plugin:name`, once as bare `name`. The
+/// duplicate costs context on every session and makes bare-name invocation
+/// ambiguous between the live plugin and the library snapshot, which can drift.
+///
+/// Redistribution to *other* tools is the whole point of consolidating managed
+/// skills, so the suppression is deliberately narrow: it applies only when the
+/// source is a [`DirectoryType::ClaudePlugins`] directory sharing a parent with
+/// the target (e.g. `~/.claude/plugins` and `~/.claude/skills`). A Codex or
+/// Antigravity target keeps receiving them.
+///
+/// Creates symlinks in `dir_config.path` pointing to library entries. When `force`
+/// is true, all symlinks are recreated even if they already point at the correct
+/// target.
+// One argument over clippy's threshold. Grouping them into a struct would touch
+// every call site and the desktop IPC layer for no behavioural gain; the
+// parameters are all distinct types, so misordering them is a compile error.
+#[allow(clippy::too_many_arguments)]
+pub fn distribute_to_directory_with_sources(
+    library_dir: &Path,
+    dir_name: &DirectoryName,
+    dir_config: &DirectoryConfig,
+    manifest: &Manifest,
+    machine_prefs: &MachinePrefs,
+    all_directories: &BTreeMap<DirectoryName, DirectoryConfig>,
     dry_run: bool,
     force: bool,
 ) -> Result<DistributeResult> {
@@ -103,6 +171,29 @@ pub fn distribute_to_directory(
             {
                 warn!(
                     "failed to remove legacy symlink {}: {}",
+                    target_link.display(),
+                    e
+                );
+            }
+            result.skipped_managed += 1;
+            continue;
+        }
+
+        // Skip skills the target tool already loads via its own package manager
+        // (see this function's doc comment). Same cleanup of stale symlinks as
+        // the same-directory case above, so existing duplicates disappear on the
+        // next sync rather than lingering.
+        if let Some(manifest_entry) = manifest.get(skill_name_str.as_ref())
+            && let Some(source_name) = manifest_entry.source_name()
+            && let Some(source_config) = all_directories.get(source_name)
+            && owns_same_tool_as(source_config, dir_config)
+        {
+            if !dry_run
+                && target_link.is_symlink()
+                && let Err(e) = std::fs::remove_file(&target_link)
+            {
+                warn!(
+                    "failed to remove duplicate plugin symlink {}: {}",
                     target_link.display(),
                     e
                 );
@@ -634,6 +725,185 @@ mod tests {
             !target_dir.path().join("my-skill").exists(),
             "skill should NOT be distributed back to its own directory"
         );
+    }
+
+    /// Build a manifest with one skill owned by `source_name`.
+    fn manifest_owned_by(
+        skill: &str,
+        source_name: &str,
+        source_path: std::path::PathBuf,
+    ) -> Manifest {
+        let mut manifest = Manifest::default();
+        manifest.insert(
+            crate::discover::SkillName::new(skill).unwrap(),
+            SkillEntry {
+                source_path,
+                ownership: crate::manifest::SkillOwnership::Owned {
+                    source: DirectoryName::new(source_name).unwrap(),
+                },
+                content_hash: crate::validation::test_hash("abc"),
+                synced_at: "2024-01-01T00:00:00Z".to_string(),
+                managed: true,
+            },
+        );
+        manifest
+    }
+
+    fn plugins_dir_config(path: std::path::PathBuf) -> DirectoryConfig {
+        let mut c = make_dir_config(path);
+        c.directory_type = DirectoryType::ClaudePlugins;
+        c
+    }
+
+    #[test]
+    fn distribute_skips_plugin_skills_for_the_owning_tool() {
+        // Regression: a skill discovered from ~/.claude/plugins was symlinked into
+        // ~/.claude/skills, so Claude Code loaded it twice — once as
+        // `plugin:name`, once as bare `name`.
+        let library = TempDir::new().unwrap();
+        let tool_root = TempDir::new().unwrap();
+        let plugins = tool_root.path().join("plugins");
+        let skills = tool_root.path().join("skills");
+        std::fs::create_dir_all(&plugins).unwrap();
+        std::fs::create_dir_all(&skills).unwrap();
+
+        setup_library(library.path(), &["my-skill"]);
+        let manifest = manifest_owned_by("my-skill", "claude-plugins", plugins.join("my-skill"));
+
+        let mut dirs = BTreeMap::new();
+        dirs.insert(
+            DirectoryName::new("claude-plugins").unwrap(),
+            plugins_dir_config(plugins),
+        );
+
+        let target_name = DirectoryName::new("claude-skills").unwrap();
+        let target_config = make_dir_config(skills.clone());
+
+        let result = distribute_to_directory_with_sources(
+            library.path(),
+            &target_name,
+            &target_config,
+            &manifest,
+            &MachinePrefs::default(),
+            &dirs,
+            false,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.skipped_managed, 1);
+        assert_eq!(result.changed, 0);
+        assert!(
+            !skills.join("my-skill").exists(),
+            "plugin skill must not be duplicated into the same tool's skills dir"
+        );
+    }
+
+    #[test]
+    fn distribute_still_sends_plugin_skills_to_other_tools() {
+        // The whole point of consolidating managed skills is to reach tools that
+        // have no plugin manager of their own, so a different tool root must
+        // still receive them.
+        let library = TempDir::new().unwrap();
+        let claude_root = TempDir::new().unwrap();
+        let codex_root = TempDir::new().unwrap();
+        let plugins = claude_root.path().join("plugins");
+        let codex_skills = codex_root.path().join("skills");
+        std::fs::create_dir_all(&plugins).unwrap();
+        std::fs::create_dir_all(&codex_skills).unwrap();
+
+        setup_library(library.path(), &["my-skill"]);
+        let manifest = manifest_owned_by("my-skill", "claude-plugins", plugins.join("my-skill"));
+
+        let mut dirs = BTreeMap::new();
+        dirs.insert(
+            DirectoryName::new("claude-plugins").unwrap(),
+            plugins_dir_config(plugins),
+        );
+
+        let target_name = DirectoryName::new("codex-agents").unwrap();
+        let target_config = make_dir_config(codex_skills.clone());
+
+        let result = distribute_to_directory_with_sources(
+            library.path(),
+            &target_name,
+            &target_config,
+            &manifest,
+            &MachinePrefs::default(),
+            &dirs,
+            false,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.changed, 1);
+        assert!(codex_skills.join("my-skill").is_symlink());
+    }
+
+    #[test]
+    fn distribute_removes_preexisting_plugin_duplicate_symlink() {
+        // Duplicates created by earlier versions should disappear on next sync.
+        let library = TempDir::new().unwrap();
+        let tool_root = TempDir::new().unwrap();
+        let plugins = tool_root.path().join("plugins");
+        let skills = tool_root.path().join("skills");
+        std::fs::create_dir_all(&plugins).unwrap();
+        std::fs::create_dir_all(&skills).unwrap();
+
+        setup_library(library.path(), &["my-skill"]);
+        unix_fs::symlink(library.path().join("my-skill"), skills.join("my-skill")).unwrap();
+        assert!(skills.join("my-skill").is_symlink(), "precondition");
+
+        let manifest = manifest_owned_by("my-skill", "claude-plugins", plugins.join("my-skill"));
+        let mut dirs = BTreeMap::new();
+        dirs.insert(
+            DirectoryName::new("claude-plugins").unwrap(),
+            plugins_dir_config(plugins),
+        );
+
+        distribute_to_directory_with_sources(
+            library.path(),
+            &DirectoryName::new("claude-skills").unwrap(),
+            &make_dir_config(skills.clone()),
+            &manifest,
+            &MachinePrefs::default(),
+            &dirs,
+            false,
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            !skills.join("my-skill").exists(),
+            "stale duplicate symlink should be cleaned up"
+        );
+    }
+
+    #[test]
+    fn owns_same_tool_as_matches_only_the_tools_own_skills_dir() {
+        let plugins = plugins_dir_config(std::path::PathBuf::from("/home/u/.claude/plugins"));
+
+        // The tool's own skills dir — the duplicate case.
+        let own_skills = make_dir_config(std::path::PathBuf::from("/home/u/.claude/skills"));
+        assert!(owns_same_tool_as(&plugins, &own_skills));
+
+        // A different tool must keep receiving plugin skills.
+        let other_tool = make_dir_config(std::path::PathBuf::from("/home/u/.agents/skills"));
+        assert!(!owns_same_tool_as(&plugins, &other_tool));
+
+        // A plain directory source is never treated as a package manager.
+        let plain = make_dir_config(std::path::PathBuf::from("/home/u/.claude/plugins"));
+        assert!(!owns_same_tool_as(&plain, &own_skills));
+
+        // Merely sharing a parent is not enough. Two unrelated directories side by
+        // side under one root (the shape used by this crate's integration
+        // fixtures) must not suppress distribution.
+        let sibling = make_dir_config(std::path::PathBuf::from("/home/u/.claude/target"));
+        assert!(!owns_same_tool_as(&plugins, &sibling));
+
+        // A broad target elsewhere in the home directory is unaffected.
+        let broad = make_dir_config(std::path::PathBuf::from("/home/u/skills"));
+        assert!(!owns_same_tool_as(&plugins, &broad));
     }
 
     #[test]

--- a/crates/tome/src/doctor.rs
+++ b/crates/tome/src/doctor.rs
@@ -1795,6 +1795,14 @@ fn check_config(config: &Config) -> Result<Vec<DiagnosticIssue>> {
     let mut issues = Vec::new();
 
     for (name, dir_config) in &config.directories {
+        // For git directories `path` holds a clone URL, not a filesystem path, so
+        // an existence check is meaningless and previously fired on every git
+        // source unconditionally — reporting the URL as a missing directory. That
+        // noise actively hid a real defect: the message looked like a config typo
+        // when the actual problem was an unpopulated repo cache.
+        if dir_config.directory_type == crate::config::DirectoryType::Git {
+            continue;
+        }
         if !dir_config.path.exists() {
             issues.push(DiagnosticIssue::config(
                 IssueSeverity::Warning,

--- a/crates/tome/src/git.rs
+++ b/crates/tome/src/git.rs
@@ -13,14 +13,29 @@ use crate::errors::{DomainErrorKind, WithDomainKind};
 use crate::progress::{CancelToken, ProgressEvent, ProgressSink};
 
 /// Run a git command in the given directory with env clearing, returning raw output.
+///
+/// `GIT_CEILING_DIRECTORIES` is set to `repo_dir`'s **parent** so git's
+/// repository discovery cannot walk above the cache directory. Without it,
+/// running a command in a directory that is not itself a repository silently
+/// targets the nearest ancestor repository — and the repo cache lives inside the
+/// library, which is commonly a git repo itself, so a `reset --hard` would land
+/// on the user's library instead of the cache.
+///
+/// The value must be the parent, not `repo_dir`: the variable lists directories
+/// git may not *chdir up into*, and discovery starts already inside `repo_dir`.
+/// Listing `repo_dir` therefore permits the very first upward step, which is the
+/// one that escapes. Verified against git's behaviour, not assumed.
 fn git_command(repo_dir: &Path, args: &[&str]) -> Result<std::process::Output> {
-    std::process::Command::new("git")
-        .args(args)
+    let mut cmd = std::process::Command::new("git");
+    cmd.args(args)
         .current_dir(repo_dir)
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .output()
+        .env_remove("GIT_INDEX_FILE");
+    if let Some(parent) = repo_dir.parent() {
+        cmd.env("GIT_CEILING_DIRECTORIES", parent);
+    }
+    cmd.output()
         .with_context(|| format!("failed to run git {}", args.join(" ")))
 }
 
@@ -42,6 +57,20 @@ fn git_stdout(repo_dir: &Path, args: &[&str]) -> Result<String> {
         anyhow::bail!("git {} failed: {}", args.join(" "), stderr.trim());
     }
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Whether `dir` is the root of a git repository.
+///
+/// Checks for a `.git` entry directly inside `dir` — deliberately *not* using
+/// `git rev-parse`, which walks up to ancestor repositories and would report
+/// `true` for any directory nested inside one. The repo cache lives inside the
+/// library, which is frequently a git repo, so upward-walking checks are unsafe
+/// here.
+///
+/// `.git` may be a directory (normal clone) or a file (worktree/submodule
+/// gitlink), so both are accepted.
+pub(crate) fn is_git_repo(dir: &Path) -> bool {
+    dir.join(".git").exists()
 }
 
 /// Compute the cache directory path for a git repo URL.
@@ -193,6 +222,17 @@ fn update_repo_inner(
     if cancel.is_cancelled() {
         anyhow::bail!("git update cancelled before start");
     }
+    // Refuse to fetch/reset unless the directory is itself a repository. A
+    // previous clone that failed part-way leaves the cache directory present
+    // but without `.git`; updating it would let git discovery escape upward and
+    // `reset --hard` the enclosing repository. Callers treat this as
+    // "needs a fresh clone".
+    if !is_git_repo(repo_dir) {
+        anyhow::bail!(
+            "{} exists but is not a git repository (incomplete clone); a fresh clone is required",
+            repo_dir.display()
+        );
+    }
     sink.emit(ProgressEvent::GitCloneProgress {
         directory: repo_dir.to_string_lossy().into_owned(),
         received: 0,
@@ -237,6 +277,7 @@ pub(crate) fn is_git_available() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::progress::NullSink;
     use tempfile::TempDir;
 
     // -- repo_cache_dir tests --
@@ -269,6 +310,131 @@ mod tests {
         let a = repo_cache_dir(repos, url);
         let b = repo_cache_dir(repos, url);
         assert_eq!(a, b);
+    }
+
+    // -- is_git_repo / enclosing-repo safety tests --
+
+    #[test]
+    fn is_git_repo_false_for_plain_directory() {
+        let tmp = TempDir::new().unwrap();
+        assert!(!is_git_repo(tmp.path()));
+    }
+
+    #[test]
+    fn is_git_repo_false_for_directory_nested_inside_a_repo() {
+        // The repo cache lives inside the library, which is often a git repo.
+        // An upward-walking check (`git rev-parse`) would answer `true` here;
+        // that is exactly the confusion that let `reset --hard` hit the library.
+        let outer = TempDir::new().unwrap();
+        std::fs::create_dir(outer.path().join(".git")).unwrap();
+        let nested = outer.path().join("repos").join("deadbeef");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        assert!(is_git_repo(outer.path()), "outer is a repo");
+        assert!(
+            !is_git_repo(&nested),
+            "nested cache dir must not count as a repo just because an ancestor is one"
+        );
+    }
+
+    #[test]
+    fn is_git_repo_true_when_dot_git_is_a_file() {
+        // Worktrees and submodules use a `.git` *file* containing a gitdir pointer.
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".git"), "gitdir: /elsewhere\n").unwrap();
+        assert!(is_git_repo(tmp.path()));
+    }
+
+    #[test]
+    fn update_repo_refuses_incomplete_clone_and_leaves_enclosing_repo_untouched() {
+        // Regression: a clone that failed part-way leaves the cache directory
+        // present but without `.git`. Updating it used to run
+        // `git fetch && git reset --hard FETCH_HEAD` there; git discovery walked
+        // up to the enclosing library repository and reset the user's work.
+        let library = TempDir::new().unwrap();
+        run_git(library.path(), &["init", "--initial-branch", "main"]);
+        configure_test_identity(library.path());
+        std::fs::write(library.path().join("tome.toml"), "committed = true\n").unwrap();
+        run_git(library.path(), &["add", "."]);
+        run_git(library.path(), &["commit", "-m", "initial"]);
+
+        // Uncommitted local edit, standing in for the user's work.
+        std::fs::write(library.path().join("tome.toml"), "locally = edited\n").unwrap();
+
+        // Empty cache dir, as left behind by a failed clone.
+        let cache = library.path().join("repos").join("aabbcc");
+        std::fs::create_dir_all(&cache).unwrap();
+
+        let err = update_repo(&cache, None, None, None, &NullSink, &CancelToken::new())
+            .expect_err("must refuse to update a directory that is not a repository");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("not a git repository"),
+            "unexpected error: {msg}"
+        );
+
+        // The enclosing repository must be untouched.
+        assert_eq!(
+            std::fs::read_to_string(library.path().join("tome.toml")).unwrap(),
+            "locally = edited\n",
+            "enclosing repo working tree was modified"
+        );
+    }
+
+    #[test]
+    fn git_command_cannot_reach_an_enclosing_repository() {
+        // Second line of defence, independent of the `is_git_repo` guard: even if
+        // some future caller reaches `git_command` with a non-repo directory, the
+        // ceiling must stop discovery from escaping upward.
+        let library = TempDir::new().unwrap();
+        run_git(library.path(), &["init", "--initial-branch", "main"]);
+        configure_test_identity(library.path());
+        std::fs::write(library.path().join("file.txt"), "committed\n").unwrap();
+        run_git(library.path(), &["add", "."]);
+        run_git(library.path(), &["commit", "-m", "initial"]);
+        std::fs::write(library.path().join("file.txt"), "edited\n").unwrap();
+
+        let cache = library.path().join("repos").join("aabbcc");
+        std::fs::create_dir_all(&cache).unwrap();
+
+        // Bypasses update_repo entirely — calls the command layer directly.
+        let out = git_command(&cache, &["reset", "--hard", "HEAD"]).unwrap();
+        assert!(
+            !out.status.success(),
+            "reset should fail: no repository is reachable from the cache dir"
+        );
+        assert_eq!(
+            std::fs::read_to_string(library.path().join("file.txt")).unwrap(),
+            "edited\n",
+            "enclosing repo must be untouched"
+        );
+    }
+
+    fn run_git(dir: &Path, args: &[&str]) {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn configure_test_identity(dir: &Path) {
+        for args in [
+            ["config", "--local", "user.email", "test@test.com"].as_slice(),
+            ["config", "--local", "user.name", "Test"].as_slice(),
+            ["config", "--local", "commit.gpgsign", "false"].as_slice(),
+        ] {
+            run_git(dir, args);
+        }
     }
 
     // -- ref_spec_for_config tests --

--- a/crates/tome/src/lib.rs
+++ b/crates/tome/src/lib.rs
@@ -1669,7 +1669,12 @@ fn resolve_git_directories(
 
         let url = dir_config.path.to_string_lossy();
         let cache_dir = git::repo_cache_dir(&repos_dir, &url);
-        let already_cloned = cache_dir.is_dir();
+        // Must be a *repository*, not merely an existing directory. A clone that
+        // failed part-way leaves the directory behind without `.git`; treating
+        // that as "already cloned" sends it down the fetch/reset path, where git
+        // discovery escapes upward and `reset --hard` lands on the enclosing
+        // library repository.
+        let already_cloned = git::is_git_repo(&cache_dir);
 
         if dry_run {
             // In dry-run, use cached path if it exists, skip otherwise
@@ -1702,7 +1707,22 @@ fn resolve_git_directories(
                 cancel,
             )
         } else {
-            // Fresh clone (GIT-02)
+            // Fresh clone (GIT-02).
+            //
+            // Clear any leftover directory first: `git clone` refuses a
+            // non-empty destination, so an incomplete previous clone would
+            // otherwise fail here forever. Only the cache dir is removed, and
+            // only when it is not a repository (checked above), so no user
+            // content is at risk.
+            if cache_dir.exists()
+                && let Err(e) = std::fs::remove_dir_all(&cache_dir)
+            {
+                warn!(
+                    "failed to clear incomplete clone at {}: {e}",
+                    cache_dir.display()
+                );
+                continue;
+            }
             debug!("Cloning git directory '{}'...", name);
             git::clone_repo(
                 &url,
@@ -2239,12 +2259,13 @@ pub fn sync(
                 // there instead.
                 item: Some(name.to_string()),
             });
-            let result = distribute::distribute_to_directory(
+            let result = distribute::distribute_to_directory_with_sources(
                 paths.library_dir(),
                 name,
                 dir_config,
                 &manifest,
                 &machine_prefs,
+                &config.directories,
                 dry_run,
                 force,
             )?;


### PR DESCRIPTION
Fixes #585 and #586.

Three defects, two of which turned out to share a root cause.

## 1. `tome sync` could `git reset --hard` the user's library repo

Git-source caches live at `<library>/repos/<sha256>/` — **inside** the library. The clone-vs-update decision tested only `cache_dir.is_dir()`:

```rust
let already_cloned = cache_dir.is_dir();
```

A clone that failed part-way leaves that directory present but without `.git`, so it counted as "already cloned". `update_repo` then ran `git fetch && git reset --hard FETCH_HEAD` inside it, git's repository discovery walked **up**, found the enclosing library repo, and reset that instead.

Reproduced standalone:

```bash
mkdir -p lib/repos/aabbcc && cd lib
git init -q . && echo "committed = true" > tome.toml
git add . && git commit -qm init
echo "locally = edited" > tome.toml     # user's work
cd repos/aabbcc && git reset --hard HEAD
cd ../.. && cat tome.toml               # -> "committed = true"   ← destroyed
```

Two independent guards:

- `update_repo` refuses a directory that is not itself a repository. The caller treats that as needing a fresh clone and clears the stale directory first, since `git clone` rejects a non-empty destination.
- `git_command` sets `GIT_CEILING_DIRECTORIES` so discovery cannot escape the cache dir.

**Note on the ceiling value** — it must be the *parent*, not the directory itself. `GIT_CEILING_DIRECTORIES` lists directories git may not chdir up *into*, and discovery starts already inside the cache dir, so listing that dir still permits the one escaping step. My first attempt set it to the dir itself and did not work; I only caught it by testing against real git rather than trusting the docs' phrasing.

## 2. Git sources dropped from `tome.toml` on the next sync

Not a separate defect. `tome.toml` is tracked in the library repo, so the reset above reverted it and erased the entry `tome add` had just written. The source then resolved to nothing and its skills were reclassified as Unowned. Fixed by (1).

## 3. Doctor reported every git source as a missing directory

For `type = "git"` entries `path` holds a clone URL, so the existence check failed unconditionally:

```
! directory 'last30days-skill' path does not exist: https://github.com/mvanhorn/last30days-skill
```

Now skipped for git directories. This noise mattered — it made the reset bug look like a config typo and hid that a filesystem cache path was involved at all.

## 4. Plugin-owned skills loaded twice

Skills discovered from `~/.claude/plugins` were symlinked into `~/.claude/skills`, so Claude Code loaded each as both `plugin:name` and bare `name`. On my machine that was **109 duplicate pairs** — redundant descriptions in every session, plus ambiguity between the live plugin and a library snapshot that can drift (my cache holds both `superpowers/6.1.1` and `6.2.0`).

Distribution now skips a skill whose source is a `claude-plugins` directory when the target is that tool's sibling `skills/` directory, and removes duplicates left by earlier versions.

**The predicate is narrower than my first attempt.** I initially matched "source and target share a parent", which broke `tome_remove_dir_cleans_claude_plugins` — its fixture places `cp-root/` and `target/` side by side under one temp root. Sibling directories are not necessarily the same tool, so the rule now matches only `<plugins>/../skills`. Good catch by the existing suite.

Distribution to *other* tools is untouched; reaching tools without a plugin manager is the reason managed skills are consolidated at all.

## API note

`distribute_to_directory` gained a directory-set parameter. Rather than churn 19 test call sites, the new logic lives in `distribute_to_directory_with_sources` (the only public entry point, used by sync) and the old 7-arg form is now a `#[cfg(test)]` helper. Happy to collapse them into one name if you would rather take the test churn — the asymmetric naming is the one thing here I would call a compromise.

## Verification

- 6 new unit tests: both git guards exercised **independently** (so neither masks the other), the plugin skip, the must-still-distribute-to-other-tools case, stale-duplicate cleanup, and the predicate's boundaries including the sibling-directory false positive.
- Full suite green: 943 lib tests + all integration suites.
- `cargo fmt --check` clean, `cargo clippy --all-targets` clean.

One `#[allow(clippy::too_many_arguments)]` added with rationale: 8 args, one over the threshold; grouping into a struct would touch every call site and the desktop IPC layer for no behavioural gain, and the parameters are all distinct types so misordering is a compile error.

## Not addressed

`<library>/repos/` has no ignore rule and `git ls-files repos` reports tracked files there, so clone content has been committed into the library repo at some point. Left alone — it is a separate concern from these fixes and I did not want to widen the diff.