### PR TITLE
fix(deps): resolve RUSTSEC-2026-0194, -0195, and -0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3649,9 +3649,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
@@ -3855,9 +3855,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -6162,9 +6162,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
  "quick-xml",


### PR DESCRIPTION
Lockfile-only change. No manifest edits, no first-party code touched.

`cargo-deny` has been failing on `main` since 2026-07-03 (`advisories FAILED`; bans, licenses, and sources all pass) on three advisories in transitive dependencies.

## The advisories

| Advisory | Crate | Issue | Fix |
| --- | --- | --- | --- |
| RUSTSEC-2026-0204 | `crossbeam-epoch` | invalid pointer dereference in `fmt::Pointer` for `Atomic`/`Shared` | 0.9.18 → 0.9.20 |
| RUSTSEC-2026-0194 | `quick-xml` | quadratic runtime checking a start tag for duplicate attribute names | 0.39.4 → 0.41.0 |
| RUSTSEC-2026-0195 | `quick-xml` | unbounded namespace-declaration allocation in `NsReader` → memory-exhaustion DoS | 0.39.4 → 0.41.0 |

`crossbeam-epoch` was a plain patch bump.

## Why `quick-xml` needed two updates, not one

The fix requires 0.41, a *minor* bump — which cargo treats as breaking for `0.x`, so it cannot be updated directly. `quick-xml` reached the tree through two independent paths, and **both** had to move:

```
plist 1.9.0             requires ^0.39.2   ->  plist 1.10.0             requires ^0.41
wayland-scanner 0.31.10 requires ^0.39     ->  wayland-scanner 0.31.11  requires ^0.41
```

Both are semver-compatible updates of their own crates, so no manifest change is needed.

Updating only `plist` was not enough — it left `quick-xml 0.39.4` in the tree via `wayland-scanner` (the Linux clipboard stack, reached through `arboard`, used at build time as a proc-macro), and the advisory would have kept firing. I checked the version history to confirm 0.31.11 was the first release to move.

After the update the lockfile contains **only** `quick-xml 0.41.0` and `crossbeam-epoch 0.9.20`. No vulnerable copies remain:

```
$ rg -A1 '^name = "quick-xml"' Cargo.lock | rg version
version = "0.41.0"
```

## Verification

- **1136 tests pass** across all suites, 0 failures.
- `cargo check -p tome-desktop` succeeds — worth checking explicitly, since both bumped crates sit on the tauri dependency path.

## One thing worth flagging

My first full-suite run after the update showed two failures in `marketplace::tests::git_adapter_*`. They were a flake, not a regression: that run raced with the post-update recompile, and those tests spawn real `git` subprocesses that are timing-sensitive under CPU load. Three subsequent clean runs of the full suite confirmed it, and the same tests pass on pristine `main`.

Mentioning it because this looks related to the intermittent `backup::tests::push_and_pull_roundtrip` flake already noted in `CLAUDE.md` — there may be a family of subprocess-spawning tests worth making load-tolerant.

## Relationship to the other open PR

Independent of #587 (branched from `main`, touches only `Cargo.lock`). #587 is a code fix whose CI shows the same pre-existing `cargo-deny` failure; merging this first should turn that check green there too. No CHANGELOG entry, since this changes no tome behaviour.